### PR TITLE
Support Gemini text generation with video refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also manually copy `manifest.json`, `main.js`, and `styles.css` from the
 4. Select a model and parameters in the generation bar.
 5. Run the generation. Bragi Canvas creates the output node near the source node and connects it back to the source.
 
-Incoming directed edges are treated as upstream references. Text nodes contribute prompt text, image nodes become image references, video nodes can be used for supported video workflows, and audio nodes can be used for supported audio workflows.
+Incoming directed edges are treated as upstream references. Text nodes contribute prompt text, image nodes become image references, video nodes can be used for supported video workflows and Gemini text understanding, and audio nodes can be used for supported audio workflows.
 
 ## MCP server
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
-    "lint:obsidian": "eslint ."
+    "lint:obsidian": "eslint .",
+    "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-gemini-video-text.mjs
+++ b/scripts/verify-gemini-video-text.mjs
@@ -11,13 +11,25 @@ assert.match(
 )
 
 assert.match(
+	mainSource,
+	/Video references for text generation are currently supported only with Google Gemini\./,
+	'text generation must fail clearly when upstream videos are used with unsupported providers',
+)
+
+assert.match(
+	mainSource,
+	/const videoUrl = await uploadRef\(undefined, binary, `ref\.\$\{ext\}`, videoMimeType\(videoPath\)\)/,
+	'Gemini text video refs must use the same relay URL upload path as video generation',
+)
+
+assert.match(
 	textGenSource,
-	/const refVideos: string\[\] = Array\.isArray\(params\?\.refVideos\) \? params\.refVideos : \[\]/,
+	/const refVideos = Array\.isArray\(params\?\.refVideos\) \? params\.refVideos\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
 	'Gemini text provider must read refVideos defensively',
 )
 
 assert.match(
 	textGenSource,
-	/for \(const dataUri of refVideos\)[\s\S]*inlineData: \{ mimeType: match\[1\], data: match\[2\] \}/,
-	'Gemini text provider must send upstream videos as inlineData parts',
+	/fileData: \{ mimeType: videoMimeTypeFromRef\(ref\), fileUri: ref \}/,
+	'Gemini text provider must send upstream video URLs as fileData parts',
 )

--- a/scripts/verify-gemini-video-text.mjs
+++ b/scripts/verify-gemini-video-text.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const mainSource = readFileSync('src/main.ts', 'utf8')
+const textGenSource = readFileSync('src/providers/text-gen.ts', 'utf8')
+
+assert.match(
+	mainSource,
+	/provider\.generateText\(finalPrompt, \{ modelId: apiModelId, refImages, refVideos \}\)/,
+	'text generation must pass collected upstream videos to text providers',
+)
+
+assert.match(
+	textGenSource,
+	/const refVideos: string\[\] = Array\.isArray\(params\?\.refVideos\) \? params\.refVideos : \[\]/,
+	'Gemini text provider must read refVideos defensively',
+)
+
+assert.match(
+	textGenSource,
+	/for \(const dataUri of refVideos\)[\s\S]*inlineData: \{ mimeType: match\[1\], data: match\[2\] \}/,
+	'Gemini text provider must send upstream videos as inlineData parts',
+)

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ import { isSupportedLanguage, LanguageGateModal } from './ui/language-gate'
 import { installAlwaysNewTab } from './always-new-tab'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 
+const GEMINI_INLINE_VIDEO_LIMIT_BYTES = 20 * 1024 * 1024
+
 export default class BragiCanvas extends Plugin {
 	settings: BragiSettings = DEFAULT_SETTINGS
 	private thumbInterval: ReturnType<typeof window.setInterval> | null = null
@@ -411,10 +413,20 @@ export default class BragiCanvas extends Plugin {
 				}
 			}
 
-			// Upload reference videos. BytePlus Seedance videos must go through asset://
-			// so face-containing clips are reviewed by the asset library first.
 			const refVideos: string[] = []
-			if (model.type === 'video' && uniqueVideos.length > 0) {
+			if (model.type === 'text' && activeProvider === 'gemini' && uniqueVideos.length > 0) {
+				for (const videoPath of uniqueVideos) {
+					const binary = await this.app.vault.adapter.readBinary(videoPath)
+					if (binary.byteLength > GEMINI_INLINE_VIDEO_LIMIT_BYTES) {
+						throw new Error('Gemini text video input supports inline videos up to 20 MB. Use a shorter clip or split the video.')
+					}
+					const ext = videoPath.split('.').pop()?.toLowerCase() || 'mp4'
+					const mime = ext === 'mov' ? 'video/quicktime' : ext === 'webm' ? 'video/webm' : 'video/mp4'
+					refVideos.push(`data:${mime};base64,${arrayBufferToBase64(binary)}`)
+				}
+			} else if (model.type === 'video' && uniqueVideos.length > 0) {
+				// Upload reference videos. BytePlus Seedance videos must go through asset://
+				// so face-containing clips are reviewed by the asset library first.
 				if (mode === 'video-ref' && !supportsSeedanceRefs) {
 					throw new Error('Reference video is only available with Volcengine, BytePlus, or TokenRouter Seedance.')
 				}
@@ -499,7 +511,7 @@ export default class BragiCanvas extends Plugin {
 					markNodeFailed(placeholder, `${activeProvider} doesn't support text generation`)
 					return
 				}
-				const { text: textResult } = await provider.generateText(finalPrompt, { modelId: apiModelId, refImages })
+				const { text: textResult } = await provider.generateText(finalPrompt, { modelId: apiModelId, refImages, refVideos })
 
 				// Split result into multiple nodes if ---SPLIT--- is present
 				canvas.removeNode(placeholder)

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,6 @@ import { isSupportedLanguage, LanguageGateModal } from './ui/language-gate'
 import { installAlwaysNewTab } from './always-new-tab'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 
-const GEMINI_INLINE_VIDEO_LIMIT_BYTES = 20 * 1024 * 1024
-
 export default class BragiCanvas extends Plugin {
 	settings: BragiSettings = DEFAULT_SETTINGS
 	private thumbInterval: ReturnType<typeof window.setInterval> | null = null
@@ -413,20 +411,20 @@ export default class BragiCanvas extends Plugin {
 				}
 			}
 
+			// Prepare reference videos for models/providers that can consume upstream video inputs.
+			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			const refVideos: string[] = []
-			if (model.type === 'text' && activeProvider === 'gemini' && uniqueVideos.length > 0) {
+			if (model.type === 'text' && uniqueVideos.length > 0) {
+				if (!textProviderSupportsVideoRefs(activeProvider)) {
+					throw new Error('Video references for text generation are currently supported only with Google Gemini.')
+				}
 				for (const videoPath of uniqueVideos) {
 					const binary = await this.app.vault.adapter.readBinary(videoPath)
-					if (binary.byteLength > GEMINI_INLINE_VIDEO_LIMIT_BYTES) {
-						throw new Error('Gemini text video input supports inline videos up to 20 MB. Use a shorter clip or split the video.')
-					}
-					const ext = videoPath.split('.').pop()?.toLowerCase() || 'mp4'
-					const mime = ext === 'mov' ? 'video/quicktime' : ext === 'webm' ? 'video/webm' : 'video/mp4'
-					refVideos.push(`data:${mime};base64,${arrayBufferToBase64(binary)}`)
+					const ext = getFileExtension(videoPath, 'mp4')
+					const videoUrl = await uploadRef(undefined, binary, `ref.${ext}`, videoMimeType(videoPath))
+					refVideos.push(videoUrl)
 				}
 			} else if (model.type === 'video' && uniqueVideos.length > 0) {
-				// Upload reference videos. BytePlus Seedance videos must go through asset://
-				// so face-containing clips are reviewed by the asset library first.
 				if (mode === 'video-ref' && !supportsSeedanceRefs) {
 					throw new Error('Reference video is only available with Volcengine, BytePlus, or TokenRouter Seedance.')
 				}
@@ -443,9 +441,8 @@ export default class BragiCanvas extends Plugin {
 							refVideos.push(await ensureBytePlusAsset(this, canvas, videoPath, bytePlusCreds))
 						} else {
 							const binary = await this.app.vault.adapter.readBinary(videoPath)
-							const ext = videoPath.split('.').pop()?.toLowerCase() || 'mp4'
-							const mime = ext === 'mov' ? 'video/quicktime' : ext === 'webm' ? 'video/webm' : 'video/mp4'
-							const videoUrl = await uploadRef(undefined, binary, `ref.${ext}`, mime)
+							const ext = getFileExtension(videoPath, 'mp4')
+							const videoUrl = await uploadRef(undefined, binary, `ref.${ext}`, videoMimeType(videoPath))
 							refVideos.push(videoUrl)
 						}
 					}
@@ -845,6 +842,21 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 		binary += String.fromCharCode(bytes[i])
 	}
 	return btoa(binary)
+}
+
+function getFileExtension(filePath: string, fallback: string): string {
+	return filePath.split('.').pop()?.toLowerCase() || fallback
+}
+
+function videoMimeType(filePath: string): string {
+	const ext = getFileExtension(filePath, 'mp4')
+	if (ext === 'mov') return 'video/quicktime'
+	if (ext === 'webm') return 'video/webm'
+	return 'video/mp4'
+}
+
+function textProviderSupportsVideoRefs(activeProvider: string): boolean {
+	return activeProvider === 'gemini'
 }
 
 /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- Resume strict linting after the runtime-shaped data boundary. */

--- a/src/providers/text-gen.ts
+++ b/src/providers/text-gen.ts
@@ -178,12 +178,21 @@ export class GeminiTextProvider implements TextGenProvider {
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = stringParam(params?.modelId, 'gemini-2.5-flash')
-		const refImages: string[] = params?.refImages || []
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		const refVideos: string[] = Array.isArray(params?.refVideos) ? params.refVideos : []
 
-		// Build parts: images first, then text
+		// Build parts: media first, then text
 		const parts: unknown[] = []
 
 		for (const dataUri of refImages) {
+			const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+			if (match) {
+				parts.push({
+					inlineData: { mimeType: match[1], data: match[2] },
+				})
+			}
+		}
+		for (const dataUri of refVideos) {
 			const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
 			if (match) {
 				parts.push({

--- a/src/providers/text-gen.ts
+++ b/src/providers/text-gen.ts
@@ -37,6 +37,13 @@ function isOpenAIResponsesModel(modelId: string): boolean {
 	return /^gpt-5\.[45]-pro(?:-|$)/.test(modelId)
 }
 
+function videoMimeTypeFromRef(ref: string): string {
+	const path = ref.split(/[?#]/)[0].toLowerCase()
+	if (path.endsWith('.mov')) return 'video/quicktime'
+	if (path.endsWith('.webm')) return 'video/webm'
+	return 'video/mp4'
+}
+
 function extractOpenAIChatText(data: unknown): string {
 	const choices = asArray(asRecord(data)?.choices)
 	const message = asRecord(asRecord(choices[0])?.message)
@@ -178,8 +185,8 @@ export class GeminiTextProvider implements TextGenProvider {
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = stringParam(params?.modelId, 'gemini-2.5-flash')
-		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
-		const refVideos: string[] = Array.isArray(params?.refVideos) ? params.refVideos : []
+		const refImages = Array.isArray(params?.refImages) ? params.refImages.filter((ref): ref is string => typeof ref === 'string') : []
+		const refVideos = Array.isArray(params?.refVideos) ? params.refVideos.filter((ref): ref is string => typeof ref === 'string') : []
 
 		// Build parts: media first, then text
 		const parts: unknown[] = []
@@ -192,11 +199,15 @@ export class GeminiTextProvider implements TextGenProvider {
 				})
 			}
 		}
-		for (const dataUri of refVideos) {
-			const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+		for (const ref of refVideos) {
+			const match = ref.match(/^data:([^;]+);base64,(.+)$/)
 			if (match) {
 				parts.push({
 					inlineData: { mimeType: match[1], data: match[2] },
+				})
+			} else {
+				parts.push({
+					fileData: { mimeType: videoMimeTypeFromRef(ref), fileUri: ref },
 				})
 			}
 		}


### PR DESCRIPTION
## Summary
- Pass upstream video refs into text generation requests
- Convert upstream videos to inline data URIs for Gemini text understanding
- Add a regression check for Gemini video refs and document the behavior

## Verification
- npm run test:gemini-video-text
- npm run build
- npm run lint:obsidian