### PR TITLE
feat: add Gemini 3.5 Flash multimodal text

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,53 @@
+# AGENT.md
+
+This repository is an Obsidian community plugin. Treat Obsidian Community review compatibility as a hard release requirement, not as a post-release cleanup task.
+
+## Branch Workflow
+
+- Do not make feature, fix, model/provider, MCP, or release-prep changes directly on `main`.
+- Create a branch before editing, using `feat/<short-topic>`, `fix/<short-topic>`, `docs/<short-topic>`, `refactor/<short-topic>`, or `release/<version>` / `chore/release-<version>`.
+- If the change also requires skill updates, use the same branch suffix in the skill repository (`nextbound/bragi-canvas-skill`) and keep both branches in sync.
+- Before merging plugin changes, confirm the paired skill branch has been updated for any MCP tool, model/provider, generation behavior, params, return shape, or gotcha changes.
+- Cross-reference paired plugin and skill PRs/branches when merging. Do not merge only one side of a coupled change.
+
+## Required Before Release
+
+- Run `npm run lint:obsidian`.
+- Run `npm run build`.
+- Verify `manifest.json`, `package.json`, `package-lock.json`, and `versions.json` are version-aligned.
+- Update the root `CHANGELOG.md` for every version bump.
+- Verify the release tag is plain semver with no `v` prefix, for example `1.12.14`.
+- Verify the GitHub release has separate `manifest.json`, `main.js`, and `styles.css` assets. Do not upload a zip instead.
+
+## Obsidian Review Rules
+
+- Use sentence case for all UI text, settings text, notices, placeholders, commands, tooltips, and menu labels.
+- Avoid file-level `eslint-disable`. If a lint suppression is unavoidable, scope it to the smallest block and explain why.
+- Do not leave unused imports, variables, functions, or debug `console.log` calls.
+- Avoid `as any`. Prefer typed runtime boundaries or narrow local casts with comments.
+- Keep CSS scoped to Bragi classes such as `.bragi-*` or `.bragi-canvas-*`.
+- Do not use `!important` unless a reviewer-approved exception is unavoidable.
+- Do not duplicate CSS selectors; Obsidian's backend CSS lint reports them.
+- Do not hardcode `.obsidian` paths. Use Obsidian APIs and `Vault.configDir` where applicable.
+- Use `Plugin.loadData()` and `Plugin.saveData()` for plugin data.
+- Use `normalizePath()` for user-controlled vault paths.
+- Do not bundle provider API keys or secrets. Bragi Relay configuration is allowed only through the existing user/runtime configuration path.
+
+## Bragi-Specific Release Notes
+
+- `manifest.json` must keep `"id": "bragi-canvas"`, `"author": "Nextbound"`, and `"authorUrl": "https://bragi.now"`.
+- Treat `manifest.json` as the source of truth for `minAppVersion`; do not lower it without checking all Obsidian APIs used by the plugin.
+- If `minAppVersion` changes, update the matching entry in `versions.json`.
+- The repository uses `MPL-2.0` because it is recognized by GitHub and Obsidian's review backend.
+- Submit or preview reviews through the Obsidian Community backend at `community.obsidian.md` when possible. Do not rely only on the old `obsidian-releases` PR workflow.
+
+## Reference Asset Upload Policy
+
+- When a provider needs a publicly fetchable reference asset URL, prefer the built-in Bragi temporary relay path first (`src/providers/upload.ts` + `src/providers/bragi-relay.ts`) and pass the returned public URL into the model request.
+- Keep upload endpoints and model-input URL endpoints conceptually separate. The relay upload API endpoint is only for writing bytes; the model request must receive the returned fetchable asset URL, not the upload endpoint.
+- Use a provider's own upload/File API only when that provider cannot consume a Bragi Relay HTTPS URL, or when it explicitly requires provider-native file IDs/URIs for the requested feature.
+- Do not write provider keys, relay tokens, uploaded asset URLs, or temporary media files into the repository. Keep live-test outputs summarized and redacted.
+
+## Reference Checklist
+
+For the full checklist and rationale, read `docs/obsidian-review-checklist.md`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also manually copy `manifest.json`, `main.js`, and `styles.css` from the
 4. Select a model and parameters in the generation bar.
 5. Run the generation. Bragi Canvas creates the output node near the source node and connects it back to the source.
 
-Incoming directed edges are treated as upstream references. Text nodes contribute prompt text, image nodes become image references, video nodes can be used for supported video workflows and Gemini text understanding, and audio nodes can be used for supported audio workflows.
+Incoming directed edges are treated as upstream references. Text nodes contribute prompt text, image nodes become image references, video nodes can be used for supported video workflows and Gemini text understanding, and audio or PDF nodes can be used by multimodal text models such as Gemini 3.5 Flash.
 
 ## MCP server
 
@@ -68,7 +68,7 @@ No provider API keys are bundled with the plugin or included in release assets.
 
 ## Network and data disclosure
 
-Bragi Canvas sends prompts and selected upstream reference files to the AI providers configured by the user when a generation is run. Some providers require publicly fetchable reference URLs; for those workflows, Bragi Canvas may upload temporary copies of selected reference files to the built-in Bragi Relay service so the provider can fetch them. Relay-hosted files are intended as temporary transfer files and are not used for client-side telemetry.
+Bragi Canvas sends prompts and selected upstream reference files to the AI providers configured by the user when a generation is run. Some providers require publicly fetchable reference URLs; for those workflows, Bragi Canvas may upload temporary copies of selected reference files to the built-in Bragi Relay service so the provider can fetch them. Gemini multimodal text generation uses inline image data, and sends upstream video, audio, and PDF refs through Bragi Relay as `fileData.fileUri` inputs. Relay-hosted files are intended as temporary transfer files and are not used for client-side telemetry.
 
 Importing and exporting `.bragi` workflow packages uses the file selected by the user in the desktop file picker. Imported package assets are written only into the vault at `_bragi/assets`; Bragi Canvas does not write plugin update files or modify its installed plugin files at runtime.
 

--- a/scripts/verify-gemini-video-text.mjs
+++ b/scripts/verify-gemini-video-text.mjs
@@ -3,23 +3,32 @@ import assert from 'node:assert/strict'
 
 const mainSource = readFileSync('src/main.ts', 'utf8')
 const textGenSource = readFileSync('src/providers/text-gen.ts', 'utf8')
+const tokenRouterSource = readFileSync('src/providers/tokenrouter.ts', 'utf8')
+const modelSource = readFileSync('src/models/text-gen.ts', 'utf8')
+const mcpToolRegistrySource = readFileSync('src/mcp-tool-registry.ts', 'utf8')
 
 assert.match(
-	mainSource,
-	/provider\.generateText\(finalPrompt, \{ modelId: apiModelId, refImages, refVideos \}\)/,
-	'text generation must pass collected upstream videos to text providers',
+	modelSource,
+	/id: 'gemini-3\.5-flash'[\s\S]*gemini: \{ apiModelId: 'gemini-3\.5-flash' \}[\s\S]*tokenrouter: \{ apiModelId: 'google\/gemini-3\.5-flash' \}/,
+	'Gemini 3.5 Flash must be registered for Gemini and TokenRouter',
 )
 
 assert.match(
 	mainSource,
-	/Video references for text generation are currently supported only with Google Gemini\./,
-	'text generation must fail clearly when upstream videos are used with unsupported providers',
+	/provider\.generateText\(finalPrompt, \{ modelId: apiModelId, refImages, refVideos, refAudios, refPdfs \}\)/,
+	'text generation must pass collected upstream video/audio/PDF refs to text providers',
 )
 
 assert.match(
 	mainSource,
-	/const videoUrl = await uploadRef\(undefined, binary, `ref\.\$\{ext\}`, videoMimeType\(videoPath\)\)/,
-	'Gemini text video refs must use the same relay URL upload path as video generation',
+	/Video, audio, and PDF references for text generation are currently supported only with Google Gemini or TokenRouter\./,
+	'text generation must fail clearly when upstream file refs are used with unsupported providers',
+)
+
+assert.match(
+	mainSource,
+	/const uniquePdfs = \[\.\.\.new Set\(upstream\.pdfs\)\]/,
+	'text generation must collect upstream PDF refs',
 )
 
 assert.match(
@@ -30,6 +39,42 @@ assert.match(
 
 assert.match(
 	textGenSource,
-	/fileData: \{ mimeType: videoMimeTypeFromRef\(ref\), fileUri: ref \}/,
-	'Gemini text provider must send upstream video URLs as fileData parts',
+	/const refAudios = Array\.isArray\(params\?\.refAudios\) \? params\.refAudios\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
+	'Gemini text provider must read refAudios defensively',
+)
+
+assert.match(
+	textGenSource,
+	/const refPdfs = Array\.isArray\(params\?\.refPdfs\) \? params\.refPdfs\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
+	'Gemini text provider must read refPdfs defensively',
+)
+
+assert.match(
+	textGenSource,
+	/import \{ uploadRef \} from '\.\/upload'[\s\S]*await uploadRef\(undefined, copyToArrayBuffer\(decoded\.bytes\), `\$\{label\}\.\$\{extensionForMime\(decoded\.mimeType\)\}`, decoded\.mimeType\)/,
+	'Gemini text provider must upload file refs through Bragi Relay before passing fileData URLs',
+)
+
+assert.match(
+	textGenSource,
+	/parts\.push\(\{ fileData: file \}\)/,
+	'Gemini text provider must send uploaded file refs as fileData parts',
+)
+
+assert.match(
+	tokenRouterSource,
+	/const refPdfs: string\[\] = Array\.isArray\(params\?\.refPdfs\) \? params\.refPdfs : \[\]/,
+	'TokenRouter text provider must receive upstream PDF refs for live payload testing',
+)
+
+assert.match(
+	tokenRouterSource,
+	/type: 'file'[\s\S]*file_data: ref/,
+	'TokenRouter text provider must send file refs as OpenAI-compatible file content parts',
+)
+
+assert.match(
+	mcpToolRegistrySource,
+	/audios: upstream\.audios[\s\S]*pdfs: upstream\.pdfs/,
+	'MCP get_upstream must expose audio and PDF refs',
 )

--- a/src/edge-parser.ts
+++ b/src/edge-parser.ts
@@ -7,6 +7,7 @@ export interface UpstreamInputs {
 	images: string[]         // vault-relative file paths of upstream images
 	videos: string[]         // vault-relative file paths of upstream videos
 	audios: string[]         // vault-relative file paths of upstream audio files
+	pdfs: string[]           // vault-relative file paths of upstream PDF files
 }
 
 /**
@@ -19,6 +20,7 @@ export function getUpstreamInputs(canvas: Canvas, node: CanvasNode): UpstreamInp
 		images: [],
 		videos: [],
 		audios: [],
+		pdfs: [],
 	}
 
 	const edges = canvas.getEdgesForNode(node)
@@ -51,6 +53,8 @@ export function getUpstreamInputs(canvas: Canvas, node: CanvasNode): UpstreamInp
 				// Note node — will need to read file content later (async)
 				// For now, store the path; caller resolves it
 				result.prompts.push(`__md__:${filePath}`)
+			} else if (/\.pdf$/i.test(filePath)) {
+				result.pdfs.push(filePath)
 			} else if (/\.(png|jpg|jpeg|webp|gif)$/i.test(filePath)) {
 				result.images.push(filePath)
 			} else if (/\.(mp4|mov|webm)$/i.test(filePath)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,8 +336,9 @@ export default class BragiCanvas extends Plugin {
 		const placeholder = createPlaceholderNode(canvas, model.name, node, targetSize)
 		// Register as in-flight so the ghost sweeper doesn't flag it on reloads.
 		this.syncGenerating.add(placeholder.id)
-		const inputInfo = upstream.images.length > 0
-			? ` with ${upstream.images.length} reference${upstream.images.length > 1 ? 's' : ''}`
+		const inputRefCount = upstream.images.length + upstream.videos.length + upstream.audios.length + upstream.pdfs.length
+		const inputInfo = inputRefCount > 0
+			? ` with ${inputRefCount} reference${inputRefCount > 1 ? 's' : ''}`
 			: ''
 		new Notice(`Generating ${model.name}${inputInfo}…`)
 
@@ -373,13 +374,15 @@ export default class BragiCanvas extends Plugin {
 			// Read reference images in user-defined order (from thumbnail drag)
 			const uniqueImages = getOrderedImages(canvas, node)
 			const uniqueVideos = [...new Set(upstream.videos)]
+			const uniqueAudios = [...new Set(upstream.audios)]
+			const uniquePdfs = [...new Set(upstream.pdfs)]
 			// Only native Volcengine / BytePlus Seedance can consume asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const supportsSeedanceRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
 			const assetIdMap = isNativeSeedance ? getAssetIds(canvas, node) : {}
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
-			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && (uniqueImages.length > 0 || upstream.audios.length > 0 || uniqueVideos.length > 0))
+			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && (uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0))
 				? getBytePlusAssetCreds(this)
 				: null
 			const refImages: string[] = []
@@ -400,11 +403,15 @@ export default class BragiCanvas extends Plugin {
 
 			// Upload reference audios for Seedance
 			const refAudios: string[] = []
-			if (supportsSeedanceRefs && upstream.audios.length > 0) {
-				if (upstream.audios.length > 3) {
+			if (model.type === 'text' && uniqueAudios.length > 0) {
+				for (const audioPath of uniqueAudios) {
+					refAudios.push(await readVaultFileAsDataUri(this, audioPath, audioMimeType(audioPath)))
+				}
+			} else if (supportsSeedanceRefs && uniqueAudios.length > 0) {
+				if (uniqueAudios.length > 3) {
 					throw new Error('Seedance supports up to 3 reference audio files.')
 				}
-				for (const audioPath of upstream.audios) {
+				for (const audioPath of uniqueAudios) {
 					if (bytePlusCreds) {
 						// Route audio through asset library for content review
 						refAudios.push(await ensureBytePlusAsset(this, canvas, audioPath, bytePlusCreds))
@@ -422,14 +429,8 @@ export default class BragiCanvas extends Plugin {
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			const refVideos: string[] = []
 			if (model.type === 'text' && uniqueVideos.length > 0) {
-				if (!textProviderSupportsVideoRefs(activeProvider)) {
-					throw new Error('Video references for text generation are currently supported only with Google Gemini.')
-				}
 				for (const videoPath of uniqueVideos) {
-					const binary = await this.app.vault.adapter.readBinary(videoPath)
-					const ext = getFileExtension(videoPath, 'mp4')
-					const videoUrl = await uploadRef(undefined, binary, `ref.${ext}`, videoMimeType(videoPath))
-					refVideos.push(videoUrl)
+					refVideos.push(await readVaultFileAsDataUri(this, videoPath, videoMimeType(videoPath)))
 				}
 			} else if (model.type === 'video' && uniqueVideos.length > 0) {
 				if (mode === 'video-ref' && !supportsSeedanceRefs) {
@@ -454,6 +455,17 @@ export default class BragiCanvas extends Plugin {
 						}
 					}
 				}
+			}
+
+			const refPdfs: string[] = []
+			if (model.type === 'text' && uniquePdfs.length > 0) {
+				for (const pdfPath of uniquePdfs) {
+					refPdfs.push(await readVaultFileAsDataUri(this, pdfPath, 'application/pdf'))
+				}
+			}
+
+			if (model.type === 'text' && (refVideos.length > 0 || refAudios.length > 0 || refPdfs.length > 0) && !textProviderSupportsFileRefs(activeProvider)) {
+				throw new Error('Video, audio, and PDF references for text generation are currently supported only with Google Gemini or TokenRouter.')
 			}
 
 			if (model.type === 'image') {
@@ -515,7 +527,7 @@ export default class BragiCanvas extends Plugin {
 					markNodeFailed(placeholder, `${activeProvider} doesn't support text generation`)
 					return
 				}
-				const { text: textResult } = await provider.generateText(finalPrompt, { modelId: apiModelId, refImages, refVideos })
+				const { text: textResult } = await provider.generateText(finalPrompt, { modelId: apiModelId, refImages, refVideos, refAudios, refPdfs })
 
 				// Split result into multiple nodes if ---SPLIT--- is present
 				canvas.removeNode(placeholder)
@@ -1159,8 +1171,13 @@ function videoMimeType(filePath: string): string {
 	return 'video/mp4'
 }
 
-function textProviderSupportsVideoRefs(activeProvider: string): boolean {
-	return activeProvider === 'gemini'
+async function readVaultFileAsDataUri(plugin: BragiCanvas, filePath: string, mimeType: string): Promise<string> {
+	const binary = await plugin.app.vault.adapter.readBinary(filePath)
+	return `data:${mimeType};base64,${arrayBufferToBase64(binary)}`
+}
+
+function textProviderSupportsFileRefs(activeProvider: string): boolean {
+	return activeProvider === 'gemini' || activeProvider === 'tokenrouter'
 }
 
 /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- Resume strict linting after the runtime-shaped data boundary. */

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -450,7 +450,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 		{
 			category: 'Generation',
 			name: 'get_upstream',
-			description: 'Get upstream inputs (text prompts, reference images, reference videos) connected to a node via arrows',
+			description: 'Get upstream inputs (text prompts, reference images, reference videos, audio files, and PDFs) connected to a node via arrows',
 			inputSchema: { id: z.string().describe('Target node ID') },
 			handler: ({ id }) => {
 				const canvas = requireCanvas(getCanvas)
@@ -462,6 +462,8 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 					prompts: upstream.prompts,
 					images: orderedImages,
 					videos: upstream.videos,
+					audios: upstream.audios,
+					pdfs: upstream.pdfs,
 					textRefs: textRefs.map(r => ({ nodeId: r.nodeId, preview: r.preview, kind: r.kind, mdPath: r.mdPath })),
 				})
 			},

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,7 +6,7 @@ import { seedance2, seedance2Fast } from './seedance'
 import { kling3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
-import { gpt55, gpt55Pro, gemini31Pro, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
+import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
 import { lumaUni1 } from './luma'
@@ -47,6 +47,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	// Text
 	claudeOpus47,
 	claudeSonnet46,
+	gemini35Flash,
 	gemini3Flash,
 	gemini31Pro,
 	grok43,

--- a/src/models/text-gen.ts
+++ b/src/models/text-gen.ts
@@ -38,6 +38,18 @@ export const gemini31Pro: ModelConfig = {
 	params: [],
 }
 
+export const gemini35Flash: ModelConfig = {
+	id: 'gemini-3.5-flash',
+	name: 'Gemini 3.5 Flash',
+	type: 'text',
+	supportedProviders: {
+		gemini: { apiModelId: 'gemini-3.5-flash' },
+		tokenrouter: { apiModelId: 'google/gemini-3.5-flash' },
+	},
+	modes: ['text-to-text'],
+	params: [],
+}
+
 export const gemini3Flash: ModelConfig = {
 	id: 'gemini-3-flash',
 	name: 'Gemini 3 Flash',

--- a/src/providers/text-gen.ts
+++ b/src/providers/text-gen.ts
@@ -51,6 +51,52 @@ function videoMimeTypeFromRef(ref: string): string {
 	return 'video/mp4'
 }
 
+function audioMimeTypeFromRef(ref: string): string {
+	const path = ref.split(/[?#]/)[0].toLowerCase()
+	if (path.endsWith('.wav')) return 'audio/wav'
+	if (path.endsWith('.m4a') || path.endsWith('.mp4')) return 'audio/mp4'
+	if (path.endsWith('.aac')) return 'audio/aac'
+	if (path.endsWith('.flac')) return 'audio/flac'
+	if (path.endsWith('.ogg')) return 'audio/ogg'
+	if (path.endsWith('.opus')) return 'audio/opus'
+	return 'audio/mpeg'
+}
+
+function extensionForMime(mimeType: string): string {
+	if (mimeType === 'application/pdf') return 'pdf'
+	if (mimeType.includes('quicktime')) return 'mov'
+	if (mimeType.includes('webm')) return 'webm'
+	if (mimeType.includes('wav')) return 'wav'
+	if (mimeType.includes('mp4')) return 'mp4'
+	if (mimeType.includes('aac')) return 'aac'
+	if (mimeType.includes('flac')) return 'flac'
+	if (mimeType.includes('ogg')) return 'ogg'
+	if (mimeType.includes('opus')) return 'opus'
+	if (mimeType.includes('mpeg')) return 'mp3'
+	return 'bin'
+}
+
+function parseDataUri(dataUri: string): { mimeType: string; data: string } | null {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+	if (!match) return null
+	return { mimeType: match[1], data: match[2] }
+}
+
+function dataUriToBytes(dataUri: string): { mimeType: string; bytes: Uint8Array } | null {
+	const parsed = parseDataUri(dataUri)
+	if (!parsed) return null
+	return {
+		mimeType: parsed.mimeType,
+		bytes: Uint8Array.from(atob(parsed.data), c => c.charCodeAt(0)),
+	}
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const out = new Uint8Array(bytes.byteLength)
+	out.set(bytes)
+	return out.buffer
+}
+
 function extractOpenAIChatText(data: unknown): string {
 	const choices = asArray(asRecord(unwrapDataEnvelope(data))?.choices)
 	const message = asRecord(asRecord(choices[0])?.message)
@@ -297,29 +343,31 @@ export class GeminiTextProvider implements TextGenProvider {
 		const modelId = stringParam(params?.modelId, 'gemini-2.5-flash')
 		const refImages = Array.isArray(params?.refImages) ? params.refImages.filter((ref): ref is string => typeof ref === 'string') : []
 		const refVideos = Array.isArray(params?.refVideos) ? params.refVideos.filter((ref): ref is string => typeof ref === 'string') : []
+		const refAudios = Array.isArray(params?.refAudios) ? params.refAudios.filter((ref): ref is string => typeof ref === 'string') : []
+		const refPdfs = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((ref): ref is string => typeof ref === 'string') : []
 
 		// Build parts: media first, then text
 		const parts: unknown[] = []
 
 		for (const dataUri of refImages) {
-			const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
-			if (match) {
+			const parsed = parseDataUri(dataUri)
+			if (parsed) {
 				parts.push({
-					inlineData: { mimeType: match[1], data: match[2] },
+					inlineData: { mimeType: parsed.mimeType, data: parsed.data },
 				})
 			}
 		}
 		for (const ref of refVideos) {
-			const match = ref.match(/^data:([^;]+);base64,(.+)$/)
-			if (match) {
-				parts.push({
-					inlineData: { mimeType: match[1], data: match[2] },
-				})
-			} else {
-				parts.push({
-					fileData: { mimeType: videoMimeTypeFromRef(ref), fileUri: ref },
-				})
-			}
+			const file = await this.fileDataPart(ref, videoMimeTypeFromRef(ref), 'video')
+			parts.push({ fileData: file })
+		}
+		for (const ref of refAudios) {
+			const file = await this.fileDataPart(ref, audioMimeTypeFromRef(ref), 'audio')
+			parts.push({ fileData: file })
+		}
+		for (const ref of refPdfs) {
+			const file = await this.fileDataPart(ref, 'application/pdf', 'document')
+			parts.push({ fileData: file })
 		}
 
 		parts.push({ text: prompt })
@@ -333,22 +381,33 @@ export class GeminiTextProvider implements TextGenProvider {
 				'Content-Type': 'application/json',
 				'x-goog-api-key': this.apiKey,
 			},
+			throw: false,
 			body: JSON.stringify({
 				systemInstruction: { parts: [{ text: SYSTEM_PROMPT }] },
 				contents: [{ parts }],
 			}),
 		})
 
+		if (response.status >= 400) throw new Error(parseProviderError('Gemini text', response))
 		const data = response.json
-		const text = data.candidates?.[0]?.content?.parts
-			?.filter((p: unknown) => p.text)
-			?.map((p: unknown) => p.text)
+		const text = asArray(asRecord(asRecord(asArray(asRecord(data)?.candidates)[0])?.content)?.parts)
+			.map(part => asRecord(part))
+			.filter(Boolean)
+			.filter(part => part?.text)
+			.map(part => stringParam(part?.text, ''))
 			?.join('\n')
 			?.trim()
 
 		if (!text) throw new Error('Gemini: No text in response')
 
 		return { text }
+	}
+
+	private async fileDataPart(ref: string, fallbackMimeType: string, label: string): Promise<{ mimeType: string; fileUri: string }> {
+		const decoded = dataUriToBytes(ref)
+		if (!decoded) return { mimeType: fallbackMimeType, fileUri: ref }
+		const fileUri = await uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `${label}.${extensionForMime(decoded.mimeType)}`, decoded.mimeType)
+		return { mimeType: decoded.mimeType, fileUri }
 	}
 }
 

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -51,14 +51,31 @@ function isHttpUrl(value: string): boolean {
 	return /^https?:\/\//i.test(value)
 }
 
-function dataUriToBytes(dataUri: string): { bytes: Uint8Array; ext: string } | null {
+function extensionForMime(mimeType: string): string {
+	if (mimeType === 'application/pdf') return 'pdf'
+	if (mimeType.includes('webp')) return 'webp'
+	if (mimeType.includes('jpeg') || mimeType.includes('jpg')) return 'jpg'
+	if (mimeType.includes('png')) return 'png'
+	if (mimeType.includes('quicktime')) return 'mov'
+	if (mimeType.includes('webm')) return 'webm'
+	if (mimeType.includes('wav')) return 'wav'
+	if (mimeType.includes('mp4')) return 'mp4'
+	if (mimeType.includes('aac')) return 'aac'
+	if (mimeType.includes('flac')) return 'flac'
+	if (mimeType.includes('ogg')) return 'ogg'
+	if (mimeType.includes('opus')) return 'opus'
+	if (mimeType.includes('mpeg')) return 'mp3'
+	return 'bin'
+}
+
+function dataUriToBytes(dataUri: string): { bytes: Uint8Array; ext: string; mimeType: string } | null {
 	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
 	if (!match) return null
 	const mime = match[1]
-	const ext = mime.includes('webp') ? 'webp' : mime.includes('jpeg') || mime.includes('jpg') ? 'jpg' : 'png'
 	return {
 		bytes: Uint8Array.from(atob(match[2]), c => c.charCodeAt(0)),
-		ext,
+		ext: extensionForMime(mime),
+		mimeType: mime,
 	}
 }
 
@@ -265,10 +282,22 @@ export class TokenRouterTextProvider implements TextGenProvider {
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = stringParam(params?.modelId, 'openai/gpt-5.5')
 		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		const refVideos: string[] = Array.isArray(params?.refVideos) ? params.refVideos : []
+		const refAudios: string[] = Array.isArray(params?.refAudios) ? params.refAudios : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs : []
 		const content: unknown[] = []
 
 		for (const ref of refImages) {
 			content.push({ type: 'image_url', image_url: { url: ref } })
+		}
+		for (let i = 0; i < refVideos.length; i++) {
+			content.push(this.fileContentPart(refVideos[i], `video-${i + 1}`))
+		}
+		for (let i = 0; i < refAudios.length; i++) {
+			content.push(this.fileContentPart(refAudios[i], `audio-${i + 1}`))
+		}
+		for (let i = 0; i < refPdfs.length; i++) {
+			content.push(this.fileContentPart(refPdfs[i], `document-${i + 1}`))
 		}
 		content.push({ type: 'text', text: prompt })
 
@@ -294,6 +323,23 @@ export class TokenRouterTextProvider implements TextGenProvider {
 		const text = extractText(resp.json)
 		if (!text) throw new Error('TokenRouter: No text in response')
 		return { text }
+	}
+
+	private fileContentPart(ref: string, basename: string): unknown {
+		const decoded = dataUriToBytes(ref)
+		if (!decoded) {
+			return {
+				type: 'file',
+				file: { file_id: ref, filename: basename },
+			}
+		}
+		return {
+			type: 'file',
+			file: {
+				filename: `${basename}.${decoded.ext}`,
+				file_data: ref,
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Add Gemini 3.5 Flash as a text model for Google Gemini and TokenRouter.\n- Support upstream image, video, audio, and PDF refs for Gemini 3.5 Flash text generation.\n- Route Google Gemini video/audio/PDF refs through Bragi Relay and pass the returned URL as fileData.fileUri.\n- Expose audios and pdfs from get_upstream and document the relay upload policy.\n\n## Verification\n- npm run test:gemini-video-text\n- npm run build\n- npm run lint:obsidian\n- npm run sync:check\n- npm run verify\n- Obsidian smoke tested with image/video/audio/PDF refs.