### PR TITLE
feat: add multimodal text input support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "node esbuild.config.mjs production",
     "audit:theme": "node scripts/audit-theme-vars.mjs",
     "lint:obsidian": "eslint .",
-    "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs"
+    "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
+    "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-text-multimodal.mjs
+++ b/scripts/verify-text-multimodal.mjs
@@ -1,0 +1,170 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const mainSource = readFileSync('src/main.ts', 'utf8')
+const textGenSource = readFileSync('src/providers/text-gen.ts', 'utf8')
+const tokenRouterSource = readFileSync('src/providers/tokenrouter.ts', 'utf8')
+const modelSource = readFileSync('src/models/text-gen.ts', 'utf8')
+const mcpToolRegistrySource = readFileSync('src/mcp-tool-registry.ts', 'utf8')
+const capabilitiesSource = readFileSync('src/models/text-input-capabilities.ts', 'utf8')
+const prepSource = readFileSync('src/text-input-prep.ts', 'utf8')
+const registrySource = readFileSync('src/providers/registry.ts', 'utf8')
+const dashscopeTextSource = readFileSync('src/providers/dashscope-text.ts', 'utf8')
+
+assert.match(
+	capabilitiesSource,
+	/export function getTextInputCapability/,
+	'capability matrix must expose getTextInputCapability',
+)
+
+assert.match(
+	capabilitiesSource,
+	/export function validateTextInputs/,
+	'capability matrix must expose validateTextInputs',
+)
+
+assert.match(
+	prepSource,
+	/export async function prepareTextInputs/,
+	'text input prep pipeline must expose prepareTextInputs',
+)
+
+assert.doesNotMatch(
+	mainSource,
+	/textProviderSupportsFileRefs/,
+	'main.ts must not use coarse textProviderSupportsFileRefs gate',
+)
+
+assert.match(
+	mainSource,
+	/validateTextInputs\(model\.id, activeProvider/,
+	'main.ts must validate text inputs before generation',
+)
+
+assert.match(
+	mainSource,
+	/prepareTextInputs\(this\.app, canvas, node, model\.id, activeProvider, upstream, apiModelId\)/,
+	'main.ts must prepare text refs through the shared prep pipeline',
+)
+
+assert.match(
+	mainSource,
+	/provider\.generateText\(finalPrompt, \{ modelId: apiModelId, refImages, refVideos, refAudios, refPdfs \}\)/,
+	'text generation must pass collected upstream video/audio/PDF refs to text providers',
+)
+
+assert.match(
+	mcpToolRegistrySource,
+	/supportedInputs: listSupportedInputLabels\(capability\)/,
+	'MCP list_models must expose supportedInputs for text models',
+)
+
+assert.match(
+	mcpToolRegistrySource,
+	/unsupportedInputs: listUnsupportedInputLabels\(capability\)/,
+	'MCP list_models must expose unsupportedInputs for text models',
+)
+
+assert.match(
+	textGenSource,
+	/type: 'document'/,
+	'Anthropic text provider must send PDF refs as document blocks',
+)
+
+assert.match(
+	textGenSource,
+	/type: 'input_file'/,
+	'OpenAI-compatible Responses providers must send PDF refs as input_file blocks',
+)
+
+assert.match(
+	textGenSource,
+	/export class XAITextProvider/,
+	'xAI text provider must use Responses API directly',
+)
+
+assert.match(
+	dashscopeTextSource,
+	/multimodal-generation\/generation/,
+	'DashScope text provider must call multimodal-generation endpoint',
+)
+
+assert.match(
+	dashscopeTextSource,
+	/\{ file: url \}/,
+	'DashScope text provider must send PDF refs as file parts',
+)
+
+assert.match(
+	modelSource,
+	/dashscope: \{ apiModelId: 'qwen3\.6-plus' \}/,
+	'Qwen 3.6 Plus must register DashScope provider',
+)
+
+assert.match(
+	registrySource,
+	/new DashScopeTextProvider\(settings\.providers\.dashscope\)/,
+	'DashScope text provider must be registered in provider registry',
+)
+
+assert.match(
+	registrySource,
+	/new XAITextProvider\(settings\.providers\.xai\)/,
+	'xAI text provider must replace OpenAI chat wrapper in registry',
+)
+
+assert.match(
+	modelSource,
+	/id: 'gemini-3\.5-flash'[\s\S]*gemini: \{ apiModelId: 'gemini-3\.5-flash' \}[\s\S]*tokenrouter: \{ apiModelId: 'google\/gemini-3\.5-flash' \}/,
+	'Gemini 3.5 Flash must be registered for Gemini and TokenRouter',
+)
+
+assert.match(
+	textGenSource,
+	/const refVideos = Array\.isArray\(params\?\.refVideos\) \? params\.refVideos\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
+	'Gemini text provider must read refVideos defensively',
+)
+
+assert.match(
+	textGenSource,
+	/const refAudios = Array\.isArray\(params\?\.refAudios\) \? params\.refAudios\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
+	'Gemini text provider must read refAudios defensively',
+)
+
+assert.match(
+	textGenSource,
+	/const refPdfs = Array\.isArray\(params\?\.refPdfs\) \? params\.refPdfs\.filter\(\(ref\): ref is string => typeof ref === 'string'\) : \[\]/,
+	'Gemini text provider must read refPdfs defensively',
+)
+
+assert.match(
+	textGenSource,
+	/import \{ uploadRef \} from '\.\/upload'[\s\S]*await uploadRef\(undefined, copyToArrayBuffer\(decoded\.bytes\), `\$\{label\}\.\$\{extensionForMime\(decoded\.mimeType\)\}`, decoded\.mimeType\)/,
+	'Gemini text provider must upload file refs through Bragi Relay before passing fileData URLs',
+)
+
+assert.match(
+	textGenSource,
+	/parts\.push\(\{ fileData: file \}\)/,
+	'Gemini text provider must send uploaded file refs as fileData parts',
+)
+
+assert.match(
+	tokenRouterSource,
+	/const refPdfs: string\[\] = Array\.isArray\(params\?\.refPdfs\) \? params\.refPdfs : \[\]/,
+	'TokenRouter text provider must receive upstream PDF refs for live payload testing',
+)
+
+assert.match(
+	tokenRouterSource,
+	/type: 'file'[\s\S]*file_data: ref/,
+	'TokenRouter text provider must send file refs as OpenAI-compatible file content parts',
+)
+
+assert.match(
+	mcpToolRegistrySource,
+	/audios: upstream\.audios[\s\S]*pdfs: upstream\.pdfs/,
+	'MCP get_upstream must expose audio and PDF refs',
+)
+
+console.log('verify-text-multimodal: all static checks passed')

--- a/scripts/verify-text-multimodal.mjs
+++ b/scripts/verify-text-multimodal.mjs
@@ -150,6 +150,12 @@ assert.match(
 )
 
 assert.match(
+	textGenSource,
+	/for \(const ref of refImages\)[\s\S]*parseDataUri\(ref\)[\s\S]*fileDataPart\(ref, imageMimeTypeFromRef\(ref\), 'image'\)/,
+	'Gemini text provider must preserve uploaded image URLs as fileData parts',
+)
+
+assert.match(
 	tokenRouterSource,
 	/const refPdfs: string\[\] = Array\.isArray\(params\?\.refPdfs\) \? params\.refPdfs : \[\]/,
 	'TokenRouter text provider must receive upstream PDF refs for live payload testing',
@@ -159,6 +165,12 @@ assert.match(
 	tokenRouterSource,
 	/type: 'file'[\s\S]*file_data: ref/,
 	'TokenRouter text provider must send file refs as OpenAI-compatible file content parts',
+)
+
+assert.match(
+	tokenRouterSource,
+	/if \(isHttpUrl\(ref\)\) \{[\s\S]*file_data: ref[\s\S]*return \{[\s\S]*file_id: ref/,
+	'TokenRouter text provider must send relay URLs as file_data, not file_id',
 )
 
 assert.match(

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,8 @@ import type { Canvas, CanvasNode } from './types/canvas-internal'
 import type { VoiceSourceMode } from './models/types'
 import { existsSync } from 'fs'
 import { join } from 'path'
+import { validateTextInputs } from './models/text-input-capabilities'
+import { prepareTextInputs } from './text-input-prep'
 
 export default class BragiCanvas extends Plugin {
 	settings: BragiSettings = DEFAULT_SETTINGS
@@ -395,6 +397,25 @@ export default class BragiCanvas extends Plugin {
 			const uniqueVideos = [...new Set(upstream.videos)]
 			const uniqueAudios = [...new Set(upstream.audios)]
 			const uniquePdfs = [...new Set(upstream.pdfs)]
+
+			let refImages: string[] = []
+			let refAudios: string[] = []
+			let refVideos: string[] = []
+			let refPdfs: string[] = []
+
+			if (model.type === 'text') {
+				validateTextInputs(model.id, activeProvider, {
+					images: uniqueImages.length,
+					pdfs: uniquePdfs.length,
+					videos: uniqueVideos.length,
+					audios: uniqueAudios.length,
+				}, apiModelId)
+				const prepared = await prepareTextInputs(this.app, canvas, node, model.id, activeProvider, upstream, apiModelId)
+				refImages = prepared.refImages
+				refVideos = prepared.refVideos
+				refAudios = prepared.refAudios
+				refPdfs = prepared.refPdfs
+			} else {
 			// Only native Volcengine / BytePlus Seedance can consume asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
@@ -404,7 +425,6 @@ export default class BragiCanvas extends Plugin {
 			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && (uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0))
 				? getBytePlusAssetCreds(this)
 				: null
-			const refImages: string[] = []
 			for (const imgPath of uniqueImages) {
 				if (assetIdMap[imgPath]) {
 					refImages.push(`asset://${assetIdMap[imgPath]}`)
@@ -421,12 +441,7 @@ export default class BragiCanvas extends Plugin {
 			}
 
 			// Upload reference audios for Seedance
-			const refAudios: string[] = []
-			if (model.type === 'text' && uniqueAudios.length > 0) {
-				for (const audioPath of uniqueAudios) {
-					refAudios.push(await readVaultFileAsDataUri(this, audioPath, audioMimeType(audioPath)))
-				}
-			} else if (supportsSeedanceRefs && uniqueAudios.length > 0) {
+			if (supportsSeedanceRefs && uniqueAudios.length > 0) {
 				if (uniqueAudios.length > 3) {
 					throw new Error('Seedance supports up to 3 reference audio files.')
 				}
@@ -446,12 +461,7 @@ export default class BragiCanvas extends Plugin {
 
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
-			const refVideos: string[] = []
-			if (model.type === 'text' && uniqueVideos.length > 0) {
-				for (const videoPath of uniqueVideos) {
-					refVideos.push(await readVaultFileAsDataUri(this, videoPath, videoMimeType(videoPath)))
-				}
-			} else if (model.type === 'video' && uniqueVideos.length > 0) {
+			if (model.type === 'video' && uniqueVideos.length > 0) {
 				if (mode === 'video-ref' && !supportsSeedanceRefs) {
 					throw new Error('Reference video is only available with Volcengine, BytePlus, or TokenRouter Seedance.')
 				}
@@ -475,16 +485,6 @@ export default class BragiCanvas extends Plugin {
 					}
 				}
 			}
-
-			const refPdfs: string[] = []
-			if (model.type === 'text' && uniquePdfs.length > 0) {
-				for (const pdfPath of uniquePdfs) {
-					refPdfs.push(await readVaultFileAsDataUri(this, pdfPath, 'application/pdf'))
-				}
-			}
-
-			if (model.type === 'text' && (refVideos.length > 0 || refAudios.length > 0 || refPdfs.length > 0) && !textProviderSupportsFileRefs(activeProvider)) {
-				throw new Error('Video, audio, and PDF references for text generation are currently supported only with Google Gemini or TokenRouter.')
 			}
 
 			if (model.type === 'image') {
@@ -1188,15 +1188,6 @@ function videoMimeType(filePath: string): string {
 	if (ext === 'mov') return 'video/quicktime'
 	if (ext === 'webm') return 'video/webm'
 	return 'video/mp4'
-}
-
-async function readVaultFileAsDataUri(plugin: BragiCanvas, filePath: string, mimeType: string): Promise<string> {
-	const binary = await plugin.app.vault.adapter.readBinary(filePath)
-	return `data:${mimeType};base64,${arrayBufferToBase64(binary)}`
-}
-
-function textProviderSupportsFileRefs(activeProvider: string): boolean {
-	return activeProvider === 'gemini' || activeProvider === 'tokenrouter'
 }
 
 /* eslint-enable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- Resume strict linting after the runtime-shaped data boundary. */

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -7,6 +7,7 @@ import type { AllCanvasNodeData, CanvasEdgeData } from 'obsidian/canvas'
 import type { Canvas, CanvasEdge, CanvasNode, MoveAndResizeOptions } from './types/canvas-internal'
 import type { PanelResult } from './panel'
 import { getModelById, getActiveProvider, getEnabledModels } from './models/index'
+import { getTextInputCapability, listSupportedInputLabels, listUnsupportedInputLabels } from './models/text-input-capabilities'
 import { getConfiguredProviderIds } from './providers/registry'
 import type { GenerationType, Mode } from './models/types'
 import { getUpstreamInputs } from './edge-parser'
@@ -426,12 +427,20 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 					for (const m of models) {
 						const pref = settings.modelPrefs[m.id]
 						const provider = getActiveProvider(m, pref?.selectedProvider, configured)
+						const apiModelId = m.supportedProviders[provider]?.apiModelId
+						const capability = m.type === 'text'
+							? getTextInputCapability(m.id, provider, apiModelId)
+							: null
 						result.push({
 							id: m.id,
 							name: m.name,
 							type: m.type,
 							provider,
 							modes: m.modes,
+							...(capability ? {
+								supportedInputs: listSupportedInputLabels(capability),
+								unsupportedInputs: listUnsupportedInputLabels(capability),
+							} : {}),
 							params: m.params.map(p => ({
 								id: p.id,
 								label: p.label,

--- a/src/models/text-gen.ts
+++ b/src/models/text-gen.ts
@@ -81,6 +81,7 @@ export const qwen36Plus: ModelConfig = {
 	type: 'text',
 	supportedProviders: {
 		tokenrouter: { apiModelId: 'qwen/qwen3.6-plus' },
+		dashscope: { apiModelId: 'qwen3.6-plus' },
 	},
 	modes: ['text-to-text'],
 	params: [],

--- a/src/models/text-input-capabilities.ts
+++ b/src/models/text-input-capabilities.ts
@@ -1,0 +1,142 @@
+import { getModelById } from './index'
+
+export type TextInputKind = 'image' | 'pdf' | 'video' | 'audio'
+
+export interface TextInputCapability {
+	kinds: TextInputKind[]
+	maxImages?: number
+	maxPdfs?: number
+	maxVideos?: number
+	maxAudios?: number
+	maxPdfBytes?: number
+}
+
+export interface TextInputCounts {
+	images: number
+	pdfs: number
+	videos: number
+	audios: number
+}
+
+const IMAGE_PDF: TextInputKind[] = ['image', 'pdf']
+const FULL_MULTIMODAL: TextInputKind[] = ['image', 'pdf', 'video', 'audio']
+const IMAGE_ONLY: TextInputKind[] = ['image']
+
+const PROVIDER_DEFAULTS: Record<string, TextInputCapability> = {
+	openai: { kinds: IMAGE_PDF, maxPdfBytes: 50 * 1024 * 1024 },
+	anthropic: { kinds: IMAGE_PDF, maxPdfs: 5, maxPdfBytes: 32 * 1024 * 1024 },
+	bedrock: { kinds: IMAGE_PDF, maxPdfs: 5, maxPdfBytes: 32 * 1024 * 1024 },
+	gemini: { kinds: FULL_MULTIMODAL, maxVideos: 1, maxAudios: 1, maxImages: 10 },
+	xai: { kinds: IMAGE_PDF, maxPdfBytes: 48 * 1024 * 1024 },
+	apimart: { kinds: IMAGE_PDF, maxPdfBytes: 50 * 1024 * 1024 },
+	dashscope: { kinds: ['image', 'pdf', 'video', 'audio'], maxVideos: 64 },
+}
+
+function tokenRouterCapability(apiModelId: string): TextInputCapability {
+	const slug = apiModelId.toLowerCase()
+	if (slug.startsWith('google/') || slug.includes('gemini')) {
+		return { kinds: FULL_MULTIMODAL, maxVideos: 1, maxAudios: 1, maxImages: 10 }
+	}
+	if (slug.startsWith('qwen/') || slug.includes('qwen3')) {
+		return { kinds: ['image', 'pdf', 'video', 'audio'], maxVideos: 64 }
+	}
+	if (slug.startsWith('anthropic/') || slug.startsWith('openai/') || slug.startsWith('x-ai/') || slug.startsWith('xai/')) {
+		return { kinds: IMAGE_PDF, maxPdfBytes: 50 * 1024 * 1024 }
+	}
+	return { kinds: FULL_MULTIMODAL }
+}
+
+export function getTextInputCapability(
+	modelId: string,
+	providerId: string,
+	apiModelId?: string,
+): TextInputCapability {
+	if (providerId === 'tokenrouter') {
+		const model = getModelById(modelId)
+		const slug = apiModelId || model?.supportedProviders.tokenrouter?.apiModelId || ''
+		return tokenRouterCapability(slug)
+	}
+
+	const base = PROVIDER_DEFAULTS[providerId]
+	if (!base) return { kinds: IMAGE_ONLY }
+
+	if (providerId === 'gemini' || providerId === 'dashscope') {
+		return base
+	}
+
+	return base
+}
+
+export function textInputKindSupported(
+	capability: TextInputCapability,
+	kind: TextInputKind,
+): boolean {
+	return capability.kinds.includes(kind)
+}
+
+export function listSupportedInputLabels(capability: TextInputCapability): string[] {
+	const labels = ['text']
+	if (capability.kinds.includes('image')) labels.push('image')
+	if (capability.kinds.includes('pdf')) labels.push('pdf')
+	if (capability.kinds.includes('video')) labels.push('video')
+	if (capability.kinds.includes('audio')) labels.push('audio')
+	return labels
+}
+
+export function listUnsupportedInputLabels(capability: TextInputCapability): string[] {
+	const all = ['image', 'pdf', 'video', 'audio'] as const
+	return all.filter(kind => !capability.kinds.includes(kind))
+}
+
+function kindLabel(kind: TextInputKind): string {
+	if (kind === 'pdf') return 'PDF'
+	if (kind === 'audio') return 'audio'
+	if (kind === 'video') return 'video'
+	return 'image'
+}
+
+function providerLabel(providerId: string): string {
+	const labels: Record<string, string> = {
+		openai: 'OpenAI',
+		anthropic: 'Anthropic',
+		bedrock: 'AWS Bedrock',
+		gemini: 'Google Gemini',
+		xai: 'xAI',
+		apimart: 'APIMart',
+		tokenrouter: 'TokenRouter',
+		dashscope: 'DashScope',
+	}
+	return labels[providerId] || providerId
+}
+
+export function validateTextInputs(
+	modelId: string,
+	providerId: string,
+	counts: TextInputCounts,
+	apiModelId?: string,
+): void {
+	const capability = getTextInputCapability(modelId, providerId, apiModelId)
+	const model = getModelById(modelId)
+	const modelName = model?.name || modelId
+
+	const checks: Array<{ kind: TextInputKind; count: number; max?: number }> = [
+		{ kind: 'image', count: counts.images, max: capability.maxImages },
+		{ kind: 'pdf', count: counts.pdfs, max: capability.maxPdfs },
+		{ kind: 'video', count: counts.videos, max: capability.maxVideos },
+		{ kind: 'audio', count: counts.audios, max: capability.maxAudios },
+	]
+
+	for (const { kind, count, max } of checks) {
+		if (count <= 0) continue
+		if (!textInputKindSupported(capability, kind)) {
+			throw new Error(
+				`${modelName} via ${providerLabel(providerId)} does not support upstream ${kindLabel(kind)} for text generation.`,
+			)
+		}
+		if (max !== undefined && count > max) {
+			throw new Error(
+				`${modelName} via ${providerLabel(providerId)} supports up to ${max} upstream ${kindLabel(kind)} file${max === 1 ? '' : 's'}.`,
+			)
+		}
+	}
+}

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -2,6 +2,7 @@
 import { Notice, App } from 'obsidian'
 import type { ModelConfig, GenerationType, Mode, VoiceSourceMode } from './models/types'
 import { getEnabledModels, getActiveProvider } from './models/index'
+import { getTextInputCapability, textInputKindSupported } from './models/text-input-capabilities'
 import { getConfiguredProviderIds } from './providers/registry'
 import { getUpstreamInputs } from './edge-parser'
 import { getOrderedAudios } from './audio-refs'
@@ -278,6 +279,8 @@ export function showGenerateBar(
 
 	let upstreamImageCount = 0
 	let upstreamVideoCount = 0
+	let upstreamPdfCount = 0
+	let upstreamAudioCount = 0
 	let orderedAudios: string[] = []
 	let orderedTextRefCount = 0
 	const canvas = node.canvas
@@ -285,6 +288,8 @@ export function showGenerateBar(
 		const upstream = getUpstreamInputs(canvas, node)
 		upstreamImageCount = [...new Set(upstream.images)].length
 		upstreamVideoCount = upstream.videos.length
+		upstreamPdfCount = upstream.pdfs.length
+		upstreamAudioCount = upstream.audios.length
 		orderedAudios = getOrderedAudios(canvas, node)
 		orderedTextRefCount = getOrderedTextRefs(canvas, node).length
 	}
@@ -696,8 +701,28 @@ export function showGenerateBar(
 	/**
 	 * Check if a model can handle the current upstream inputs.
 	 */
+	function textUpstreamIssue(m: ModelConfig): string | null {
+		if (m.type !== 'text') return null
+		const { provider, apiModelId } = resolveProvider(m, settings, configuredProviders)
+		const capability = getTextInputCapability(m.id, provider, apiModelId)
+		const checks = [
+			{ kind: 'image' as const, count: upstreamImageCount },
+			{ kind: 'pdf' as const, count: upstreamPdfCount },
+			{ kind: 'video' as const, count: upstreamVideoCount },
+			{ kind: 'audio' as const, count: upstreamAudioCount },
+		]
+		for (const { kind, count } of checks) {
+			if (count > 0 && !textInputKindSupported(capability, kind)) {
+				const label = kind === 'pdf' ? 'PDF' : kind
+				return `Upstream ${label} not supported for ${m.name} via ${provider}`
+			}
+		}
+		return null
+	}
+
 	function modelSupportsInputs(m: ModelConfig): boolean {
-		// Text and image models — always compatible for now
+		if (m.type === 'text') return textUpstreamIssue(m) === null
+		// Image models — always compatible for now
 		if (m.type !== 'video') return true
 		// No special inputs — only text-to-video models can run without refs.
 		if (upstreamImageCount === 0 && upstreamVideoCount === 0) return m.modes.includes('text-to-video')
@@ -818,6 +843,14 @@ export function showGenerateBar(
 			} else if (!voiceConfig.builtin) {
 				disabled = true
 				title = 'Choose voice ref or design.'
+			}
+		}
+
+		if (selectedModel?.type === 'text') {
+			const issue = textUpstreamIssue(selectedModel)
+			if (issue) {
+				disabled = true
+				title = issue
 			}
 		}
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -275,6 +275,10 @@ export function showGenerateBar(
 	runBtn.textContent = 'Run'
 	rightGroup.appendChild(runBtn)
 
+	const upstreamMediaHint = createSpan()
+	upstreamMediaHint.className = 'bragi-bar-upstream-hint bragi-bar-upstream-hint-hidden'
+	leftGroup.appendChild(upstreamMediaHint)
+
 	// ── Read upstream for mode inference ──
 
 	let upstreamImageCount = 0
@@ -806,9 +810,29 @@ export function showGenerateBar(
 
 	let savedParams: Record<string, unknown> | null = null
 
+	function updateUpstreamMediaHint() {
+		if (currentType !== 'text') {
+			upstreamMediaHint.textContent = ''
+			upstreamMediaHint.classList.add('bragi-bar-upstream-hint-hidden')
+			return
+		}
+		const parts: string[] = []
+		if (upstreamPdfCount > 0) parts.push(`${upstreamPdfCount} PDF`)
+		if (upstreamVideoCount > 0) parts.push(`${upstreamVideoCount} video`)
+		if (upstreamAudioCount > 0) parts.push(`${upstreamAudioCount} audio`)
+		if (parts.length === 0) {
+			upstreamMediaHint.textContent = ''
+			upstreamMediaHint.classList.add('bragi-bar-upstream-hint-hidden')
+			return
+		}
+		upstreamMediaHint.textContent = `Upstream: ${parts.join(', ')}`
+		upstreamMediaHint.classList.remove('bragi-bar-upstream-hint-hidden')
+	}
+
 	// ── Run button state ──
 
 	function updateRunState() {
+		updateUpstreamMediaHint()
 		let disabled = false
 		let title = ''
 

--- a/src/providers/dashscope-text.ts
+++ b/src/providers/dashscope-text.ts
@@ -1,0 +1,119 @@
+import { requestUrl } from 'obsidian'
+import { stringParam } from './params'
+import { uploadRef } from './upload'
+import type { TextGenProvider, TextGenResult } from './text-gen'
+
+const MULTIMODAL_URL = 'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation'
+
+const SYSTEM_PROMPT = `You are a helpful assistant on a visual canvas. Follow the user's instructions precisely.
+If the user asks you to produce multiple separate items (e.g. "split into 3 chapters", "give me 5 titles", "break this into sections"), output each item separated by a line containing only ---SPLIT--- on its own. Do NOT use ---SPLIT--- for any other purpose. If the output is a single piece of content, do not use ---SPLIT--- at all.`
+
+function parseErr(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = resp.json || (() => { try { return JSON.parse(resp.text || '') } catch { return null } })()
+	const msg = body?.message || body?.error?.message || resp.text || `HTTP ${resp.status}`
+	return typeof msg === 'string' ? msg : JSON.stringify(msg).substring(0, 240)
+}
+
+function parseDataUri(dataUri: string): { mimeType: string; data: string } | null {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+	if (!match) return null
+	return { mimeType: match[1], data: match[2] }
+}
+
+async function ensurePublicUrl(ref: string, fallbackMime: string, label: string): Promise<string> {
+	if (/^https?:\/\//i.test(ref)) return ref
+	const parsed = parseDataUri(ref)
+	if (!parsed) return ref
+	const bytes = Uint8Array.from(atob(parsed.data), c => c.charCodeAt(0))
+	const ext = label.includes('.') ? label.split('.').pop() || 'bin' : label
+	return uploadRef(undefined, bytes.buffer, `ref.${ext}`, parsed.mimeType || fallbackMime)
+}
+
+async function buildContentParts(
+	prompt: string,
+	refImages: string[],
+	refVideos: string[],
+	refAudios: string[],
+	refPdfs: string[],
+): Promise<Array<Record<string, unknown>>> {
+	const parts: Array<Record<string, unknown>> = []
+
+	for (const ref of refImages) {
+		if (/^https?:\/\//i.test(ref) || parseDataUri(ref)) {
+			parts.push({ image: ref })
+		}
+	}
+
+	for (const ref of refVideos) {
+		const url = await ensurePublicUrl(ref, 'video/mp4', 'mp4')
+		parts.push({ video: url, fps: 2 })
+	}
+
+	for (const ref of refAudios) {
+		const url = await ensurePublicUrl(ref, 'audio/mpeg', 'mp3')
+		parts.push({ audio: url })
+	}
+
+	for (const ref of refPdfs) {
+		const url = await ensurePublicUrl(ref, 'application/pdf', 'pdf')
+		parts.push({ file: url })
+	}
+
+	parts.push({ text: prompt })
+	return parts
+}
+
+export class DashScopeTextProvider implements TextGenProvider {
+	name = 'DashScope'
+	private apiKey: string
+
+	constructor(apiKey: string) {
+		this.apiKey = apiKey
+	}
+
+	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
+		const modelId = stringParam(params?.modelId, 'qwen3.6-plus')
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refVideos: string[] = Array.isArray(params?.refVideos) ? params.refVideos.filter((r): r is string => typeof r === 'string') : []
+		const refAudios: string[] = Array.isArray(params?.refAudios) ? params.refAudios.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
+
+		const content = await buildContentParts(prompt, refImages, refVideos, refAudios, refPdfs)
+
+		const response = await requestUrl({
+			url: MULTIMODAL_URL,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			throw: false,
+			body: JSON.stringify({
+				model: modelId,
+				input: {
+					messages: [
+						{ role: 'system', content: [{ text: SYSTEM_PROMPT }] },
+						{ role: 'user', content },
+					],
+				},
+			}),
+		})
+
+		if (response.status >= 400) throw new Error(`DashScope text: ${parseErr(response)}`)
+
+		const choices = response.json?.output?.choices
+		const messageContent = choices?.[0]?.message?.content
+		let text = ''
+		if (Array.isArray(messageContent)) {
+			text = messageContent
+				.map((part: unknown) => (part && typeof part === 'object' && 'text' in part ? String((part as { text?: string }).text || '') : ''))
+				.join('\n')
+				.trim()
+		} else if (typeof messageContent === 'string') {
+			text = messageContent.trim()
+		}
+
+		if (!text) throw new Error('DashScope: No text in response')
+		return { text }
+	}
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -22,7 +22,8 @@ import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProv
 import { DashScopeAudioProvider } from './dashscope'
 
 const LUMA_ENDPOINT = 'https://luma.bragi.now'
-import { OpenAITextProvider, APIMartTextProvider, GeminiTextProvider, AnthropicTextProvider, BedrockClaudeTextProvider } from './text-gen'
+import { OpenAITextProvider, APIMartTextProvider, GeminiTextProvider, AnthropicTextProvider, BedrockClaudeTextProvider, XAITextProvider } from './text-gen'
+import { DashScopeTextProvider } from './dashscope-text'
 import { requestUrl } from 'obsidian'
 
 export type ProviderKey = keyof BragiSettings['providers']
@@ -357,6 +358,8 @@ export const PROVIDERS: ProviderSpec[] = [
 		isConfigured: (s) => !!s.providers.dashscope,
 		makeAudio: ({ settings, app, outputDir }) =>
 			new DashScopeAudioProvider(settings.providers.dashscope, app, outputDir),
+		makeText: ({ settings }) =>
+			new DashScopeTextProvider(settings.providers.dashscope),
 		testConnection: async (d) => {
 			const key = d.dashscope || ''
 			if (!key) return { ok: false, message: 'API key is empty.' }
@@ -435,7 +438,7 @@ export const PROVIDERS: ProviderSpec[] = [
 		makeVideo: ({ settings, app, outputDir }) =>
 			new XAIVideoProvider(settings.providers.xai, app, outputDir),
 		makeText: ({ settings }) =>
-			new OpenAITextProvider(settings.providers.xai, 'https://api.x.ai/v1'),
+			new XAITextProvider(settings.providers.xai),
 		makeAudio: ({ settings, app, outputDir }) =>
 			new XAIAudioProvider(settings.providers.xai, app, outputDir),
 		testConnection: (d) => testListModels('https://api.x.ai/v1/models', d.xai || ''),

--- a/src/providers/text-gen.ts
+++ b/src/providers/text-gen.ts
@@ -41,8 +41,29 @@ function parseProviderError(provider: string, resp: { status: number; text?: str
 	return `${provider}: ${code ? code + ' — ' : ''}${msg}`
 }
 
-function isOpenAIResponsesModel(modelId: string): boolean {
-	return /^gpt-5\.[45]-pro(?:-|$)/.test(modelId)
+function buildResponsesInputContent(prompt: string, refImages: string[], refPdfs: string[]): unknown[] {
+	const content: unknown[] = []
+	for (const dataUri of refImages) {
+		content.push({ type: 'input_image', image_url: dataUri })
+	}
+	for (let i = 0; i < refPdfs.length; i++) {
+		const pdf = refPdfs[i]
+		if (/^https?:\/\//i.test(pdf)) {
+			content.push({ type: 'input_file', file_url: pdf })
+		} else {
+			content.push({
+				type: 'input_file',
+				filename: `document-${i + 1}.pdf`,
+				file_data: pdf,
+			})
+		}
+	}
+	content.push({ type: 'input_text', text: prompt })
+	return content
+}
+
+function shouldUseOpenAIResponses(modelId: string, refImages: string[], refPdfs: string[]): boolean {
+	return refImages.length > 0 || refPdfs.length > 0 || /^gpt-5/.test(modelId)
 }
 
 function videoMimeTypeFromRef(ref: string): string {
@@ -156,20 +177,20 @@ export class OpenAITextProvider implements TextGenProvider {
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = stringParam(params?.modelId, 'gpt-5.5')
-		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
 
-		if (isOpenAIResponsesModel(modelId)) return this.generateViaResponses(modelId, prompt, refImages)
+		if (shouldUseOpenAIResponses(modelId, refImages, refPdfs)) {
+			return this.generateViaResponses(modelId, prompt, refImages, refPdfs)
+		}
 
-		// Build messages with optional images
 		const content: unknown[] = []
-
 		for (const dataUri of refImages) {
 			content.push({
 				type: 'image_url',
 				image_url: { url: dataUri },
 			})
 		}
-
 		content.push({ type: 'text', text: prompt })
 
 		const response = await requestUrl({
@@ -197,12 +218,8 @@ export class OpenAITextProvider implements TextGenProvider {
 		return { text }
 	}
 
-	private async generateViaResponses(modelId: string, prompt: string, refImages: string[]): Promise<TextGenResult> {
-		const content: unknown[] = []
-		for (const dataUri of refImages) {
-			content.push({ type: 'input_image', image_url: dataUri })
-		}
-		content.push({ type: 'input_text', text: prompt })
+	private async generateViaResponses(modelId: string, prompt: string, refImages: string[], refPdfs: string[]): Promise<TextGenResult> {
+		const content = buildResponsesInputContent(prompt, refImages, refPdfs)
 
 		const response = await requestUrl({
 			url: `${this.baseUrl}/responses`,
@@ -242,9 +259,12 @@ export class APIMartTextProvider implements TextGenProvider {
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = stringParam(params?.modelId, 'gpt-5.5')
-		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
 
-		if (refImages.length > 0) return this.generateViaResponses(modelId, prompt, refImages)
+		if (refImages.length > 0 || refPdfs.length > 0) {
+			return this.generateViaResponses(modelId, prompt, refImages, refPdfs)
+		}
 
 		return this.generateViaChat(modelId, prompt)
 	}
@@ -285,11 +305,23 @@ export class APIMartTextProvider implements TextGenProvider {
 		return { text }
 	}
 
-	private async generateViaResponses(modelId: string, prompt: string, refImages: string[]): Promise<TextGenResult> {
+	private async generateViaResponses(modelId: string, prompt: string, refImages: string[], refPdfs: string[]): Promise<TextGenResult> {
 		const content: unknown[] = []
 		content.push({ type: 'input_text', text: prompt })
 		for (const dataUri of refImages) {
 			content.push({ type: 'input_image', image_url: await this.ensureImageUrl(dataUri) })
+		}
+		for (let i = 0; i < refPdfs.length; i++) {
+			const pdf = refPdfs[i]
+			if (/^https?:\/\//i.test(pdf)) {
+				content.push({ type: 'input_file', file_url: pdf })
+			} else {
+				content.push({
+					type: 'input_file',
+					filename: `document-${i + 1}.pdf`,
+					file_data: pdf,
+				})
+			}
 		}
 
 		const response = await requestUrl({
@@ -415,8 +447,17 @@ export class GeminiTextProvider implements TextGenProvider {
 /**
  * Build Anthropic Messages API content blocks from prompt + optional images.
  */
-function buildAnthropicContent(prompt: string, refImages: string[]): unknown[] {
+function buildAnthropicContent(prompt: string, refImages: string[], refPdfs: string[]): unknown[] {
 	const content: unknown[] = []
+	for (const dataUri of refPdfs) {
+		const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+		if (match) {
+			content.push({
+				type: 'document',
+				source: { type: 'base64', media_type: match[1], data: match[2] },
+			})
+		}
+	}
 	for (const dataUri of refImages) {
 		const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
 		if (match) {
@@ -449,7 +490,8 @@ export class AnthropicTextProvider implements TextGenProvider {
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const modelId = params?.modelId || 'claude-sonnet-4-6'
-		const refImages: string[] = params?.refImages || []
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
 
 		const response = await requestUrl({
 			url: 'https://api.anthropic.com/v1/messages',
@@ -463,7 +505,7 @@ export class AnthropicTextProvider implements TextGenProvider {
 				model: modelId,
 				max_tokens: 4096,
 				system: SYSTEM_PROMPT,
-				messages: [{ role: 'user', content: buildAnthropicContent(prompt, refImages) }],
+				messages: [{ role: 'user', content: buildAnthropicContent(prompt, refImages, refPdfs) }],
 			}),
 		})
 
@@ -492,14 +534,15 @@ export class BedrockClaudeTextProvider implements TextGenProvider {
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
 		const bedrockModelId = params?.modelId
 		if (!bedrockModelId) throw new Error('Bedrock: missing modelId')
-		const refImages: string[] = params?.refImages || []
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
 
 		const url = `https://bedrock-runtime.${this.region}.amazonaws.com/model/${encodeURIComponent(bedrockModelId)}/invoke`
 		const body = JSON.stringify({
 			anthropic_version: 'bedrock-2023-05-31',
 			max_tokens: 4096,
 			system: SYSTEM_PROMPT,
-			messages: [{ role: 'user', content: buildAnthropicContent(prompt, refImages) }],
+			messages: [{ role: 'user', content: buildAnthropicContent(prompt, refImages, refPdfs) }],
 		})
 
 		const headers = await signRequest({
@@ -524,6 +567,48 @@ export class BedrockClaudeTextProvider implements TextGenProvider {
 		const text = parseAnthropicText(response.json)
 		if (!text) throw new Error('Bedrock Claude: No text in response')
 
+		return { text }
+	}
+}
+
+/**
+ * xAI Grok text generation via Responses API (images + PDFs).
+ */
+export class XAITextProvider implements TextGenProvider {
+	name = 'xAI'
+	private apiKey: string
+	private baseUrl: string
+
+	constructor(apiKey: string, baseUrl: string = 'https://api.x.ai/v1') {
+		this.apiKey = apiKey
+		this.baseUrl = baseUrl.replace(/\/$/, '')
+	}
+
+	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
+		const modelId = stringParam(params?.modelId, 'grok-4-3')
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const refPdfs: string[] = Array.isArray(params?.refPdfs) ? params.refPdfs.filter((r): r is string => typeof r === 'string') : []
+		const content = buildResponsesInputContent(prompt, refImages, refPdfs)
+
+		const response = await requestUrl({
+			url: `${this.baseUrl}/responses`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			throw: false,
+			body: JSON.stringify({
+				model: modelId,
+				instructions: SYSTEM_PROMPT,
+				input: [{ role: 'user', content }],
+				max_output_tokens: 4096,
+			}),
+		})
+
+		if (response.status >= 400) throw new Error(parseProviderError('xAI responses', response))
+		const text = extractOpenAIResponsesText(response.json)
+		if (!text) throw new Error('Grok: No text in response')
 		return { text }
 	}
 }

--- a/src/providers/text-gen.ts
+++ b/src/providers/text-gen.ts
@@ -73,6 +73,14 @@ function videoMimeTypeFromRef(ref: string): string {
 	return 'video/mp4'
 }
 
+function imageMimeTypeFromRef(ref: string): string {
+	const path = ref.split(/[?#]/)[0].toLowerCase()
+	if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg'
+	if (path.endsWith('.webp')) return 'image/webp'
+	if (path.endsWith('.gif')) return 'image/gif'
+	return 'image/png'
+}
+
 function audioMimeTypeFromRef(ref: string): string {
 	const path = ref.split(/[?#]/)[0].toLowerCase()
 	if (path.endsWith('.wav')) return 'audio/wav'
@@ -382,12 +390,15 @@ export class GeminiTextProvider implements TextGenProvider {
 		// Build parts: media first, then text
 		const parts: unknown[] = []
 
-		for (const dataUri of refImages) {
-			const parsed = parseDataUri(dataUri)
+		for (const ref of refImages) {
+			const parsed = parseDataUri(ref)
 			if (parsed) {
 				parts.push({
 					inlineData: { mimeType: parsed.mimeType, data: parsed.data },
 				})
+			} else {
+				const file = await this.fileDataPart(ref, imageMimeTypeFromRef(ref), 'image')
+				parts.push({ fileData: file })
 			}
 		}
 		for (const ref of refVideos) {

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -93,6 +93,12 @@ function videoExtFromUrl(url: string): string {
 	return 'mp4'
 }
 
+function fileExtFromUrl(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	const match = clean.match(/\.([a-z0-9]+)$/)
+	return match?.[1] || 'bin'
+}
+
 function pushUnique(target: string[], value: string): void {
 	const text = value.trim()
 	if (text && !target.includes(text)) target.push(text)
@@ -327,18 +333,27 @@ export class TokenRouterTextProvider implements TextGenProvider {
 
 	private fileContentPart(ref: string, basename: string): unknown {
 		const decoded = dataUriToBytes(ref)
-		if (!decoded) {
+		if (decoded) {
 			return {
 				type: 'file',
-				file: { file_id: ref, filename: basename },
+				file: {
+					filename: `${basename}.${decoded.ext}`,
+					file_data: ref,
+				},
+			}
+		}
+		if (isHttpUrl(ref)) {
+			return {
+				type: 'file',
+				file: {
+					filename: `${basename}.${fileExtFromUrl(ref)}`,
+					file_data: ref,
+				},
 			}
 		}
 		return {
 			type: 'file',
-			file: {
-				filename: `${basename}.${decoded.ext}`,
-				file_data: ref,
-			},
+			file: { file_id: ref, filename: basename },
 		}
 	}
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -814,6 +814,16 @@
 	gap: 6px;
 }
 
+.bragi-bar-upstream-hint {
+	font-size: 11px;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.bragi-bar-upstream-hint-hidden {
+	display: none;
+}
+
 /* Right group: params + batch + run */
 .bragi-bar-right {
 	display: flex;

--- a/src/text-input-prep.ts
+++ b/src/text-input-prep.ts
@@ -1,0 +1,147 @@
+import type { App } from 'obsidian'
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+import type { UpstreamInputs } from './edge-parser'
+import { getOrderedImages } from './ref-thumbnails'
+import { uploadRef } from './providers/upload'
+import { getTextInputCapability, textInputKindSupported } from './models/text-input-capabilities'
+
+const GEMINI_INLINE_MAX_BYTES = 15 * 1024 * 1024
+const ANTHROPIC_PDF_MAX_BYTES = 32 * 1024 * 1024
+
+export interface PreparedTextInputs {
+	refImages: string[]
+	refPdfs: string[]
+	refVideos: string[]
+	refAudios: string[]
+}
+
+interface PrepContext {
+	app: App
+	modelId: string
+	providerId: string
+	apiModelId?: string
+}
+
+function getFileExtension(filePath: string, fallback: string): string {
+	return filePath.split('.').pop()?.toLowerCase() || fallback
+}
+
+function audioMimeType(filePath: string): string {
+	const ext = getFileExtension(filePath, 'mp3')
+	if (ext === 'wav') return 'audio/wav'
+	if (ext === 'm4a' || ext === 'mp4') return 'audio/mp4'
+	if (ext === 'aac') return 'audio/aac'
+	if (ext === 'flac') return 'audio/flac'
+	if (ext === 'ogg') return 'audio/ogg'
+	if (ext === 'opus') return 'audio/opus'
+	return 'audio/mpeg'
+}
+
+function videoMimeType(filePath: string): string {
+	const ext = getFileExtension(filePath, 'mp4')
+	if (ext === 'mov') return 'video/quicktime'
+	if (ext === 'webm') return 'video/webm'
+	return 'video/mp4'
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer)
+	let binary = ''
+	for (let i = 0; i < bytes.length; i++) {
+		binary += String.fromCharCode(bytes[i])
+	}
+	return btoa(binary)
+}
+
+async function readVaultFileAsDataUri(app: App, filePath: string, mimeType: string): Promise<string> {
+	const binary = await app.vault.adapter.readBinary(filePath)
+	return `data:${mimeType};base64,${arrayBufferToBase64(binary)}`
+}
+
+async function readVaultFileSize(app: App, filePath: string): Promise<number> {
+	const stat = await app.vault.adapter.stat(filePath)
+	return stat?.size || 0
+}
+
+function shouldUploadForProvider(providerId: string, byteSize: number): boolean {
+	if (providerId === 'gemini' || providerId === 'dashscope') {
+		return byteSize > GEMINI_INLINE_MAX_BYTES
+	}
+	if (providerId === 'tokenrouter') {
+		return byteSize > GEMINI_INLINE_MAX_BYTES
+	}
+	return false
+}
+
+async function prepareMediaRef(
+	ctx: PrepContext,
+	filePath: string,
+	mimeType: string,
+	label: string,
+): Promise<string> {
+	const byteSize = await readVaultFileSize(ctx.app, filePath)
+	if (ctx.providerId === 'anthropic' || ctx.providerId === 'bedrock') {
+		if (mimeType === 'application/pdf' && byteSize > ANTHROPIC_PDF_MAX_BYTES) {
+			throw new Error('PDF is too large for Claude (max 32 MB per request). Split the document and try again.')
+		}
+	}
+
+	if (shouldUploadForProvider(ctx.providerId, byteSize)) {
+		const binary = await ctx.app.vault.adapter.readBinary(filePath)
+		const ext = getFileExtension(filePath, label)
+		return uploadRef(undefined, binary, `ref.${ext}`, mimeType)
+	}
+
+	return readVaultFileAsDataUri(ctx.app, filePath, mimeType)
+}
+
+export async function prepareTextInputs(
+	app: App,
+	canvas: Canvas,
+	node: CanvasNode,
+	modelId: string,
+	providerId: string,
+	upstream: UpstreamInputs,
+	apiModelId?: string,
+): Promise<PreparedTextInputs> {
+	const capability = getTextInputCapability(modelId, providerId, apiModelId)
+	const ctx: PrepContext = { app, modelId, providerId, apiModelId }
+
+	const refImages: string[] = []
+	if (textInputKindSupported(capability, 'image')) {
+		const imagePaths = getOrderedImages(canvas, node)
+		for (const imgPath of imagePaths) {
+			const ext = getFileExtension(imgPath, 'png')
+			const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : `image/${ext}`
+			if (shouldUploadForProvider(providerId, await readVaultFileSize(app, imgPath))) {
+				const binary = await app.vault.adapter.readBinary(imgPath)
+				refImages.push(await uploadRef(undefined, binary, `ref.${ext}`, mime))
+			} else {
+				refImages.push(await readVaultFileAsDataUri(app, imgPath, mime))
+			}
+		}
+	}
+
+	const refPdfs: string[] = []
+	if (textInputKindSupported(capability, 'pdf')) {
+		for (const pdfPath of [...new Set(upstream.pdfs)]) {
+			refPdfs.push(await prepareMediaRef(ctx, pdfPath, 'application/pdf', 'pdf'))
+		}
+	}
+
+	const refVideos: string[] = []
+	if (textInputKindSupported(capability, 'video')) {
+		for (const videoPath of [...new Set(upstream.videos)]) {
+			refVideos.push(await prepareMediaRef(ctx, videoPath, videoMimeType(videoPath), 'mp4'))
+		}
+	}
+
+	const refAudios: string[] = []
+	if (textInputKindSupported(capability, 'audio')) {
+		for (const audioPath of [...new Set(upstream.audios)]) {
+			refAudios.push(await prepareMediaRef(ctx, audioPath, audioMimeType(audioPath), 'mp3'))
+		}
+	}
+
+	return { refImages, refPdfs, refVideos, refAudios }
+}

--- a/styles.css
+++ b/styles.css
@@ -814,6 +814,16 @@
 	gap: 6px;
 }
 
+.bragi-bar-upstream-hint {
+	font-size: 11px;
+	color: var(--text-muted);
+	white-space: nowrap;
+}
+
+.bragi-bar-upstream-hint-hidden {
+	display: none;
+}
+
 /* Right group: params + batch + run */
 .bragi-bar-right {
 	display: flex;


### PR DESCRIPTION
## Summary
- add provider capability matrix for text model upstream media
- prepare image, PDF, video, and audio refs per active provider
- expose text supportedInputs/unsupportedInputs via MCP list_models
- preserve uploaded Gemini and TokenRouter file refs

## Verification
- npm run test:text-multimodal
- npm run build
- npx eslint src/main.ts src/mcp-tool-registry.ts src/models/text-gen.ts src/models/text-input-capabilities.ts src/panel.ts src/providers/dashscope-text.ts src/providers/registry.ts src/providers/text-gen.ts src/providers/tokenrouter.ts src/text-input-prep.ts