### PR TITLE
Fix audio nodes and error details modal

### DIFF
--- a/src/media-node-hover.ts
+++ b/src/media-node-hover.ts
@@ -242,7 +242,11 @@ async function syncMediaNode(node: CanvasNode): Promise<void> {
 	}
 
 	nodeEl.classList.add(MEDIA_NODE_CLASS)
-	node.containerEl?.classList.add(MEDIA_CONTAINER_CLASS)
+	if (kind === 'image' || kind === 'video') {
+		node.containerEl?.classList.add(MEDIA_CONTAINER_CLASS)
+	} else {
+		node.containerEl?.classList.remove(MEDIA_CONTAINER_CLASS)
+	}
 
 	const extLabel = formatExtensionLabel(filePath)
 	const labelEl = getLabelEl(node as MediaNodeInternals)

--- a/src/styles.css
+++ b/src/styles.css
@@ -2215,9 +2215,6 @@
 }
 
 .bragi-error-details-body {
-	display: block;
-	width: 100%;
-	min-height: 160px;
 	margin: 0;
 	padding: 12px;
 	border-radius: 8px;
@@ -2230,8 +2227,6 @@
 	word-break: break-word;
 	max-height: min(50vh, 360px);
 	overflow: auto;
-	resize: vertical;
-	user-select: text;
 }
 
 .bragi-modal input:focus,

--- a/src/ui/error-details-modal.ts
+++ b/src/ui/error-details-modal.ts
@@ -17,17 +17,11 @@ export class ErrorDetailsModal extends Modal {
 		modalEl.classList.add('bragi-modal')
 		titleEl.setText('Error details')
 
-		const body = contentEl.createEl('textarea', { cls: 'bragi-error-details-body' })
-		body.value = this.errorMessage
-		body.readOnly = true
+		const body = contentEl.createEl('pre', { cls: 'bragi-error-details-body' })
+		body.textContent = this.errorMessage
 
 		const row = contentEl.createDiv({ cls: 'modal-button-container' })
-		const selectBtn = row.createEl('button', { text: 'Select all', cls: 'mod-cta' })
-		const closeBtn = row.createEl('button', { text: 'Close' })
-		selectBtn.addEventListener('click', () => {
-			body.focus()
-			body.select()
-		})
+		const closeBtn = row.createEl('button', { text: 'Close', cls: 'mod-cta' })
 		closeBtn.addEventListener('click', () => this.close())
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -2215,9 +2215,6 @@
 }
 
 .bragi-error-details-body {
-	display: block;
-	width: 100%;
-	min-height: 160px;
 	margin: 0;
 	padding: 12px;
 	border-radius: 8px;
@@ -2230,8 +2227,6 @@
 	word-break: break-word;
 	max-height: min(50vh, 360px);
 	overflow: auto;
-	resize: vertical;
-	user-select: text;
 }
 
 .bragi-modal input:focus,


### PR DESCRIPTION
## Summary
- restore Error details to a plain pre block with only a Close button
- keep image/video edge-to-edge media styling scoped away from audio nodes

## Tests
- npm run lint:obsidian
- npm run build
- static scan for clipboard API, dynamic code execution, vault enumeration, :has(), and !important