### PR TITLE
Fix OpenAI GPT Image 2 sizing

### DIFF
--- a/src/models/gpt-image.ts
+++ b/src/models/gpt-image.ts
@@ -1,16 +1,22 @@
 import type { ModelConfig } from './types'
 
 const GPT_IMAGE_RATIOS = [
+	{ label: 'Auto', value: 'auto' },
 	{ label: '1:1', value: '1:1' },
-	{ label: '16:9', value: '16:9' },
-	{ label: '9:16', value: '9:16' },
 	{ label: '3:2', value: '3:2' },
 	{ label: '2:3', value: '2:3' },
 	{ label: '4:3', value: '4:3' },
 	{ label: '3:4', value: '3:4' },
-	{ label: '4:5', value: '4:5' },
 	{ label: '5:4', value: '5:4' },
+	{ label: '4:5', value: '4:5' },
+	{ label: '16:9', value: '16:9' },
+	{ label: '9:16', value: '9:16' },
+	{ label: '2:1', value: '2:1' },
+	{ label: '1:2', value: '1:2' },
+	{ label: '3:1', value: '3:1' },
+	{ label: '1:3', value: '1:3' },
 	{ label: '21:9', value: '21:9' },
+	{ label: '9:21', value: '9:21' },
 ]
 
 export const gptImage: ModelConfig = {

--- a/src/providers/openai-image-size.ts
+++ b/src/providers/openai-image-size.ts
@@ -1,0 +1,33 @@
+import { optionalStringParam, stringParam } from './params'
+
+const SIZE_BY_RATIO_AND_TIER: Record<string, Record<string, string>> = {
+	'1:1': { '1K': '1024x1024', '2K': '2048x2048', '4K': '2880x2880' },
+	'3:2': { '1K': '1536x1024', '2K': '2048x1360', '4K': '3520x2336' },
+	'2:3': { '1K': '1024x1536', '2K': '1360x2048', '4K': '2336x3520' },
+	'4:3': { '1K': '1024x768', '2K': '2048x1536', '4K': '3312x2480' },
+	'3:4': { '1K': '768x1024', '2K': '1536x2048', '4K': '2480x3312' },
+	'5:4': { '1K': '1280x1024', '2K': '2560x2048', '4K': '3216x2576' },
+	'4:5': { '1K': '1024x1280', '2K': '2048x2560', '4K': '2576x3216' },
+	'16:9': { '1K': '1536x864', '2K': '2048x1152', '4K': '3840x2160' },
+	'9:16': { '1K': '864x1536', '2K': '1152x2048', '4K': '2160x3840' },
+	'2:1': { '1K': '2048x1024', '2K': '2688x1344', '4K': '3840x1920' },
+	'1:2': { '1K': '1024x2048', '2K': '1344x2688', '4K': '1920x3840' },
+	'3:1': { '1K': '1536x512', '2K': '3072x1024', '4K': '3840x1280' },
+	'1:3': { '1K': '512x1536', '2K': '1024x3072', '4K': '1280x3840' },
+	'21:9': { '1K': '2016x864', '2K': '2688x1152', '4K': '3840x1648' },
+	'9:21': { '1K': '864x2016', '2K': '1152x2688', '4K': '1648x3840' },
+}
+
+export function resolveOpenAIImageSize(params?: Record<string, unknown>): string {
+	const explicitSize = optionalStringParam(params?.size)
+	if (explicitSize) return explicitSize
+
+	const aspectRatio = stringParam(params?.aspectRatio, '1:1')
+	if (aspectRatio.toLowerCase() === 'auto') return 'auto'
+
+	const imageSize = stringParam(params?.imageSize, '2K')
+	if (imageSize.toLowerCase() === 'auto') return 'auto'
+
+	const tier = imageSize.toUpperCase()
+	return SIZE_BY_RATIO_AND_TIER[aspectRatio]?.[tier] || SIZE_BY_RATIO_AND_TIER['1:1']['2K']
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -2,18 +2,8 @@
 import type { ImageProvider, GenerateImageResult } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-
-// GPT Image 2 only accepts a fixed set of sizes: 1024x1024, 1024x1536, 1536x1024, auto.
-// Sending anything else gets silently coerced by the API (we used to compute arbitrary
-// sizes like 2736x1536 which came back as portrait 1024x1536 regardless of aspect ratio).
-function resolveSize(aspectRatio: string): string {
-	const parts = aspectRatio.split(':').map(Number)
-	if (parts.length !== 2 || !parts[0] || !parts[1]) return '1024x1024'
-	const ratio = parts[0] / parts[1]
-	if (ratio > 1.15) return '1536x1024'   // landscape
-	if (ratio < 0.87) return '1024x1536'   // portrait
-	return '1024x1024'                     // square
-}
+import { resolveOpenAIImageSize } from './openai-image-size'
+import { stringParam } from './params'
 
 export class OpenAIProvider implements ImageProvider {
 	name = 'GPT Image'
@@ -30,18 +20,10 @@ export class OpenAIProvider implements ImageProvider {
 	}
 
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
-		const modelId = params?.modelId || 'gpt-image-2'
-		const refImages: string[] = params?.refImages || []
-		const quality = params?.quality || 'auto'
-
-		let size: string
-		if (params?.size) {
-			size = params.size
-		} else if (params?.imageSize === 'auto') {
-			size = 'auto'
-		} else {
-			size = resolveSize(params?.aspectRatio || '1:1')
-		}
+		const modelId = stringParam(params?.modelId, 'gpt-image-2')
+		const refImages = Array.isArray(params?.refImages) ? params.refImages.filter((r): r is string => typeof r === 'string') : []
+		const quality = stringParam(params?.quality, 'auto')
+		const size = resolveOpenAIImageSize(params)
 
 		let b64: string
 		if (refImages.length > 0) {

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -4,6 +4,7 @@ import { requestUrl } from 'obsidian'
 import type { GenerateImageResult, GenerateVideoResult, ImageProvider, VideoProvider } from './types'
 import type { TextGenProvider, TextGenResult } from './text-gen'
 import { uploadRef } from './upload'
+import { resolveOpenAIImageSize } from './openai-image-size'
 
 const DEFAULT_BASE_URL = 'https://api.tokenrouter.com/v1'
 const IMAGE_GENERATION_MODELS = new Set([
@@ -231,15 +232,6 @@ function isSeedanceModel(modelId: string): boolean {
 	return modelId.includes('seedance')
 }
 
-function imageSizeFromAspectRatio(aspectRatio: string): string {
-	const parts = aspectRatio.split(':').map(Number)
-	if (parts.length !== 2 || !parts[0] || !parts[1]) return '1024x1024'
-	const ratio = parts[0] / parts[1]
-	if (ratio > 1.15) return '1536x1024'
-	if (ratio < 0.87) return '1024x1536'
-	return '1024x1024'
-}
-
 function appendMultipartField(parts: Uint8Array[], boundary: string, name: string, value: string): void {
 	const enc = new TextEncoder()
 	parts.push(enc.encode(`--${boundary}\r\n`))
@@ -387,8 +379,7 @@ export class TokenRouterImageProvider implements ImageProvider {
 	private async generateViaImagesApi(modelId: string, prompt: string, params: Record<string, unknown>, refImages: string[]): Promise<string[]> {
 		if (refImages.length > 0) return this.editWithRefs(modelId, prompt, params, refImages)
 
-		const imageSize = stringParam(params.imageSize, 'auto')
-		const size = imageSize === 'auto' ? 'auto' : imageSizeFromAspectRatio(stringParam(params.aspectRatio, '1:1'))
+		const size = resolveOpenAIImageSize(params)
 		const quality = stringParam(params.quality, 'auto')
 
 		const resp = await requestUrl({
@@ -411,7 +402,7 @@ export class TokenRouterImageProvider implements ImageProvider {
 		const parts: Uint8Array[] = []
 		appendMultipartField(parts, boundary, 'model', modelId)
 		appendMultipartField(parts, boundary, 'prompt', prompt)
-		appendMultipartField(parts, boundary, 'size', imageSizeFromAspectRatio(stringParam(params.aspectRatio, '1:1')))
+		appendMultipartField(parts, boundary, 'size', resolveOpenAIImageSize(params))
 		appendMultipartField(parts, boundary, 'quality', stringParam(params.quality, 'auto'))
 		appendMultipartField(parts, boundary, 'n', '1')
 


### PR DESCRIPTION
## Summary
- expose the full GPT Image 2 aspect ratio set, including Auto and APIMart-supported wide/tall ratios
- map OpenAI official GPT Image 2 imageSize + aspectRatio choices to concrete pixel sizes instead of the old 1024/1536-only buckets
- reuse the same mapping for TokenRouter's OpenAI image route

Paired skill PR: nextbound/bragi-canvas-skill#7

## Verification
- npm run build
- npm run lint:obsidian