### PR TITLE
feat: add TokenRouter Seedance asset flow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import { checkMigration } from './migrate-assets'
 import { migrateProviderPrefs } from './migrate-providers'
 import { startAttachmentRedirect } from './attachment-redirect'
 import { ensureBytePlusAsset, getBytePlusAssetCreds } from './byteplus-asset-flow'
+import { ensureTokenRouterModelArkAsset, getTokenRouterModelArkCreds } from './tokenrouter-asset-flow'
 import { splitImageNodeIntoTiles } from './grid-split-flow'
 import { isSupportedLanguage, LanguageGateModal } from './ui/language-gate'
 import { installAlwaysNewTab } from './always-new-tab'
@@ -31,6 +32,14 @@ import type { Canvas, CanvasNode } from './types/canvas-internal'
 import type { VoiceSourceMode } from './models/types'
 import { validateTextInputs } from './models/text-input-capabilities'
 import { prepareTextInputs } from './text-input-prep'
+
+type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
+
+const SEEDANCE_ASSET_PROVIDER_LABELS: Record<SeedanceAssetProviderId, string> = {
+	tokenrouter: 'TokenRouter',
+	byteplus: 'BytePlus',
+	bytedance: 'Volcengine',
+}
 
 export default class BragiCanvas extends Plugin {
 	settings: BragiSettings = DEFAULT_SETTINGS
@@ -79,12 +88,13 @@ export default class BragiCanvas extends Plugin {
 			this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNode) => {
 				const nodeData = node.getData()
 				if (nodeData.type !== 'file') return
-				const filePath = (nodeData as unknown).file || ''
-				if (!/\.(png|jpg|jpeg|webp|gif)$/i.test(filePath)) return
+				const filePath = (nodeData as { file?: string }).file || ''
+				if (!/\.(png|jpg|jpeg|webp|bmp|tiff?|gif|heic|heif)$/i.test(filePath)) return
 
-				const currentId = (nodeData as unknown).bragiAssetId || ''
+				const assetIds = this.getNodeAssetIdMap(node)
+				const scopedCount = Object.keys(assetIds).length
 				menu.addItem((item) => {
-					item.setTitle(currentId ? `Asset ID: ${currentId}` : 'Set Asset ID')
+					item.setTitle(scopedCount ? `Seedance asset IDs: ${scopedCount}` : 'Set Seedance asset ID')
 						.setIcon('link')
 						.onClick(() => this.showAssetIdModal(node))
 				})
@@ -451,14 +461,18 @@ export default class BragiCanvas extends Plugin {
 				refAudios = prepared.refAudios
 				refPdfs = prepared.refPdfs
 			} else {
-			// Only native Volcengine / BytePlus Seedance can consume asset:// IDs.
+			// Seedance can consume provider-specific asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const supportsSeedanceRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
-			const assetIdMap = isNativeSeedance ? getAssetIds(canvas, node) : {}
+			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
+			const assetIdMap = supportsSeedanceRefs ? getAssetIds(canvas, node, activeProvider) : {}
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
-			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && (uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0))
+			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && hasSeedanceMediaRefs)
 				? getBytePlusAssetCreds(this)
+				: null
+			const tokenRouterModelArkCreds = (activeProvider === 'tokenrouter' && isSeedanceModel && hasSeedanceMediaRefs)
+				? getTokenRouterModelArkCreds(this)
 				: null
 			for (const imgPath of uniqueImages) {
 				if (assetIdMap[imgPath]) {
@@ -466,6 +480,8 @@ export default class BragiCanvas extends Plugin {
 				} else if (bytePlusCreds) {
 					// Run through BytePlus asset library so faces can be reviewed+approved
 					refImages.push(await ensureBytePlusAsset(this, canvas, imgPath, bytePlusCreds))
+				} else if (tokenRouterModelArkCreds) {
+					refImages.push(await ensureTokenRouterModelArkAsset(this, canvas, imgPath, tokenRouterModelArkCreds))
 				} else {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const base64 = arrayBufferToBase64(binary)
@@ -484,6 +500,8 @@ export default class BragiCanvas extends Plugin {
 					if (bytePlusCreds) {
 						// Route audio through asset library for content review
 						refAudios.push(await ensureBytePlusAsset(this, canvas, audioPath, bytePlusCreds))
+					} else if (tokenRouterModelArkCreds) {
+						refAudios.push(await ensureTokenRouterModelArkAsset(this, canvas, audioPath, tokenRouterModelArkCreds))
 					} else {
 						const binary = await this.app.vault.adapter.readBinary(audioPath)
 						const ext = audioPath.split('.').pop()?.toLowerCase() || 'mp3'
@@ -511,6 +529,8 @@ export default class BragiCanvas extends Plugin {
 					for (const videoPath of uniqueVideos) {
 						if (isNativeSeedance && bytePlusCreds) {
 							refVideos.push(await ensureBytePlusAsset(this, canvas, videoPath, bytePlusCreds))
+						} else if (tokenRouterModelArkCreds) {
+							refVideos.push(await ensureTokenRouterModelArkAsset(this, canvas, videoPath, tokenRouterModelArkCreds))
 						} else {
 							const binary = await this.app.vault.adapter.readBinary(videoPath)
 							const ext = getFileExtension(videoPath, 'mp4')
@@ -802,19 +822,74 @@ export default class BragiCanvas extends Plugin {
 		}
 	}
 
+	private getNodeAssetIdMap(node: CanvasNode): Record<string, string> {
+		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+		const ids = { ...(data.bragiAssetIds || {}) }
+		if (data.bragiAssetId && !ids.legacy) ids.legacy = data.bragiAssetId
+		return ids
+	}
+
+	private getNodeAssetId(node: CanvasNode, provider: SeedanceAssetProviderId): string {
+		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+		const scoped = data.bragiAssetIds?.[provider]
+		if (scoped) return scoped
+		if ((provider === 'bytedance' || provider === 'byteplus') && data.bragiAssetId) return data.bragiAssetId
+		return ''
+	}
+
+	private setNodeAssetId(node: CanvasNode, provider: SeedanceAssetProviderId, assetId: string): void {
+		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+		const hadScopedId = !!data.bragiAssetIds?.[provider]
+		const ids = { ...(data.bragiAssetIds || {}) }
+		if (assetId) ids[provider] = assetId
+		else delete ids[provider]
+
+		const next: typeof data = { ...data }
+		if (Object.keys(ids).length > 0) next.bragiAssetIds = ids
+		else delete next.bragiAssetIds
+		if (!assetId && !hadScopedId && (provider === 'bytedance' || provider === 'byteplus')) {
+			delete next.bragiAssetId
+		}
+		node.setData(next)
+	}
+
 	showAssetIdModal(node: CanvasNode): void {
-		const data = node.getData() as unknown
-		const currentId = data.bragiAssetId || ''
+		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+		let providerId: SeedanceAssetProviderId = data.bragiAssetIds?.tokenrouter
+			? 'tokenrouter'
+			: data.bragiAssetIds?.byteplus
+				? 'byteplus'
+				: (data.bragiAssetIds?.bytedance || data.bragiAssetId)
+					? 'bytedance'
+					: 'tokenrouter'
+		let currentId = this.getNodeAssetId(node, providerId)
 
 		const modal = new Modal(this.app)
 		modal.modalEl.classList.add('bragi-modal')
-		modal.titleEl.setText('Set asset ID')
+		modal.titleEl.setText('Set seedance asset ID')
 		modal.contentEl.createEl('p', {
-			text: 'Paste a volcengine asset ID to use this image as a seedance face reference.',
+			text: 'Asset ids are provider-specific. The same image can have separate tokenrouter, byteplus, and volcengine ids.',
 			cls: 'setting-item-description',
 		})
 
 		let inputValue = currentId
+		let inputEl: HTMLInputElement | null = null
+
+		new Setting(modal.contentEl)
+			.setName('Provider')
+			.addDropdown(dropdown => {
+				for (const [value, label] of Object.entries(SEEDANCE_ASSET_PROVIDER_LABELS)) {
+					dropdown.addOption(value, label)
+				}
+				dropdown
+					.setValue(providerId)
+					.onChange(value => {
+						providerId = value as SeedanceAssetProviderId
+						currentId = this.getNodeAssetId(node, providerId)
+						inputValue = currentId
+						if (inputEl) inputEl.value = currentId
+					})
+			})
 
 		new Setting(modal.contentEl)
 			.setName('Asset ID')
@@ -822,19 +897,18 @@ export default class BragiCanvas extends Plugin {
 				text.setPlaceholder('Asset-20260401123823-6d4x2')
 					.setValue(currentId)
 					.onChange(v => { inputValue = v })
-			text.inputEl.classList.add('bragi-full-width')
-		})
+				inputEl = text.inputEl
+				text.inputEl.classList.add('bragi-full-width')
+			})
 
 		const btnContainer = modal.contentEl.createDiv({ cls: 'modal-button-container' })
 
-		if (currentId) {
-			const clearBtn = btnContainer.createEl('button', { text: 'Clear' })
-			clearBtn.addEventListener('click', () => {
-				node.setData({ ...node.getData(), bragiAssetId: undefined })
-				new Notice('Asset ID cleared')
-				modal.close()
-			})
-		}
+		const clearBtn = btnContainer.createEl('button', { text: 'Clear' })
+		clearBtn.addEventListener('click', () => {
+			this.setNodeAssetId(node, providerId, '')
+			new Notice(`${SEEDANCE_ASSET_PROVIDER_LABELS[providerId]} asset ID cleared`)
+			modal.close()
+		})
 
 		const cancelBtn = btnContainer.createEl('button', { text: 'Cancel' })
 		cancelBtn.addEventListener('click', () => modal.close())
@@ -843,10 +917,10 @@ export default class BragiCanvas extends Plugin {
 		saveBtn.addEventListener('click', () => {
 			const val = inputValue.trim()
 			if (val) {
-				node.setData({ ...node.getData(), bragiAssetId: val })
-				new Notice(`Asset ID saved`)
+				this.setNodeAssetId(node, providerId, val)
+				new Notice(`${SEEDANCE_ASSET_PROVIDER_LABELS[providerId]} asset ID saved`)
 			} else {
-				node.setData({ ...node.getData(), bragiAssetId: undefined })
+				this.setNodeAssetId(node, providerId, '')
 			}
 			modal.close()
 		})

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -27,7 +27,11 @@ export interface McpToolResult {
 type ToolArgs<Args extends ToolSchema> = z.infer<z.ZodObject<Args>>
 
 type JsonMap = Record<string, unknown>
-type BragiCanvasNodeData = AllCanvasNodeData & { bragiAssetId?: string }
+type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
+type BragiCanvasNodeData = AllCanvasNodeData & {
+	bragiAssetId?: string
+	bragiAssetIds?: Record<string, string>
+}
 type SerializableEdge = CanvasEdgeData | CanvasEdge
 type FileView = { file?: TFile }
 type EdgeStore = Map<string, CanvasEdge> | CanvasEdge[]
@@ -854,24 +858,29 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 		{
 			category: 'Files / assets',
 			name: 'set_asset_id',
-			description: 'Bind a Volcengine/BytePlus Asset ID to an image file node. Used for Seedance face-reference (asset://<id> protocol). Pass empty string to clear.',
+			description: 'Bind a provider-specific Seedance Asset ID to an image file node. Used for face-reference asset://<id> protocol. Pass empty string to clear.',
 			inputSchema: {
 				nodeId: z.string(),
+				provider: z.enum(['tokenrouter', 'byteplus', 'bytedance']).optional().describe('Asset provider namespace. Defaults to tokenrouter.'),
 				assetId: z.string().describe('Asset ID like asset-20260403175316-... or "" to clear'),
 			},
-			handler: ({ nodeId, assetId }) => {
+			handler: ({ nodeId, provider, assetId }) => {
 				const canvas = requireCanvas(getCanvas)
 				const node = findNode(canvas, nodeId)
 				const d = node.getData() as BragiCanvasNodeData
-				if (d.type !== 'file' || !/\.(png|jpg|jpeg|webp|gif)$/i.test(d.file || '')) {
+				if (d.type !== 'file' || !/\.(png|jpg|jpeg|webp|bmp|tiff?|gif|heic|heif)$/i.test(d.file || '')) {
 					throw new Error('Asset ID only applies to image file nodes')
 				}
+				const providerId = (provider || 'tokenrouter') as SeedanceAssetProviderId
 				const next = { ...d }
-				if (assetId) next.bragiAssetId = assetId
-				else delete next.bragiAssetId
+				const ids = { ...(next.bragiAssetIds || {}) }
+				if (assetId) ids[providerId] = assetId
+				else delete ids[providerId]
+				if (Object.keys(ids).length > 0) next.bragiAssetIds = ids
+				else delete next.bragiAssetIds
 				node.setData(next)
 				void canvas.requestSave()
-				return ok({ nodeId, assetId: assetId || null })
+				return ok({ nodeId, provider: providerId, assetId: assetId || null })
 			},
 		},
 

--- a/src/providers/tokenrouter-modelark-assets.ts
+++ b/src/providers/tokenrouter-modelark-assets.ts
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- TokenRouter ModelArk responses are runtime-shaped and normalized at this provider boundary. */
+import { requestUrl } from 'obsidian'
+
+const BASE_URL = 'https://api.tokenrouter.com/thirdparty/modelark'
+const POLL_INTERVAL_MS = 5000
+const POLL_TIMEOUT_MS = 300000
+
+type JsonRecord = Record<string, unknown>
+
+export interface TokenRouterModelArkCreds {
+	apiKey: string
+}
+
+export interface ModelArkAssetGetResult {
+	status: 'Active' | 'Processing' | 'Failed' | 'Rejected' | 'Unknown'
+	raw: JsonRecord
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function randomHex(n: number): string {
+	const bytes = new Uint8Array(n)
+	crypto.getRandomValues(bytes)
+	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+function makeError(message: string, status?: number): Error & { status?: number; code?: string } {
+	const err = new Error(message) as Error & { status?: number; code?: string }
+	err.status = status
+	return err
+}
+
+async function callModelArk(
+	creds: TokenRouterModelArkCreds,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+	path: string,
+	body?: unknown,
+): Promise<JsonRecord> {
+	const resp = await requestUrl({
+		url: `${BASE_URL}${path}`,
+		method,
+		headers: {
+			'Authorization': `Bearer ${creds.apiKey}`,
+			'Content-Type': 'application/json',
+		},
+		...(body === undefined ? {} : { body: JSON.stringify(body) }),
+		throw: false,
+	})
+
+	const parsed = asRecord(resp.json) || (() => {
+		try { return asRecord(JSON.parse(resp.text || '')) } catch { return null }
+	})()
+	const success = parsed?.success
+	if (resp.status < 200 || resp.status >= 300 || success === false) {
+		const msg = stringValue(parsed?.message || parsed?.error || resp.text, `HTTP ${resp.status}`)
+		throw makeError(`TokenRouter ModelArk ${method} ${path}: ${msg}`, resp.status)
+	}
+	return asRecord(parsed?.data) || parsed || {}
+}
+
+export async function createModelArkAssetGroup(creds: TokenRouterModelArkCreds): Promise<string> {
+	const result = await callModelArk(creds, 'POST', '/asset-groups', {
+		Name: `bragi_${randomHex(8)}`,
+		Description: 'Bragi Canvas',
+		GroupType: 'AIGC',
+	})
+	const groupId = stringValue(result.Id || result.id, '')
+	if (!groupId) throw new Error('TokenRouter ModelArk CreateAssetGroup: no Id in response')
+	return groupId
+}
+
+export async function createModelArkAsset(
+	creds: TokenRouterModelArkCreds,
+	groupId: string,
+	url: string,
+	assetType: 'Image' | 'Audio' | 'Video' = 'Image',
+): Promise<string> {
+	const result = await callModelArk(creds, 'POST', '/assets', {
+		GroupId: groupId,
+		URL: url,
+		AssetType: assetType,
+		Name: `bragi_${randomHex(6)}`,
+	})
+	const assetId = stringValue(result.Id || result.id, '')
+	if (!assetId) throw new Error('TokenRouter ModelArk CreateAsset: no Id in response')
+	return assetId
+}
+
+export async function getModelArkAsset(creds: TokenRouterModelArkCreds, assetId: string): Promise<ModelArkAssetGetResult> {
+	const result = await callModelArk(creds, 'GET', `/assets/${encodeURIComponent(assetId)}`)
+	const status = stringValue(result.Status || result.status || result.asset_state, 'Unknown') as ModelArkAssetGetResult['status']
+	return { status, raw: result }
+}
+
+export function isModelArkAssetNotFound(err: unknown): boolean {
+	const e = err as { message?: string; status?: number; code?: string }
+	return e.status === 404 || /NotFound|NoSuchAsset|InvalidAsset|AssetNotExist|not\s+found/i.test(e.code || e.message || '')
+}
+
+export function isModelArkGroupNotFound(err: unknown): boolean {
+	const e = err as { message?: string; status?: number; code?: string }
+	return e.status === 404 || /NotFound|NoSuchGroup|InvalidGroup|GroupNotExist|not\s+found/i.test(e.code || e.message || '')
+}
+
+export async function waitForModelArkAssetActive(creds: TokenRouterModelArkCreds, assetId: string): Promise<void> {
+	const deadline = Date.now() + POLL_TIMEOUT_MS
+	while (Date.now() < deadline) {
+		const { status, raw } = await getModelArkAsset(creds, assetId)
+		if (status === 'Active') return
+		if (status === 'Rejected') {
+			throw new Error(`TokenRouter ModelArk asset rejected. ${stringValue(raw.Error || raw.error || raw.FailedReason, '')}`.trim())
+		}
+		if (status === 'Failed') {
+			throw new Error(`TokenRouter ModelArk asset failed. ${stringValue(raw.Error || raw.error || raw.FailedReason, '')}`.trim())
+		}
+		await new Promise(r => window.setTimeout(r, POLL_INTERVAL_MS))
+	}
+	throw new Error(`TokenRouter ModelArk asset timed out after ${POLL_TIMEOUT_MS / 1000}s`)
+}
+
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- Resume strict linting after the TokenRouter ModelArk provider boundary. */

--- a/src/ref-thumbnails.ts
+++ b/src/ref-thumbnails.ts
@@ -105,12 +105,15 @@ export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App):
 
 		// Asset ID indicator — read from the source image node
 		const sourceImageNode = findImageNode(canvas, imgPath)
-		const assetId = sourceImageNode ? (sourceImageNode.getData() as unknown).bragiAssetId : null
+		const assetIds = sourceImageNode ? getNodeAssetIds(sourceImageNode) : {}
+		const assetIdCount = Object.keys(assetIds).length
 
-		if (assetId) {
+		if (assetIdCount > 0) {
 			const assetDot = createDiv()
 			assetDot.className = 'bragi-asset-dot'
-			assetDot.title = `Asset: ${assetId}`
+			assetDot.title = Object.entries(assetIds)
+				.map(([provider, id]) => `${provider}: ${id}`)
+				.join('\n')
 			wrapper.appendChild(assetDot)
 		}
 
@@ -184,17 +187,36 @@ function findImageNode(canvas: Canvas, imgPath: string): CanvasNode | null {
 	return null
 }
 
+function getNodeAssetIds(node: CanvasNode): Record<string, string> {
+	const d = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+	const ids = { ...(d.bragiAssetIds || {}) }
+	if (d.bragiAssetId && !ids.legacy) ids.legacy = d.bragiAssetId
+	return ids
+}
+
+function getProviderAssetId(node: CanvasNode, providerId?: string): string {
+	const d = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
+	if (providerId) {
+		const scoped = d.bragiAssetIds?.[providerId]
+		if (scoped) return scoped
+		if ((providerId === 'bytedance' || providerId === 'byteplus') && d.bragiAssetId) return d.bragiAssetId
+		return ''
+	}
+	return d.bragiAssetId || ''
+}
+
 /**
  * Get asset ID map for a node's upstream images.
- * Reads bragiAssetId from each source image node.
+ * Reads provider-scoped bragiAssetIds first; legacy bragiAssetId only falls
+ * back for Volcengine/BytePlus compatibility.
  */
-export function getAssetIds(canvas: Canvas, node: CanvasNode): Record<string, string> {
+export function getAssetIds(canvas: Canvas, node: CanvasNode, providerId?: string): Record<string, string> {
 	const images = getOrderedImages(canvas, node)
 	const result: Record<string, string> = {}
 	for (const imgPath of images) {
 		const imgNode = findImageNode(canvas, imgPath)
 		if (imgNode) {
-			const assetId = (imgNode.getData() as unknown).bragiAssetId
+			const assetId = getProviderAssetId(imgNode, providerId)
 			if (assetId) result[imgPath] = assetId
 		}
 	}

--- a/src/tokenrouter-asset-flow.ts
+++ b/src/tokenrouter-asset-flow.ts
@@ -1,0 +1,174 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Obsidian Canvas internals and provider payloads are runtime-shaped data that this flow narrows at use sites. */
+import type BragiCanvas from './main'
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+import { uploadRef } from './providers/upload'
+import {
+	createModelArkAsset,
+	createModelArkAssetGroup,
+	getModelArkAsset,
+	isModelArkAssetNotFound,
+	isModelArkGroupNotFound,
+	waitForModelArkAssetActive,
+} from './providers/tokenrouter-modelark-assets'
+import type { TokenRouterModelArkCreds } from './providers/tokenrouter-modelark-assets'
+
+const PROVIDER_KEY = 'tokenrouter'
+const GROUP_ID_KEY = 'tokenrouterModelArkGroupId'
+
+type TokenRouterModelArkAssetType = 'Image' | 'Audio' | 'Video'
+
+function imageExtToMime(ext: string): string {
+	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+	if (ext === 'tif' || ext === 'tiff') return 'image/tiff'
+	if (ext === 'heic') return 'image/heic'
+	if (ext === 'heif') return 'image/heif'
+	if (ext === 'bmp') return 'image/bmp'
+	if (ext === 'gif') return 'image/gif'
+	if (ext === 'webp') return 'image/webp'
+	return 'image/png'
+}
+
+function audioExtToMime(ext: string): string {
+	if (ext === 'wav') return 'audio/wav'
+	return 'audio/mpeg'
+}
+
+function videoExtToMime(ext: string): string {
+	if (ext === 'mov') return 'video/quicktime'
+	return 'video/mp4'
+}
+
+const IMAGE_EXTS = /\.(png|jpe?g|webp|bmp|tiff?|gif|heic|heif)$/i
+const AUDIO_EXTS = /\.(mp3|wav)$/i
+const VIDEO_EXTS = /\.(mp4|mov)$/i
+
+function getAssetFileInfo(filePath: string): { assetType: TokenRouterModelArkAssetType; ext: string; mime: string } {
+	const ext = (filePath.split('.').pop() || '').toLowerCase()
+	if (IMAGE_EXTS.test(filePath)) {
+		return { assetType: 'Image', ext: ext || 'png', mime: imageExtToMime(ext || 'png') }
+	}
+	if (AUDIO_EXTS.test(filePath)) {
+		return { assetType: 'Audio', ext: ext || 'mp3', mime: audioExtToMime(ext || 'mp3') }
+	}
+	if (VIDEO_EXTS.test(filePath)) {
+		return { assetType: 'Video', ext: ext || 'mp4', mime: videoExtToMime(ext || 'mp4') }
+	}
+	throw new Error(`TokenRouter ModelArk supports images, MP3/WAV audio, MP4, or MOV files only: ${filePath.split('/').pop() || filePath}`)
+}
+
+function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
+	for (const node of canvas.nodes.values()) {
+		const d = node.getData() as { type?: string; file?: string }
+		if (d.type === 'file' && d.file === filePath) return node
+	}
+	return null
+}
+
+export function getTokenRouterModelArkCreds(plugin: BragiCanvas): TokenRouterModelArkCreds | null {
+	const apiKey = (plugin.settings.providers.tokenrouter || '').trim()
+	return apiKey ? { apiKey } : null
+}
+
+async function getOrCreateGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
+	const data = canvas.getData() as { bragi?: Record<string, unknown> }
+	const existing = data.bragi?.[GROUP_ID_KEY]
+	if (typeof existing === 'string' && existing) return existing
+	const groupId = await createModelArkAssetGroup(creds)
+	const current = canvas.getData() as { bragi?: Record<string, unknown> }
+	canvas.importData({
+		...current,
+		bragi: { ...(current.bragi || {}), [GROUP_ID_KEY]: groupId },
+	} as unknown as Parameters<Canvas['importData']>[0])
+	void canvas.requestSave()
+	return groupId
+}
+
+function clearGroupId(canvas: Canvas): void {
+	const current = canvas.getData() as { bragi?: Record<string, unknown> }
+	if (!current.bragi?.[GROUP_ID_KEY]) return
+	const rest = { ...current.bragi }
+	delete rest[GROUP_ID_KEY]
+	canvas.importData({ ...current, bragi: rest } as unknown as Parameters<Canvas['importData']>[0])
+	void canvas.requestSave()
+}
+
+function getCachedAssetId(node: CanvasNode): string | null {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	return d.bragiAssetIds?.[PROVIDER_KEY] || null
+}
+
+function setCachedAssetId(node: CanvasNode, assetId: string): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	const map = { ...(d.bragiAssetIds || {}), [PROVIDER_KEY]: assetId }
+	node.setData({ ...d, bragiAssetIds: map })
+}
+
+function clearCachedAssetId(node: CanvasNode): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	if (!d.bragiAssetIds) return
+	const rest = { ...d.bragiAssetIds }
+	delete rest[PROVIDER_KEY]
+	node.setData({ ...d, bragiAssetIds: rest })
+}
+
+export async function ensureTokenRouterModelArkAsset(
+	plugin: BragiCanvas,
+	canvas: Canvas,
+	filePath: string,
+	creds: TokenRouterModelArkCreds,
+): Promise<string> {
+	const { assetType, ext, mime } = getAssetFileInfo(filePath)
+	const node = findNodeByPath(canvas, filePath)
+
+	if (node) {
+		const cached = getCachedAssetId(node)
+		if (cached) {
+			try {
+				const { status } = await getModelArkAsset(creds, cached)
+				if (status === 'Active') return `asset://${cached}`
+				if (status === 'Rejected') {
+					throw new Error(`Reference ${assetType.toLowerCase()} rejected by TokenRouter ModelArk review: ${filePath.split('/').pop()}`)
+				}
+				if (status === 'Failed') {
+					clearCachedAssetId(node)
+				} else if (status === 'Processing') {
+					await waitForModelArkAssetActive(creds, cached)
+					return `asset://${cached}`
+				} else {
+					clearCachedAssetId(node)
+				}
+			} catch (err: unknown) {
+				if (isModelArkAssetNotFound(err)) {
+					clearCachedAssetId(node)
+				} else {
+					throw err
+				}
+			}
+		}
+	}
+
+	const adapter = plugin.app.vault.adapter
+	const binary = await adapter.readBinary(filePath)
+	const url = await uploadRef(undefined, binary, `ref.${ext}`, mime)
+
+	let groupId = await getOrCreateGroupId(canvas, creds)
+	let assetId: string
+	try {
+		assetId = await createModelArkAsset(creds, groupId, url, assetType)
+	} catch (err: unknown) {
+		if (isModelArkGroupNotFound(err)) {
+			clearGroupId(canvas)
+			groupId = await getOrCreateGroupId(canvas, creds)
+			assetId = await createModelArkAsset(creds, groupId, url, assetType)
+		} else {
+			throw err
+		}
+	}
+
+	await waitForModelArkAssetActive(creds, assetId)
+	if (node) setCachedAssetId(node, assetId)
+
+	return `asset://${assetId}`
+}
+
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Resume strict linting after the TokenRouter ModelArk asset flow. */


### PR DESCRIPTION
## Summary
- add TokenRouter ModelArk asset group/asset wrappers
- route TokenRouter Seedance references through provider-scoped asset:// ids
- allow manual/MCP asset id binding per provider

## Tests
- npm run lint:obsidian
- npm run build