### PR TITLE
feat: add MiniMax voice cloning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1149,10 +1149,11 @@ function reusableVoiceRecord(
 	sourceHash: string,
 ): CustomVoiceRecord | null {
 	return getCustomVoiceRecords(node).find(record =>
-		record.provider === activeProvider
+		record.kind === 'clone'
+		&& record.provider === activeProvider
 		&& record.region === region
 		&& record.modelId === modelId
-		&& (record.kind === 'design' || record.sourceHash === sourceHash)
+		&& record.sourceHash === sourceHash
 	) || null
 }
 

--- a/src/models/audio.ts
+++ b/src/models/audio.ts
@@ -219,6 +219,7 @@ export const minimaxTTS: ModelConfig = {
 			default: '1.0',
 		},
 	],
+	voiceConfig: { builtin: true, clone: true, design: false },
 }
 
 export const dashScopeCosyVoice35Plus: ModelConfig = {

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Obsidian Canvas internals and provider payloads are runtime-shaped data that this plugin narrows at use sites. */
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceOption } from './types'
+import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceCloneOptions, VoiceCloneResult, VoiceOption } from './types'
 
 const TTS_URL = 'https://api.minimax.io/v1/t2a_v2'
 const MUSIC_URL = 'https://api.minimax.io/v1/music_generation'
 const VOICES_URL = 'https://api.minimax.io/v1/get_voice'
+const FILE_UPLOAD_URL = 'https://api.minimax.io/v1/files/upload'
+const VOICE_CLONE_URL = 'https://api.minimax.io/v1/voice_clone'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -17,6 +19,13 @@ function stringValue(value: unknown): string {
 	if (typeof value === 'string') return value
 	if (typeof value === 'number') return String(value)
 	return ''
+}
+
+function numericParam(value: unknown): number | null {
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value !== 'string' || !value.trim()) return null
+	const parsed = parseFloat(value)
+	return Number.isFinite(parsed) ? parsed : null
 }
 
 function descriptionValue(value: unknown): string | undefined {
@@ -46,6 +55,92 @@ function normalizeVoice(record: UnknownRecord, source: VoiceOption['source']): V
 		category: source === 'custom' ? 'Custom' : 'System',
 		source,
 	}
+}
+
+function safeSnippet(value: unknown): string {
+	try {
+		return JSON.stringify(value).substring(0, 200)
+	} catch {
+		return String(value).substring(0, 200)
+	}
+}
+
+function parseErr(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = typeof resp.json === 'undefined' ? resp.text : resp.json
+	if (isRecord(body)) {
+		const baseResp = body.base_resp
+		if (isRecord(baseResp) && typeof baseResp.status_msg === 'string' && baseResp.status_msg) return baseResp.status_msg
+		if (typeof body.message === 'string') return body.message
+		if (typeof body.error === 'string') return body.error
+	}
+	return typeof resp.text === 'string' && resp.text ? resp.text : `HTTP ${resp.status}: ${safeSnippet(body)}`
+}
+
+function baseRespMessage(data: unknown): string | null {
+	if (!isRecord(data)) return null
+	const baseResp = data.base_resp
+	if (!isRecord(baseResp)) return null
+	const status = baseResp.status_code
+	const ok = status === 0 || status === '0' || typeof status === 'undefined'
+	if (ok) return null
+	return stringValue(baseResp.status_msg) || stringValue(status) || 'Unknown error'
+}
+
+function appendMultipartField(parts: Uint8Array[], boundary: string, name: string, value: string): void {
+	const enc = new TextEncoder()
+	parts.push(enc.encode(`--${boundary}\r\n`))
+	parts.push(enc.encode(`Content-Disposition: form-data; name="${name}"\r\n\r\n`))
+	parts.push(enc.encode(value))
+	parts.push(enc.encode('\r\n'))
+}
+
+function appendMultipartFile(parts: Uint8Array[], boundary: string, name: string, filename: string, mime: string, bytes: Uint8Array): void {
+	const enc = new TextEncoder()
+	parts.push(enc.encode(`--${boundary}\r\n`))
+	parts.push(enc.encode(`Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\n`))
+	parts.push(enc.encode(`Content-Type: ${mime}\r\n\r\n`))
+	parts.push(bytes)
+	parts.push(enc.encode('\r\n'))
+}
+
+function concatBytes(parts: Uint8Array[]): ArrayBuffer {
+	let total = 0
+	for (const part of parts) total += part.length
+	const body = new Uint8Array(total)
+	let offset = 0
+	for (const part of parts) {
+		body.set(part, offset)
+		offset += part.length
+	}
+	return body.buffer
+}
+
+function getFileExtension(filePath: string, fallback: string): string {
+	return filePath.split('.').pop()?.toLowerCase() || fallback
+}
+
+function supportedCloneFile(filename: string): boolean {
+	return ['mp3', 'm4a', 'wav'].includes(getFileExtension(filename, 'mp3'))
+}
+
+function sanitizeVoiceId(sourceHash: string): string {
+	const clean = sourceHash.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 48)
+	const id = `Bragi_${clean || Date.now().toString(36)}`
+	return id.replace(/[-_]+$/g, '').slice(0, 256)
+}
+
+function fileIdFromUploadResponse(resp: { text?: string; json?: unknown }): string {
+	if (typeof resp.text === 'string') {
+		const match = resp.text.match(/"file_id"\s*:\s*"?(\d+)"?/)
+		if (match) return match[1]
+	}
+	const data = resp.json
+	if (isRecord(data) && isRecord(data.file)) {
+		const id = data.file.file_id
+		if (typeof id === 'string' && id.trim()) return id.trim()
+		if (typeof id === 'number' && Number.isFinite(id)) return String(Math.trunc(id))
+	}
+	return ''
 }
 
 export class MiniMaxProvider implements AudioProvider {
@@ -102,10 +197,47 @@ export class MiniMaxProvider implements AudioProvider {
 		].some(value => value?.toLowerCase().includes(query)))
 	}
 
+	async cloneVoice(options: VoiceCloneOptions): Promise<VoiceCloneResult> {
+		if (!options.audioBytes) {
+			throw new Error('MiniMax voice clone needs audio bytes from an upstream audio file.')
+		}
+		const filename = options.filename || 'voice.mp3'
+		if (!supportedCloneFile(filename)) {
+			throw new Error('MiniMax voice clone supports mp3, m4a, and wav source audio.')
+		}
+
+		const voiceId = sanitizeVoiceId(options.voiceNamePrefix || options.sourceHash)
+		const fileId = await this.uploadCloneAudio(options.audioBytes, filename, options.mimeType || 'audio/mpeg')
+		const response = await requestUrl({
+			url: VOICE_CLONE_URL,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: `{"file_id":${fileId},"voice_id":${JSON.stringify(voiceId)},"need_noise_reduction":false,"need_volume_normalization":false}`,
+			throw: false,
+		})
+
+		if (response.status === 401 || response.status === 403) throw new Error('MiniMax: invalid token')
+		if (response.status >= 400) throw new Error(`MiniMax voice clone: ${parseErr(response)}`)
+
+		const data = response.json
+		const err = baseRespMessage(data)
+		if (err) throw new Error(`MiniMax voice clone: ${err}`)
+
+		const demoAudio = isRecord(data) ? stringValue(data.demo_audio || data.preview_audio) : ''
+		return {
+			voiceId,
+			name: voiceId,
+			previewUrl: demoAudio || undefined,
+		}
+	}
+
 	async generateTTS(text: string, params?: Record<string, unknown>): Promise<{ filePath: string }> {
 		const modelId = params?.modelId || 'speech-2.8-hd'
 		const voiceId = params?.voice || 'English_Graceful_Lady'
-		const speed = parseFloat(params?.speed || '1.0')
+		const speed = numericParam(params?.speed) ?? 1.0
 
 		const response = await requestUrl({
 			url: TTS_URL,
@@ -182,6 +314,36 @@ export class MiniMaxProvider implements AudioProvider {
 		await adapter.writeBinary(filePath, audioResponse.arrayBuffer)
 
 		return { filePath }
+	}
+
+	private async uploadCloneAudio(audioBytes: ArrayBuffer, filename: string, mimeType: string): Promise<string> {
+		const boundary = '----BragiMiniMaxBoundary' + Math.random().toString(36).slice(2)
+		const parts: Uint8Array[] = []
+		appendMultipartField(parts, boundary, 'purpose', 'voice_clone')
+		appendMultipartFile(parts, boundary, 'file', filename, mimeType, new Uint8Array(audioBytes))
+		parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
+
+		const response = await requestUrl({
+			url: FILE_UPLOAD_URL,
+			method: 'POST',
+			headers: {
+				'Content-Type': `multipart/form-data; boundary=${boundary}`,
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: concatBytes(parts),
+			throw: false,
+		})
+
+		if (response.status === 401 || response.status === 403) throw new Error('MiniMax: invalid token')
+		if (response.status >= 400) throw new Error(`MiniMax voice clone upload: ${parseErr(response)}`)
+
+		const data = response.json
+		const err = baseRespMessage(data)
+		if (err) throw new Error(`MiniMax voice clone upload: ${err}`)
+
+		const fileId = fileIdFromUploadResponse(response)
+		if (!fileId) throw new Error(`MiniMax voice clone upload: no file_id in response - ${safeSnippet(data)}`)
+		return fileId
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable Voice ref mode for native MiniMax TTS
- add MiniMax voice clone support via file upload + voice_clone API
- keep custom voice reuse scoped to clone records with provider/region/model/hash matching

## Tests
- npm run build
- npm run lint:obsidian
- git diff --check