### PR TITLE
Add canvas image collage

### DIFF
--- a/src/canvas-image-compose.ts
+++ b/src/canvas-image-compose.ts
@@ -1,0 +1,289 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Obsidian Canvas internals are runtime-shaped data that this flow narrows at use sites. */
+import { Notice } from 'obsidian'
+import type BragiCanvas from './main'
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+import { DEFAULT_MEDIA_LONG_EDGE, findFreePosition } from './canvas-ops'
+import { loadImageFromBinary } from './grid-split'
+
+const IMAGE_FILE_PATTERN = /\.(png|jpe?g|webp|bmp|tiff?|gif|heic|heif)$/i
+const MAX_OUTPUT_SIDE = 8192
+const MAX_OUTPUT_PIXELS = 32000000
+const PLACEMENT_GAP = 40
+
+type CanvasImageNodeData = {
+	id?: string
+	type?: string
+	file?: string
+	x?: number
+	y?: number
+	width?: number
+	height?: number
+	zIndex?: number
+}
+
+type ComposeSource = {
+	node: CanvasNode
+	filePath: string
+	x: number
+	y: number
+	width: number
+	height: number
+	zIndex: number
+	selectionIndex: number
+}
+
+type LoadedSource = ComposeSource & {
+	image: HTMLImageElement
+}
+
+type Side = 'left' | 'right' | 'top' | 'bottom'
+
+export function isComposableImagePath(filePath: string): boolean {
+	return IMAGE_FILE_PATTERN.test(filePath)
+}
+
+function generateId(): string {
+	return Math.random().toString(36).substring(2, 18)
+}
+
+function finiteNumber(value: unknown, fallback: number): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function extToMime(filePath: string): string {
+	const ext = (filePath.split('.').pop() || '').toLowerCase()
+	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+	if (ext === 'webp') return 'image/webp'
+	if (ext === 'gif') return 'image/gif'
+	if (ext === 'bmp') return 'image/bmp'
+	if (ext === 'tif' || ext === 'tiff') return 'image/tiff'
+	if (ext === 'heic') return 'image/heic'
+	if (ext === 'heif') return 'image/heif'
+	return 'image/png'
+}
+
+function collectSources(nodes: CanvasNode[]): ComposeSource[] {
+	return nodes.map((node, selectionIndex) => {
+		const data = node.getData() as CanvasImageNodeData
+		return {
+			node,
+			filePath: data.file || '',
+			x: finiteNumber(data.x, node.x),
+			y: finiteNumber(data.y, node.y),
+			width: Math.max(1, finiteNumber(data.width, node.width)),
+			height: Math.max(1, finiteNumber(data.height, node.height)),
+			zIndex: finiteNumber(data.zIndex, node.zIndex || 0),
+			selectionIndex,
+		}
+	})
+}
+
+function getBounds(sources: ComposeSource[]): { x: number; y: number; width: number; height: number } {
+	const minX = Math.min(...sources.map(source => source.x))
+	const minY = Math.min(...sources.map(source => source.y))
+	const maxX = Math.max(...sources.map(source => source.x + source.width))
+	const maxY = Math.max(...sources.map(source => source.y + source.height))
+	return {
+		x: minX,
+		y: minY,
+		width: Math.max(1, maxX - minX),
+		height: Math.max(1, maxY - minY),
+	}
+}
+
+function median(values: number[]): number | null {
+	const sorted = values
+		.filter(value => Number.isFinite(value) && value > 0)
+		.sort((a, b) => a - b)
+	if (sorted.length === 0) return null
+	const mid = Math.floor(sorted.length / 2)
+	if (sorted.length % 2 === 1) return sorted[mid]
+	return (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+function getNaturalLongEdge(img: HTMLImageElement): number {
+	return Math.max(img.naturalWidth || img.width, img.naturalHeight || img.height)
+}
+
+function getPixelScale(width: number, height: number, sources: LoadedSource[]): { scale: number; limited: boolean } {
+	const naturalScales = sources.map(source => getNaturalLongEdge(source.image) / DEFAULT_MEDIA_LONG_EDGE)
+	const targetScale = median(naturalScales) || 4
+	const sideScale = MAX_OUTPUT_SIDE / Math.max(width, height)
+	const pixelScale = Math.sqrt(MAX_OUTPUT_PIXELS / Math.max(1, width * height))
+	const scale = Math.min(targetScale, sideScale, pixelScale)
+	return { scale, limited: scale < targetScale }
+}
+
+function canvasToPngBlob(canvasEl: HTMLCanvasElement): Promise<Blob> {
+	return new Promise((resolve, reject) => {
+		canvasEl.toBlob((blob) => {
+			if (blob) {
+				resolve(blob)
+			} else {
+				reject(new Error('PNG export failed'))
+			}
+		}, 'image/png')
+	})
+}
+
+function drawImageCover(
+	ctx: CanvasRenderingContext2D,
+	img: HTMLImageElement,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+): void {
+	const imgWidth = img.naturalWidth || img.width
+	const imgHeight = img.naturalHeight || img.height
+	const srcAspect = imgWidth / imgHeight
+	const destAspect = width / height
+
+	let sx = 0
+	let sy = 0
+	let sw = imgWidth
+	let sh = imgHeight
+
+	if (srcAspect > destAspect) {
+		sw = imgHeight * destAspect
+		sx = (imgWidth - sw) / 2
+	} else if (srcAspect < destAspect) {
+		sh = imgWidth / destAspect
+		sy = (imgHeight - sh) / 2
+	}
+
+	ctx.drawImage(img, sx, sy, sw, sh, x, y, width, height)
+}
+
+function getEdgeSides(from: ComposeSource, target: { x: number; y: number; width: number; height: number }): { fromSide: Side; toSide: Side } {
+	const fromCenterX = from.x + from.width / 2
+	const fromCenterY = from.y + from.height / 2
+	const targetCenterX = target.x + target.width / 2
+	const targetCenterY = target.y + target.height / 2
+	const dx = targetCenterX - fromCenterX
+	const dy = targetCenterY - fromCenterY
+
+	if (Math.abs(dx) >= Math.abs(dy)) {
+		return dx >= 0
+			? { fromSide: 'right', toSide: 'left' }
+			: { fromSide: 'left', toSide: 'right' }
+	}
+
+	return dy >= 0
+		? { fromSide: 'bottom', toSide: 'top' }
+		: { fromSide: 'top', toSide: 'bottom' }
+}
+
+async function loadSources(plugin: BragiCanvas, sources: ComposeSource[]): Promise<LoadedSource[]> {
+	const adapter = plugin.app.vault.adapter
+	const loaded: LoadedSource[] = []
+	for (const source of sources) {
+		const binary = await adapter.readBinary(source.filePath)
+		const image = await loadImageFromBinary(binary, extToMime(source.filePath))
+		loaded.push({ ...source, image })
+	}
+	return loaded
+}
+
+export async function composeSelectedImageNodes(plugin: BragiCanvas, canvas: Canvas, nodes: CanvasNode[]): Promise<void> {
+	if (nodes.length < 2) {
+		new Notice('Select at least two image nodes')
+		return
+	}
+
+	const sources = collectSources(nodes)
+	if (!sources.every(source => source.filePath && isComposableImagePath(source.filePath))) {
+		new Notice('Only image nodes can be composed')
+		return
+	}
+
+	new Notice('Creating collage...')
+
+	const loaded = await loadSources(plugin, sources)
+	const bounds = getBounds(sources)
+	const { scale: pixelScale, limited: wasScaleLimited } = getPixelScale(bounds.width, bounds.height, loaded)
+	const pixelWidth = Math.max(1, Math.round(bounds.width * pixelScale))
+	const pixelHeight = Math.max(1, Math.round(bounds.height * pixelScale))
+	const canvasEl = createEl('canvas')
+	canvasEl.width = pixelWidth
+	canvasEl.height = pixelHeight
+	const ctx = canvasEl.getContext('2d')
+	if (!ctx) throw new Error('Canvas 2D context unavailable')
+	ctx.imageSmoothingEnabled = true
+	ctx.imageSmoothingQuality = 'high'
+	ctx.clearRect(0, 0, pixelWidth, pixelHeight)
+
+	loaded
+		.sort((a, b) => {
+			if (a.zIndex !== b.zIndex) return a.zIndex - b.zIndex
+			return a.selectionIndex - b.selectionIndex
+		})
+		.forEach((source) => {
+			drawImageCover(
+				ctx,
+				source.image,
+				(source.x - bounds.x) * pixelScale,
+				(source.y - bounds.y) * pixelScale,
+				source.width * pixelScale,
+				source.height * pixelScale,
+			)
+		})
+
+	const blob = await canvasToPngBlob(canvasEl)
+	const outputDir = plugin.getOutputDir()
+	const adapter = plugin.app.vault.adapter
+	if (!await adapter.exists(outputDir)) await adapter.mkdir(outputDir)
+
+	const filePath = `${outputDir}/compose_${Date.now()}_${generateId()}.png`
+	await adapter.writeBinary(filePath, await blob.arrayBuffer())
+	plugin.rememberGeneratedAsset(filePath)
+
+	const outputId = generateId()
+	const targetPosition = findFreePosition(
+		canvas,
+		bounds.x + bounds.width + PLACEMENT_GAP,
+		bounds.y,
+		bounds.width,
+		bounds.height,
+	)
+	const outputNode = {
+		id: outputId,
+		type: 'file' as const,
+		file: filePath,
+		x: targetPosition.x,
+		y: targetPosition.y,
+		width: bounds.width,
+		height: bounds.height,
+		color: '',
+	}
+	const outputBounds = {
+		x: targetPosition.x,
+		y: targetPosition.y,
+		width: bounds.width,
+		height: bounds.height,
+	}
+	const edges = sources.map((source) => {
+		const { fromSide, toSide } = getEdgeSides(source, outputBounds)
+		return {
+			id: generateId(),
+			fromNode: source.node.id,
+			fromSide,
+			toNode: outputId,
+			toSide,
+			toEnd: 'arrow',
+		}
+	})
+
+	const current = canvas.getData()
+	canvas.importData({
+		...current,
+		nodes: [...current.nodes, outputNode],
+		edges: [...current.edges, ...edges],
+	})
+	void canvas.requestSave()
+
+	const scaleNote = wasScaleLimited ? ` (${pixelScale.toFixed(2)}x)` : ''
+	new Notice(`Collage ready${scaleNote}`)
+}
+
+/* eslint-enable @typescript-eslint/no-unsafe-assignment -- Resume strict linting after the runtime-shaped data boundary. */

--- a/src/canvas-ops.ts
+++ b/src/canvas-ops.ts
@@ -28,7 +28,7 @@ const PLACEMENT_RADIUS = 20  // up to (2*R+1)² = 1681 candidate cells
 
 // Default canvas node dimensions by type. Image/video actual dimensions are
 // derived from the user-selected aspect ratio; these are the fallbacks.
-const DEFAULT_MEDIA_LONG_EDGE = 400   // image/video: long edge in canvas pixels
+export const DEFAULT_MEDIA_LONG_EDGE = 400   // image/video: long edge in canvas pixels
 const DEFAULT_TEXT_SIZE = { w: 400, h: 200 }
 const DEFAULT_AUDIO_SIZE = { w: 400, h: 100 }
 

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -285,6 +285,13 @@ export function registerBragiIcons(): void {
 		'<path d="M21 22.5C21 22.1022 21.158 21.7206 21.4393 21.4393C21.7206 21.158 22.1022 21 22.5 21H28.5C28.8978 21 29.2794 21.158 29.5607 21.4393C29.842 21.7206 30 22.1022 30 22.5V28.5C30 28.8978 29.842 29.2794 29.5607 29.5607C29.2794 29.842 28.8978 30 28.5 30H22.5C22.1022 30 21.7206 29.842 21.4393 29.5607C21.158 29.2794 21 28.8978 21 28.5V22.5Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
 	))
 
+	// 14 — Collage selected images
+	addIcon('bragi-compose', figmaIcon(
+		'<path d="M6 9C6 8.20435 6.31607 7.44129 6.87868 6.87868C7.44129 6.31607 8.20435 6 9 6H27C27.7956 6 28.5587 6.31607 29.1213 6.87868C29.6839 7.44129 30 8.20435 30 9V27C30 27.7956 29.6839 28.5587 29.1213 29.1213C28.5587 29.6839 27.7956 30 27 30H9C8.20435 30 7.44129 29.6839 6.87868 29.1213C6.31607 28.5587 6 27.7956 6 27V9Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+		'<path d="M15 6L21 30" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+		'<path d="M18 18L6 21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
+	))
+
 	// 10 — Generate Text (document + sparkle)
 	addIcon('bragi-gen-text', figmaIcon(
 		'<path d="M16.5 31.5H15C9.34314 31.5 6.51473 31.5 4.75736 29.7426C3 27.9853 3 25.1568 3 19.5V15C3 9.34314 3 6.51473 4.75736 4.75736C6.51473 3 9.34314 3 15 3H18C23.6568 3 26.4853 3 28.2426 4.75736C30 6.51473 30 9.34314 30 15V15.75" stroke="#161616" stroke-width="2" stroke-linejoin="round"/>' +

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { getCanvasFromNode, createPlaceholderNode, replacePlaceholderWithFile, m
 import { patchCanvasMenu, unpatchCanvasMenu, removeToolbarButtons, replaceCanvasControlIcons, replaceCanvasCardMenuIcons } from './toolbar'
 import { patchPlaceholderContextMenu, unpatchPlaceholderContextMenu } from './placeholder-context-menu'
 import { openPanoramaViewer } from './panorama'
+import { composeSelectedImageNodes } from './canvas-image-compose'
 import { registerBragiIcons } from './icons'
 import { showGenerateBar, showBatchGenerateBar, hideGenerateBar } from './panel'
 import { getUpstreamInputs } from './edge-parser'
@@ -284,6 +285,10 @@ export default class BragiCanvas extends Plugin {
 			(node) => void splitImageNodeIntoTiles(this, canvas, node).catch(err => {
 				console.error('Bragi split grid error:', err)
 				new Notice(`Split failed: ${err.message || err}`)
+			}),
+			(nodes) => void composeSelectedImageNodes(this, canvas, nodes).catch(err => {
+				console.error('Bragi compose images error:', err)
+				new Notice(`Collage failed: ${err.message || err}`)
 			}),
 		)
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -636,6 +636,26 @@
 	--icon-size: 20px;
 }
 
+.bragi-canvas-menu .bragi-labeled-menu-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	width: auto;
+	min-width: 0;
+	padding-inline: 8px;
+	white-space: nowrap;
+}
+
+.bragi-canvas-menu .bragi-labeled-menu-button .svg-icon {
+	flex: 0 0 auto;
+}
+
+.bragi-canvas-menu .bragi-menu-button-label {
+	font-size: 12px;
+	line-height: 1;
+	font-weight: 500;
+}
+
 
 /* Separator line between generation + native icons */
 .bragi-canvas-menu .bragi-separator {

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -13,6 +13,7 @@ import {
 } from './canvas-interaction-tool'
 import { queueSelectionMenuGapSync, resetToolbarPosition } from './node-toolbar-position'
 import { ErrorDetailsModal, getNodeErrorDetails } from './ui/error-details-modal'
+import { isComposableImagePath } from './canvas-image-compose'
 
 const CARD_MENU_TOOLTIP_OPTS = { placement: 'top' } as const
 
@@ -187,6 +188,20 @@ function createMenuButton(
 	return btn
 }
 
+function createLabeledMenuButton(
+	className: string,
+	iconName: string,
+	label: string,
+	tooltip: string,
+	onClick: (event: MouseEvent) => void,
+): HTMLElement {
+	const btn = createMenuButton(className, iconName, tooltip, onClick)
+	btn.classList.add('bragi-labeled-menu-button')
+	btn.setAttribute('aria-label', tooltip)
+	btn.createSpan({ cls: 'bragi-menu-button-label', text: label })
+	return btn
+}
+
 function getMoreItems(menuEl: HTMLElement): MoreDropdownItem[] {
 	return Array.from(menuEl.querySelectorAll('[data-bragi-more-label]'))
 		.filter((el): el is HTMLElement => el.instanceOf(HTMLElement))
@@ -275,7 +290,7 @@ function addMoreButton(menuEl: HTMLElement): void {
 function clearMenuInjection(menuEl: HTMLElement): void {
 	closeBragiDropdown()
 	menuEl
-		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-more, .bragi-actions-separator')
+		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more, .bragi-actions-separator')
 		.forEach((el) => el.remove())
 
 	for (const btn of getNativeMenuButtons(menuEl)) {
@@ -298,6 +313,10 @@ function getCanvasData(node: CanvasNode): CanvasDataLike {
 
 function isFileWithExtension(data: CanvasDataLike, pattern: RegExp): boolean {
 	return data.type === 'file' && pattern.test(data.file || '')
+}
+
+function isComposableImageNode(data: CanvasDataLike): boolean {
+	return data.type === 'file' && isComposableImagePath(data.file || '')
 }
 
 function isPromptNode(data: CanvasDataLike): boolean {
@@ -449,6 +468,7 @@ export function patchCanvasMenu(
 	onBatchGenerate?: (type: 'image' | 'video' | 'text' | 'audio', nodes: CanvasNode[]) => void,
 	onPanorama?: (node: CanvasNode) => void,
 	onGridSplit?: (node: CanvasNode) => void,
+	onComposeImages?: (nodes: CanvasNode[]) => void,
 ): void {
 	if (menuUninstaller) return
 
@@ -500,6 +520,7 @@ export function patchCanvasMenu(
 			if (selSize > 1) {
 				const markBtn = createMarkButton(menuEl, canvas, selectedNodes)
 				const isPurePromptSelection = selectedNodes.length === selSize && selectedNodes.every(node => isPromptNode(getCanvasData(node)))
+				const isPureImageSelection = selectedNodes.length === selSize && selectedNodes.length >= 2 && selectedNodes.every(node => isComposableImageNode(getCanvasData(node)))
 
 				let separator: HTMLElement | null = null
 				const generationButtons: HTMLElement[] = []
@@ -521,6 +542,12 @@ export function patchCanvasMenu(
 						generationButtons.push(btn)
 					}
 				}
+				const composeBtn = isPureImageSelection && onComposeImages
+					? createLabeledMenuButton('bragi-compose', 'bragi-compose', 'Collage', 'Create collage', () => {
+						onComposeImages(selectedNodes)
+					})
+					: null
+				if (composeBtn) menuEl.appendChild(composeBtn)
 
 				configureStandardMoreItems(menuEl, 0)
 				addMoreButton(menuEl)
@@ -528,6 +555,7 @@ export function patchCanvasMenu(
 				const alignBtn = findBuiltinByLabel(menuEl, 'align') || findBuiltinByLabel(menuEl, 'arrange')
 				const groupBtn = findBuiltinByLabel(menuEl, 'group')
 				reorderMenuButtons(menuEl, [
+					composeBtn,
 					...generationButtons,
 					separator,
 					alignBtn,
@@ -546,7 +574,7 @@ export function patchCanvasMenu(
 
 			const isTextNode = nodeData?.type === 'text'
 			const isNoteNode = Boolean(nodeData && isFileWithExtension(nodeData, /\.md$/i))
-			const isImageNode = Boolean(nodeData && isFileWithExtension(nodeData, /\.(png|jpg|jpeg|webp|gif)$/i))
+			const isImageNode = Boolean(nodeData && isComposableImageNode(nodeData))
 			const isPanoramaImageNode = Boolean(nodeData && isFileWithExtension(nodeData, /\.(png|jpe?g|webp)$/i))
 			const isVideoNode = Boolean(nodeData && isFileWithExtension(nodeData, /\.(mp4|mov|webm)$/i))
 			const isAudioNode = Boolean(nodeData && isFileWithExtension(nodeData, /\.(mp3|wav|flac|m4a|ogg|aac)$/i))
@@ -1028,7 +1056,7 @@ export function unpatchCanvasMenu(): void {
 }
 
 export function removeToolbarButtons(): void {
-	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-more').forEach(el => {
+	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more').forEach(el => {
 		if (el.previousElementSibling?.classList.contains('canvas-menu-separator')) {
 			el.previousElementSibling.remove()
 		}

--- a/styles.css
+++ b/styles.css
@@ -636,6 +636,26 @@
 	--icon-size: 20px;
 }
 
+.bragi-canvas-menu .bragi-labeled-menu-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	width: auto;
+	min-width: 0;
+	padding-inline: 8px;
+	white-space: nowrap;
+}
+
+.bragi-canvas-menu .bragi-labeled-menu-button .svg-icon {
+	flex: 0 0 auto;
+}
+
+.bragi-canvas-menu .bragi-menu-button-label {
+	font-size: 12px;
+	line-height: 1;
+	font-weight: 500;
+}
+
 
 /* Separator line between generation + native icons */
 .bragi-canvas-menu .bragi-separator {


### PR DESCRIPTION
## Summary
- add a multi-select Collage toolbar action for image-only selections
- render selected image nodes into a transparent PNG using canvas layout, overlap order, and adaptive pixel density
- create an output image node with arrowed edges from each source image

## Tests
- npm run lint:obsidian
- npm run build