### PR TITLE
Add MuleRouter Wan 2.7 Spicy I2V

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -50,6 +50,15 @@ This repository is an Obsidian community plugin. Treat Obsidian Community review
 - Keep file, asset, canvas, and vault-content migrations in their own modules. Do not mix them into settings schema migration code.
 - When adding a settings field, update defaults, validator/import parsing, migration behavior, and the test plan in the same change.
 
+## Model / Provider Catalog Changes
+
+- Adding a model to the local catalogue or adding provider support for a model must not automatically enable that model for existing users.
+- Treat newly supported models as addable candidates only. They may appear in Add Model and provider Manage models flows, but they must not appear in settings model lists, panels, or MCP `list_models` until the user explicitly enables them.
+- A model is available only when `modelPrefs[modelId].enabled === true`, its active provider is configured, the provider supports the model, and `providerModelPrefs[providerId][modelId] === true`.
+- When connecting an already enabled model to an additional provider, preserve the existing active provider unless the user explicitly switches providers or removes the active provider connection.
+- When renaming or replacing a model ID, migrate `modelPrefs`, active provider selection, and `providerModelPrefs` in the centralized settings migration pipeline.
+- MCP model exposure must match the settings UI: only explicitly enabled models with a configured active provider connection should be returned.
+
 ## Reference Asset Upload Policy
 
 - When a provider needs a publicly fetchable reference asset URL, prefer the built-in Bragi temporary relay path first (`src/providers/upload.ts` + `src/providers/bragi-relay.ts`) and pass the returned public URL into the model request.

--- a/src/main.ts
+++ b/src/main.ts
@@ -548,6 +548,7 @@ export default class BragiCanvas extends Plugin {
 			} else {
 			// Seedance can consume provider-specific asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
+			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7-i2v-spicy'
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const supportsSeedanceRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
@@ -567,6 +568,10 @@ export default class BragiCanvas extends Plugin {
 					refImages.push(await ensureBytePlusAsset(this, canvas, imgPath, bytePlusCreds))
 				} else if (tokenRouterModelArkCreds) {
 					refImages.push(await ensureTokenRouterModelArkAsset(this, canvas, imgPath, tokenRouterModelArkCreds))
+				} else if (isMuleRouterWan) {
+					const binary = await this.app.vault.adapter.readBinary(imgPath)
+					const ext = getFileExtension(imgPath, 'png')
+					refImages.push(await uploadRef(undefined, binary, `ref.${ext}`, imageMimeType(imgPath)))
 				} else {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const base64 = arrayBufferToBase64(binary)
@@ -576,12 +581,13 @@ export default class BragiCanvas extends Plugin {
 				}
 			}
 
-			// Upload reference audios for Seedance
-			if (supportsSeedanceRefs && uniqueAudios.length > 0) {
-				if (uniqueAudios.length > 3) {
+			// Upload reference audios for Seedance and MuleRouter Wan I2V.
+			if ((supportsSeedanceRefs || isMuleRouterWan) && uniqueAudios.length > 0) {
+				if (supportsSeedanceRefs && uniqueAudios.length > 3) {
 					throw new Error('Seedance supports up to 3 reference audio files.')
 				}
-				for (const audioPath of uniqueAudios) {
+				const audioRefs = isMuleRouterWan ? uniqueAudios.slice(0, 1) : uniqueAudios
+				for (const audioPath of audioRefs) {
 					if (bytePlusCreds) {
 						// Route audio through asset library for content review
 						refAudios.push(await ensureBytePlusAsset(this, canvas, audioPath, bytePlusCreds))
@@ -590,8 +596,7 @@ export default class BragiCanvas extends Plugin {
 					} else {
 						const binary = await this.app.vault.adapter.readBinary(audioPath)
 						const ext = audioPath.split('.').pop()?.toLowerCase() || 'mp3'
-						const mime = ext === 'wav' ? 'audio/wav' : 'audio/mpeg'
-						const audioUrl = await uploadRef(undefined, binary, `ref.${ext}`, mime)
+						const audioUrl = await uploadRef(undefined, binary, `ref.${ext}`, audioMimeType(audioPath))
 						refAudios.push(audioUrl)
 					}
 				}
@@ -1397,6 +1402,14 @@ function audioMimeType(filePath: string): string {
 	if (ext === 'ogg') return 'audio/ogg'
 	if (ext === 'opus') return 'audio/opus'
 	return 'audio/mpeg'
+}
+
+function imageMimeType(filePath: string): string {
+	const ext = getFileExtension(filePath, 'png')
+	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+	if (ext === 'webp') return 'image/webp'
+	if (ext === 'bmp') return 'image/bmp'
+	return 'image/png'
 }
 
 function videoMimeType(filePath: string): string {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,6 +6,7 @@ import { seedance2, seedance2Fast } from './seedance'
 import { kling3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
+import { wan27I2vSpicy } from './wan'
 import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
@@ -41,6 +42,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	kling26,
 	happyHorseT2V,
 	happyHorseI2V,
+	wan27I2vSpicy,
 	veo31,
 	veo31Lite,
 	grokVideo,

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -1,0 +1,43 @@
+import type { ModelConfig } from './types'
+
+export const wan27I2vSpicy: ModelConfig = {
+	id: 'wan-2.7-i2v-spicy',
+	name: 'Wan 2.7 Spicy I2V',
+	type: 'video',
+	supportedProviders: {
+		mulerouter: { apiModelId: 'wan2.7-i2v-spicy' },
+	},
+	modes: ['first-frame'],
+	params: [
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '720p', value: '720p' },
+				{ label: '1080p', value: '1080p' },
+			],
+			default: '1080p',
+		},
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'range',
+			default: 5,
+			min: 2,
+			max: 15,
+			step: 1,
+			unit: 's',
+		},
+		{
+			id: 'prompt_extend',
+			label: 'Prompt extend',
+			type: 'select',
+			options: [
+				{ label: 'On', value: 'true' },
+				{ label: 'Off', value: 'false' },
+			],
+			default: 'true',
+		},
+	],
+}

--- a/src/providers/mulerouter.ts
+++ b/src/providers/mulerouter.ts
@@ -1,0 +1,210 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- MuleRouter responses are runtime-shaped and narrowed at the provider boundary. */
+import type { App } from 'obsidian'
+import { requestUrl } from 'obsidian'
+import type { GenerateVideoResult, VideoProvider } from './types'
+import { uploadRef } from './upload'
+
+const BASE_URL = 'https://api.mulerouter.ai'
+const WAN27_I2V_SPICY_PATH = '/vendors/carrothub/v1/wan2.7-i2v-spicy/generation'
+const DONE_STATUSES = new Set(['completed'])
+const FAILED_STATUSES = new Set(['failed'])
+
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+}
+
+function stringParam(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function isHttpUrl(value: string): boolean {
+	return /^https:\/\//i.test(value)
+}
+
+function extensionForMime(mimeType: string): string {
+	if (mimeType.includes('webp')) return 'webp'
+	if (mimeType.includes('bmp')) return 'bmp'
+	if (mimeType.includes('jpeg') || mimeType.includes('jpg')) return 'jpg'
+	if (mimeType.includes('wav')) return 'wav'
+	if (mimeType.includes('mpeg') || mimeType.includes('mp3')) return 'mp3'
+	if (mimeType.includes('mp4')) return 'mp4'
+	return 'png'
+}
+
+function videoExtFromUrl(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	if (clean.endsWith('.mov')) return 'mov'
+	if (clean.endsWith('.webm')) return 'webm'
+	return 'mp4'
+}
+
+function dataUriToBytes(dataUri: string): { bytes: Uint8Array; ext: string; mimeType: string } | null {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+	if (!match) return null
+	const mimeType = match[1]
+	return {
+		bytes: Uint8Array.from(atob(match[2]), c => c.charCodeAt(0)),
+		ext: extensionForMime(mimeType),
+		mimeType,
+	}
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength)
+	copy.set(bytes)
+	return copy.buffer
+}
+
+function taskInfo(data: unknown): JsonRecord {
+	return asRecord(asRecord(data)?.task_info) || {}
+}
+
+function providerErrorMessage(data: unknown, fallback: string): string {
+	const body = asRecord(data) || {}
+	const info = taskInfo(body)
+	const taskError = asRecord(info.error)
+	const error = asRecord(body.error)
+	const code = stringParam(taskError?.code || error?.code, '')
+	const title = stringParam(taskError?.title || error?.title, '')
+	const detail = stringParam(taskError?.detail || error?.message || body.message, '')
+	const parts = [code, title, detail].filter(Boolean)
+	return parts.length > 0 ? parts.join(' — ') : fallback
+}
+
+function extractTaskId(data: unknown): string {
+	return stringParam(taskInfo(data).id || asRecord(data)?.id, '').trim()
+}
+
+function extractStatus(data: unknown): string {
+	return stringParam(taskInfo(data).status || asRecord(data)?.status, '').trim().toLowerCase()
+}
+
+function extractVideoUrl(data: unknown): string {
+	const body = asRecord(data) || {}
+	const videos = Array.isArray(body.videos) ? body.videos : []
+	return stringParam(videos[0], '').trim()
+}
+
+function parseDuration(value: unknown): number {
+	const parsed = typeof value === 'number' ? value : parseInt(stringParam(value, '5'), 10)
+	if (!Number.isFinite(parsed)) return 5
+	return Math.min(Math.max(parsed, 2), 15)
+}
+
+function parsePromptExtend(value: unknown): boolean {
+	if (typeof value === 'boolean') return value
+	return stringParam(value, 'true') !== 'false'
+}
+
+export class MuleRouterVideoProvider implements VideoProvider {
+	name = 'MuleRouter'
+
+	constructor(
+		private apiKey: string,
+		private app: App,
+		private outputDir: string,
+		private baseUrl = BASE_URL,
+	) {
+		this.baseUrl = this.baseUrl.replace(/\/$/, '')
+	}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		const refAudios: string[] = Array.isArray(params?.refAudios) ? params.refAudios : []
+		if (!refImages[0]) throw new Error('MuleRouter Wan 2.7 Spicy I2V requires one upstream image.')
+
+		const body: JsonRecord = {
+			prompt,
+			image: await this.ensurePublicUrl(refImages[0], 'image'),
+			resolution: stringParam(params?.resolution, '1080p') === '720p' ? '720p' : '1080p',
+			duration: parseDuration(params?.duration),
+			prompt_extend: parsePromptExtend(params?.prompt_extend),
+		}
+		if (refAudios[0]) body.audio_url = await this.ensurePublicUrl(refAudios[0], 'audio')
+
+		const resp = await requestUrl({
+			url: `${this.baseUrl}${WAN27_I2V_SPICY_PATH}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status >= 400) {
+			throw new Error(`MuleRouter video: ${providerErrorMessage(resp.json || resp.text, `HTTP ${resp.status}`)}`)
+		}
+		const taskId = extractTaskId(resp.json)
+		if (!taskId) throw new Error('MuleRouter video: task_info.id was not returned')
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const resp = await requestUrl({
+			url: `${this.baseUrl}${WAN27_I2V_SPICY_PATH}/${encodeURIComponent(taskId)}`,
+			method: 'GET',
+			headers: { 'Authorization': `Bearer ${this.apiKey}` },
+			throw: false,
+		})
+
+		if (resp.status >= 400) {
+			throw new Error(`MuleRouter video: ${providerErrorMessage(resp.json || resp.text, `HTTP ${resp.status}`)}`)
+		}
+
+		const status = extractStatus(resp.json)
+		if (DONE_STATUSES.has(status)) {
+			const videoUrl = extractVideoUrl(resp.json)
+			if (!videoUrl) throw new Error('MuleRouter video: completed task has no video URL')
+			return { done: true, filePath: await this.downloadVideo(videoUrl) }
+		}
+		if (FAILED_STATUSES.has(status)) {
+			throw new Error(`MuleRouter video: ${providerErrorMessage(resp.json, 'Task failed')}`)
+		}
+		return { done: false, taskId }
+	}
+
+	private async ensurePublicUrl(ref: string, kind: 'image' | 'audio'): Promise<string> {
+		if (isHttpUrl(ref)) return ref
+		const decoded = dataUriToBytes(ref)
+		if (!decoded) throw new Error(`MuleRouter video: unsupported reference ${kind} format`)
+		return uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `ref.${decoded.ext}`, decoded.mimeType)
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const resp = await requestUrl({ url })
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) await adapter.mkdir(this.outputDir)
+		const filePath = `${this.outputDir}/mulerouter_wan27_${Date.now()}.${videoExtFromUrl(url)}`
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return filePath
+	}
+}
+
+export async function testMuleRouterConnection(apiKey: string): Promise<{ ok: boolean; message: string }> {
+	if (!apiKey) return { ok: false, message: 'API key is empty.' }
+	try {
+		const resp = await requestUrl({
+			url: `${BASE_URL}${WAN27_I2V_SPICY_PATH}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${apiKey}`,
+			},
+			body: '{}',
+			throw: false,
+		})
+		if (resp.status === 401 || resp.status === 403) return { ok: false, message: 'Invalid API key.' }
+		if (resp.status < 500) return { ok: true, message: 'Connected.' }
+		return { ok: false, message: `Unexpected status ${resp.status}.` }
+	} catch (err: unknown) {
+		return { ok: false, message: `Network error: ${err?.message || err}` }
+	}
+}
+
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Resume strict linting after the runtime-shaped data boundary. */

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -17,6 +17,7 @@ import { MiniMaxProvider } from './minimax'
 import { LegnextProvider } from './legnext'
 import { APIMartProvider } from './apimart'
 import { LumaProvider } from './luma'
+import { MuleRouterVideoProvider, testMuleRouterConnection } from './mulerouter'
 import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
 import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProvider } from './tokenrouter'
 import { DashScopeAudioProvider } from './dashscope'
@@ -412,6 +413,17 @@ export const PROVIDERS: ProviderSpec[] = [
 		makeText: ({ settings }) =>
 			new TokenRouterTextProvider(settings.providers.tokenrouter, 'https://api.tokenrouter.com/v1'),
 		testConnection: (d) => testListModels('https://api.tokenrouter.com/v1/models', d.tokenrouter || ''),
+	},
+	{
+		id: 'mulerouter',
+		name: 'MuleRouter',
+		description: 'Wan 2.7 Spicy image-to-video.',
+		docUrl: 'https://www.mulerouter.ai/docs/api-reference/endpoint/carrothub/wan2.7-i2v-spicy/generation',
+		fields: [{ key: 'mulerouter', label: 'API Key', placeholder: 'sk-mr-...', type: 'password' }],
+		isConfigured: (s) => !!s.providers.mulerouter,
+		makeVideo: ({ settings, app, outputDir }) =>
+			new MuleRouterVideoProvider(settings.providers.mulerouter, app, outputDir),
+		testConnection: (d) => testMuleRouterConnection(d.mulerouter || ''),
 	},
 	{
 		id: 'apimart',

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,8 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 2
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 3
+const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {
 	settings: BragiSettings
@@ -429,7 +430,7 @@ function migrateProviderPrefs19(settings: BragiSettings): void {
 }
 
 function migrateProviderModelPrefs(settings: BragiSettings, previousVersion: number): void {
-	if (previousVersion >= CURRENT_SETTINGS_SCHEMA_VERSION) {
+	if (previousVersion >= PROVIDER_MODEL_PREFS_SCHEMA_VERSION) {
 		pruneProviderModelPrefs(settings)
 		return
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,6 +104,7 @@ export interface BragiSettings {
 		elevenlabs: string
 		legnext: string
 		tokenrouter: string
+		mulerouter: string
 		apimart: string
 		lumaToken: string
 		xai: string
@@ -165,6 +166,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		elevenlabs: '',
 		legnext: '',
 		tokenrouter: '',
+		mulerouter: '',
 		apimart: '',
 		lumaToken: '',
 		xai: '',


### PR DESCRIPTION
## Summary
- Add MuleRouter as a video provider.
- Add Wan 2.7 Spicy I2V as an explicit opt-in video model.
- Route image and audio refs through Bragi temporary relay URLs before calling MuleRouter.
- Preserve explicit provider/model connection semantics for existing users.

## Verification
- npm run build
- npm run lint:obsidian
- git diff --check
- npm run sync:check
- MuleRouter live API task: create, poll to completed, download mp4