### PR TITLE
Add Token360 Seedance provider

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { checkMigration } from './migrate-assets'
 import { startAttachmentRedirect } from './attachment-redirect'
 import { ensureBytePlusAsset, getBytePlusAssetCreds } from './byteplus-asset-flow'
 import { ensureTokenRouterModelArkAsset, getTokenRouterModelArkCreds } from './tokenrouter-asset-flow'
+import { ensureToken360Asset, getToken360AssetCreds } from './token360-asset-flow'
 import { splitImageNodeIntoTiles } from './grid-split-flow'
 import { isSupportedLanguage, LanguageGateModal } from './ui/language-gate'
 import { installAlwaysNewTab } from './always-new-tab'
@@ -550,15 +551,19 @@ export default class BragiCanvas extends Plugin {
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7-i2v-spicy'
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
-			const supportsSeedanceRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
+			const supportsSeedanceAssetRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
+			const supportsSeedanceUrlRefs = supportsSeedanceAssetRefs || (activeProvider === 'token360' && isSeedanceModel)
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
-			const assetIdMap = supportsSeedanceRefs ? getAssetIds(canvas, node, activeProvider) : {}
+			const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
 			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && hasSeedanceMediaRefs)
 				? getBytePlusAssetCreds(this)
 				: null
 			const tokenRouterModelArkCreds = (activeProvider === 'tokenrouter' && isSeedanceModel && hasSeedanceMediaRefs)
 				? getTokenRouterModelArkCreds(this)
+				: null
+			const token360AssetCreds = (activeProvider === 'token360' && isSeedanceModel && uniqueImages.length > 0)
+				? getToken360AssetCreds(this)
 				: null
 			for (const imgPath of uniqueImages) {
 				if (assetIdMap[imgPath]) {
@@ -568,6 +573,8 @@ export default class BragiCanvas extends Plugin {
 					refImages.push(await ensureBytePlusAsset(this, canvas, imgPath, bytePlusCreds))
 				} else if (tokenRouterModelArkCreds) {
 					refImages.push(await ensureTokenRouterModelArkAsset(this, canvas, imgPath, tokenRouterModelArkCreds))
+				} else if (token360AssetCreds) {
+					refImages.push(await ensureToken360Asset(this, canvas, imgPath, token360AssetCreds))
 				} else if (isMuleRouterWan) {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const ext = getFileExtension(imgPath, 'png')
@@ -582,8 +589,8 @@ export default class BragiCanvas extends Plugin {
 			}
 
 			// Upload reference audios for Seedance and MuleRouter Wan I2V.
-			if ((supportsSeedanceRefs || isMuleRouterWan) && uniqueAudios.length > 0) {
-				if (supportsSeedanceRefs && uniqueAudios.length > 3) {
+			if ((supportsSeedanceUrlRefs || isMuleRouterWan) && uniqueAudios.length > 0) {
+				if (supportsSeedanceUrlRefs && uniqueAudios.length > 3) {
 					throw new Error('Seedance supports up to 3 reference audio files.')
 				}
 				const audioRefs = isMuleRouterWan ? uniqueAudios.slice(0, 1) : uniqueAudios
@@ -605,16 +612,16 @@ export default class BragiCanvas extends Plugin {
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
-				if (mode === 'video-ref' && !supportsSeedanceRefs) {
-					throw new Error('Reference video is only available with Volcengine, BytePlus, or TokenRouter Seedance.')
+				if (mode === 'video-ref' && !supportsSeedanceUrlRefs) {
+					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance.')
 				}
-				if (supportsSeedanceRefs && uniqueVideos.length > 3) {
+				if (supportsSeedanceUrlRefs && uniqueVideos.length > 3) {
 					throw new Error('Seedance supports up to 3 reference videos.')
 				}
 				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
 					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')
 				}
-				const shouldUseVideos = supportsSeedanceRefs || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref'
+				const shouldUseVideos = supportsSeedanceUrlRefs || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref'
 				if (shouldUseVideos) {
 					for (const videoPath of uniqueVideos) {
 						if (isNativeSeedance && bytePlusCreds) {

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -9,6 +9,7 @@ export const seedance2: ModelConfig = {
 		byteplus: { apiModelId: 'ep-20260423151427-fj6dh' },
 		fal: { apiModelId: 'bytedance/seedance-2.0' },
 		tokenrouter: { apiModelId: 'dreamina-seedance-2-0-260128' },
+		token360: { apiModelId: 'seedance-2.0' },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'],
 	params: [
@@ -78,6 +79,7 @@ export const seedance2Fast: ModelConfig = {
 		bytedance: { apiModelId: 'doubao-seedance-2-0-fast-260128' },
 		byteplus: { apiModelId: 'ep-20260423151341-p2zm9' },
 		tokenrouter: { apiModelId: 'dreamina-seedance-2-0-fast-260128' },
+		token360: { apiModelId: 'seedance-2.0-fast' },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'],
 	params: [

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -20,6 +20,7 @@ import { LumaProvider } from './luma'
 import { MuleRouterVideoProvider, testMuleRouterConnection } from './mulerouter'
 import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
 import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProvider } from './tokenrouter'
+import { Token360VideoProvider } from './token360'
 import { DashScopeAudioProvider } from './dashscope'
 
 const LUMA_ENDPOINT = 'https://luma.bragi.now'
@@ -413,6 +414,24 @@ export const PROVIDERS: ProviderSpec[] = [
 		makeText: ({ settings }) =>
 			new TokenRouterTextProvider(settings.providers.tokenrouter, 'https://api.tokenrouter.com/v1'),
 		testConnection: (d) => testListModels('https://api.tokenrouter.com/v1/models', d.tokenrouter || ''),
+	},
+	{
+		id: 'token360',
+		name: 'Token360',
+		description: 'Unified AI gateway for Seedance video.',
+		docUrl: 'https://www.token360.ai/en-US/docs/api-reference/video-generation/submit-video-generation-request',
+		fields: [
+			{ key: 'token360', label: 'API Key', placeholder: 'sk-token360-...', type: 'password' },
+			{ key: 'token360AssetGroupId', label: 'Asset group ID (optional)', placeholder: 'legacy_rf_9032', type: 'text' },
+		],
+		isConfigured: (s) => !!s.providers.token360,
+		makeVideo: ({ settings, app, outputDir }) =>
+			new Token360VideoProvider(settings.providers.token360, app, outputDir),
+		testConnection: async (d) => {
+			const key = d.token360 || ''
+			if (!key) return { ok: false, message: 'API key is empty.' }
+			return testGenericGet('https://api.token360.ai/v1/videos?limit=1', { 'Authorization': `Bearer ${key}` })
+		},
 	},
 	{
 		id: 'mulerouter',

--- a/src/providers/token360-assets.ts
+++ b/src/providers/token360-assets.ts
@@ -1,0 +1,184 @@
+import { requestUrl } from 'obsidian'
+
+const BASE_URL = 'https://api.token360.ai/v1'
+const POLL_INTERVAL_MS = 5000
+const POLL_TIMEOUT_MS = 300000
+
+type JsonRecord = Record<string, unknown>
+
+export interface Token360AssetCreds {
+	apiKey: string
+	groupId: string
+}
+
+export interface Token360AssetGetResult {
+	status: 'Active' | 'Processing' | 'Failed' | 'Rejected' | 'Inactive' | 'Unknown'
+	raw: JsonRecord
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function randomHex(n: number): string {
+	const bytes = new Uint8Array(n)
+	crypto.getRandomValues(bytes)
+	return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+function appendMultipartField(parts: Uint8Array[], boundary: string, name: string, value: string): void {
+	const enc = new TextEncoder()
+	parts.push(enc.encode(`--${boundary}\r\n`))
+	parts.push(enc.encode(`Content-Disposition: form-data; name="${name}"\r\n\r\n`))
+	parts.push(enc.encode(value))
+	parts.push(enc.encode('\r\n'))
+}
+
+function appendMultipartFile(parts: Uint8Array[], boundary: string, name: string, filename: string, mime: string, bytes: Uint8Array): void {
+	const enc = new TextEncoder()
+	parts.push(enc.encode(`--${boundary}\r\n`))
+	parts.push(enc.encode(`Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\n`))
+	parts.push(enc.encode(`Content-Type: ${mime}\r\n\r\n`))
+	parts.push(bytes)
+	parts.push(enc.encode('\r\n'))
+}
+
+function concatBytes(parts: Uint8Array[]): ArrayBuffer {
+	let total = 0
+	for (const part of parts) total += part.length
+	const body = new Uint8Array(total)
+	let offset = 0
+	for (const part of parts) {
+		body.set(part, offset)
+		offset += part.length
+	}
+	return body.buffer
+}
+
+function parseBody(resp: { text?: string; json?: unknown }): JsonRecord | null {
+	return asRecord(resp.json) || (() => {
+		try { return asRecord(JSON.parse(resp.text || '')) } catch { return null }
+	})()
+}
+
+function extractError(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = parseBody(resp)
+	const error = asRecord(body?.error)
+	const msg = stringValue(error?.message || body?.message || body?.error || resp.text, `HTTP ${resp.status}`)
+	const code = stringValue(error?.code || error?.type || body?.code, '')
+	return `${code ? code + ' - ' : ''}${msg}`
+}
+
+function makeError(message: string, status?: number): Error & { status?: number; code?: string } {
+	const err = new Error(message) as Error & { status?: number; code?: string }
+	err.status = status
+	return err
+}
+
+function normalizeStatus(value: unknown): Token360AssetGetResult['status'] {
+	const normalized = stringValue(value, 'Unknown').trim().toLowerCase()
+	if (normalized === 'active' || normalized === 'success' || normalized === 'completed') return 'Active'
+	if (normalized === 'processing' || normalized === 'pending' || normalized === 'queued' || normalized === 'in_progress') return 'Processing'
+	if (normalized === 'failed' || normalized === 'failure' || normalized === 'error') return 'Failed'
+	if (normalized === 'rejected') return 'Rejected'
+	if (normalized === 'inactive' || normalized === 'disabled') return 'Inactive'
+	return 'Unknown'
+}
+
+function extractAssetId(data: JsonRecord): string {
+	const nestedData = asRecord(data.data)
+	const result = asRecord(data.result) || asRecord(data.Result)
+	const source = nestedData || result || data
+	return stringValue(
+		source.assetId ||
+		source.token360AssetId ||
+		source.AssetId ||
+		source.Id ||
+		source.id,
+		'',
+	)
+}
+
+export async function uploadToken360Asset(
+	creds: Token360AssetCreds,
+	fileName: string,
+	mimeType: string,
+	bytes: ArrayBuffer,
+): Promise<string> {
+	const boundary = '----BragiToken360AssetBoundary' + Math.random().toString(36).slice(2)
+	const parts: Uint8Array[] = []
+	appendMultipartFile(parts, boundary, 'file', fileName, mimeType, new Uint8Array(bytes))
+	appendMultipartField(parts, boundary, 'name', fileName || `bragi_${randomHex(6)}`)
+	appendMultipartField(parts, boundary, 'groupId', creds.groupId)
+	parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
+
+	const resp = await requestUrl({
+		url: `${BASE_URL}/assets`,
+		method: 'POST',
+		headers: {
+			'Authorization': `Bearer ${creds.apiKey}`,
+			'Content-Type': `multipart/form-data; boundary=${boundary}`,
+		},
+		body: concatBytes(parts),
+		throw: false,
+	})
+	if (resp.status < 200 || resp.status >= 300) {
+		throw makeError(`Token360 Upload Asset: ${extractError(resp)}`, resp.status)
+	}
+
+	const body = parseBody(resp) || {}
+	const assetId = extractAssetId(body)
+	if (!assetId) throw new Error('Token360 Upload Asset: no assetId in response')
+	return assetId
+}
+
+export async function getToken360Asset(creds: Token360AssetCreds, assetId: string): Promise<Token360AssetGetResult> {
+	const resp = await requestUrl({
+		url: `${BASE_URL}/assets/${encodeURIComponent(assetId)}`,
+		method: 'GET',
+		headers: { 'Authorization': `Bearer ${creds.apiKey}` },
+		throw: false,
+	})
+	if (resp.status < 200 || resp.status >= 300) {
+		throw makeError(`Token360 Get Asset: ${extractError(resp)}`, resp.status)
+	}
+
+	const body = parseBody(resp) || {}
+	const nestedData = asRecord(body.data)
+	const result = asRecord(body.result) || asRecord(body.Result)
+	const source = nestedData || result || body
+	return {
+		status: normalizeStatus(source.status || source.Status || source.assetStatus || source.state),
+		raw: source,
+	}
+}
+
+export function isToken360AssetNotFound(err: unknown): boolean {
+	const e = err as { message?: string; status?: number; code?: string }
+	return e.status === 404 || /NotFound|NoSuchAsset|InvalidAsset|AssetNotExist|not\s+found/i.test(e.code || e.message || '')
+}
+
+export async function waitForToken360AssetActive(creds: Token360AssetCreds, assetId: string): Promise<void> {
+	const deadline = Date.now() + POLL_TIMEOUT_MS
+	while (Date.now() < deadline) {
+		const { status, raw } = await getToken360Asset(creds, assetId)
+		if (status === 'Active') return
+		if (status === 'Rejected') {
+			throw new Error(`Token360 asset rejected. ${stringValue(raw.reason || raw.message || raw.error, '')}`.trim())
+		}
+		if (status === 'Failed') {
+			throw new Error(`Token360 asset failed. ${stringValue(raw.reason || raw.message || raw.error, '')}`.trim())
+		}
+		if (status === 'Inactive') {
+			throw new Error(`Token360 asset inactive. ${stringValue(raw.reason || raw.message || raw.error, '')}`.trim())
+		}
+		await new Promise(r => window.setTimeout(r, POLL_INTERVAL_MS))
+	}
+	throw new Error(`Token360 asset timed out after ${POLL_TIMEOUT_MS / 1000}s`)
+}

--- a/src/providers/token360.ts
+++ b/src/providers/token360.ts
@@ -1,0 +1,266 @@
+import type { App } from 'obsidian'
+import { requestUrl } from 'obsidian'
+import type { GenerateVideoResult, VideoProvider } from './types'
+import { uploadRef } from './upload'
+
+const BASE_URL = 'https://api.token360.ai/v1'
+const DONE_STATUSES = new Set(['completed', 'succeeded', 'success'])
+const FAILED_STATUSES = new Set(['failed', 'failure', 'error', 'cancelled', 'canceled'])
+
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+}
+
+function stringParam(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function optionalString(value: unknown): string | undefined {
+	const text = stringParam(value, '').trim()
+	return text || undefined
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+	if (typeof value === 'boolean') return value
+	if (typeof value === 'number') return value !== 0
+	if (typeof value !== 'string') return undefined
+	const normalized = value.trim().toLowerCase()
+	if (!normalized) return undefined
+	if (['false', '0', 'no', 'off'].includes(normalized)) return false
+	return true
+}
+
+function stringList(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function isHttpUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value)
+}
+
+function extensionForMime(mimeType: string): string {
+	if (mimeType.includes('webp')) return 'webp'
+	if (mimeType.includes('jpeg') || mimeType.includes('jpg')) return 'jpg'
+	if (mimeType.includes('png')) return 'png'
+	if (mimeType.includes('quicktime')) return 'mov'
+	if (mimeType.includes('webm')) return 'webm'
+	if (mimeType.includes('wav')) return 'wav'
+	if (mimeType.includes('mp4')) return 'mp4'
+	if (mimeType.includes('aac')) return 'aac'
+	if (mimeType.includes('flac')) return 'flac'
+	if (mimeType.includes('ogg')) return 'ogg'
+	if (mimeType.includes('opus')) return 'opus'
+	if (mimeType.includes('mpeg')) return 'mp3'
+	return 'bin'
+}
+
+function dataUriToBytes(dataUri: string): { bytes: Uint8Array; ext: string; mimeType: string } | null {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+	if (!match) return null
+	const mimeType = match[1]
+	return {
+		bytes: Uint8Array.from(atob(match[2]), c => c.charCodeAt(0)),
+		ext: extensionForMime(mimeType),
+		mimeType,
+	}
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function videoExtFromUrl(url: string): string {
+	const clean = url.split('?')[0].toLowerCase()
+	if (clean.endsWith('.mov')) return 'mov'
+	if (clean.endsWith('.webm')) return 'webm'
+	return 'mp4'
+}
+
+function parseProviderError(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = asRecord(resp.json) || (() => {
+		try { return asRecord(JSON.parse(resp.text || '')) } catch { return null }
+	})()
+	const error = asRecord(body?.error)
+	const msg = stringParam(error?.message || body?.message || resp.text, `HTTP ${resp.status}`)
+	const code = stringParam(error?.code || error?.type || body?.code, '')
+	return `Token360 video: ${code ? code + ' - ' : ''}${msg}`
+}
+
+function extractTaskId(data: unknown): string {
+	const body = asRecord(data)
+	return stringParam(body?.id || body?.task_id || body?.video_id, '')
+}
+
+function extractStatus(data: unknown): string {
+	const body = asRecord(data)
+	return stringParam(body?.status || body?.state, '')
+}
+
+function extractFailure(data: unknown): string {
+	const body = asRecord(data)
+	const error = asRecord(body?.error)
+	return stringParam(error?.message || body?.message || body?.failure_reason, 'Task failed')
+}
+
+function extractVideoUrl(data: unknown): string {
+	const body = asRecord(data)
+	if (!body) return ''
+	const topLevel = stringParam(body.url || body.video_url, '')
+	if (topLevel) return topLevel
+	const content = asRecord(body.content)
+	return stringParam(content?.video_url || content?.url, '')
+}
+
+function addCommonParams(body: JsonRecord, params: Record<string, unknown>): void {
+	const duration = optionalString(params.duration ?? params.durationSeconds)
+	if (duration && duration !== '-1') {
+		const parsed = parseInt(duration, 10)
+		if (Number.isFinite(parsed)) body.duration = parsed
+	}
+
+	const ratio = optionalString(params.ratio ?? params.aspect_ratio ?? params.aspectRatio)
+	if (ratio) body.aspect_ratio = ratio
+
+	const resolution = optionalString(params.resolution)
+	if (resolution) body.resolution = resolution
+
+	const generateAudio = optionalBoolean(params.generate_audio)
+	if (generateAudio !== undefined) body.generate_audio = generateAudio
+}
+
+export class Token360VideoProvider implements VideoProvider {
+	name = 'Token360'
+	private apiKey: string
+	private app: App
+	private outputDir: string
+
+	constructor(apiKey: string, app: App, outputDir: string) {
+		this.apiKey = apiKey
+		this.app = app
+		this.outputDir = outputDir
+	}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const modelId = stringParam(params?.modelId, 'seedance-2.0')
+		const genMode = stringParam(params?.genMode, 'text-to-video')
+		const imageUrls = await Promise.all(stringList(params?.refImages).map(ref => this.ensureUrl(ref, 'image')))
+		const audioUrls = await Promise.all(stringList(params?.refAudios).map(ref => this.ensureUrl(ref, 'audio')))
+		const videoUrls = await Promise.all(stringList(params?.refVideos).map(ref => this.ensureUrl(ref, 'video')))
+
+		if (imageUrls.length > 9) throw new Error('Token360 Seedance supports up to 9 reference images.')
+		if (audioUrls.length > 3) throw new Error('Token360 Seedance supports up to 3 reference audio files.')
+		if (videoUrls.length > 3) throw new Error('Token360 Seedance supports up to 3 reference videos.')
+
+		const body: JsonRecord = { model: modelId, prompt }
+		this.applyMedia(body, genMode, imageUrls, audioUrls, videoUrls)
+		addCommonParams(body, params || {})
+
+		const resp = await requestUrl({
+			url: `${BASE_URL}/videos`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			throw: false,
+			body: JSON.stringify(body),
+		})
+
+		if (resp.status >= 400) throw new Error(parseProviderError(resp))
+		const taskId = extractTaskId(resp.json as unknown)
+		if (!taskId) throw new Error('Token360 video: id was not returned')
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const resp = await requestUrl({
+			url: `${BASE_URL}/videos/${encodeURIComponent(taskId)}`,
+			method: 'GET',
+			headers: { 'Authorization': `Bearer ${this.apiKey}` },
+			throw: false,
+		})
+
+		if (resp.status >= 400) throw new Error(parseProviderError(resp))
+
+		const data = resp.json as unknown
+		const normalized = extractStatus(data).toLowerCase()
+		const videoUrl = extractVideoUrl(data)
+		if (DONE_STATUSES.has(normalized) || videoUrl) {
+			if (!videoUrl) throw new Error('Token360 video: completed task has no video URL')
+			return { done: true, filePath: await this.downloadVideo(videoUrl) }
+		}
+		if (FAILED_STATUSES.has(normalized)) {
+			throw new Error(`Token360 video: ${extractFailure(data)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	private async ensureUrl(ref: string, kind: 'image' | 'audio' | 'video'): Promise<string> {
+		if (isHttpUrl(ref)) return ref
+		if (ref.startsWith('asset://')) return ref
+		const decoded = dataUriToBytes(ref)
+		if (!decoded) throw new Error(`Token360 video: unsupported reference ${kind} format`)
+		return uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `ref.${decoded.ext}`, decoded.mimeType)
+	}
+
+	private applyMedia(body: JsonRecord, genMode: string, imageUrls: string[], audioUrls: string[], videoUrls: string[]): void {
+		if (genMode === 'first-frame') {
+			if (!imageUrls[0]) throw new Error('Token360 Seedance first-frame mode requires one reference image.')
+			body.frame_images = [{
+				type: 'image_url',
+				frame_type: 'first_frame',
+				image_url: { url: imageUrls[0] },
+			}]
+			const refs = [
+				...imageUrls.slice(1).map(url => this.imageReference(url)),
+				...videoUrls.map(url => this.videoReference(url)),
+				...audioUrls.map(url => this.audioReference(url)),
+			]
+			if (refs.length > 0) body.input_references = refs
+			return
+		}
+
+		if (genMode !== 'text-to-video' && genMode !== 'image-ref' && genMode !== 'video-ref') {
+			throw new Error(`Token360 Seedance does not support ${genMode} mode yet.`)
+		}
+
+		if (genMode === 'image-ref' && imageUrls.length === 0) {
+			throw new Error('Token360 Seedance image-ref mode requires at least one reference image.')
+		}
+		if (genMode === 'video-ref' && imageUrls.length + audioUrls.length + videoUrls.length === 0) {
+			throw new Error('Token360 Seedance video-ref mode requires at least one reference input.')
+		}
+
+		const refs = [
+			...imageUrls.map(url => this.imageReference(url)),
+			...videoUrls.map(url => this.videoReference(url)),
+			...audioUrls.map(url => this.audioReference(url)),
+		]
+		if (refs.length > 0) body.input_references = refs
+	}
+
+	private imageReference(url: string): JsonRecord {
+		return { type: 'image_url', role: 'reference', image_url: { url } }
+	}
+
+	private videoReference(url: string): JsonRecord {
+		return { type: 'video_url', role: 'reference', video_url: { url } }
+	}
+
+	private audioReference(url: string): JsonRecord {
+		return { type: 'audio_url', role: 'reference', audio_url: { url } }
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const resp = await requestUrl({ url })
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) await adapter.mkdir(this.outputDir)
+		const filePath = `${this.outputDir}/token360_video_${Date.now()}.${videoExtFromUrl(url)}`
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return filePath
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,6 +104,8 @@ export interface BragiSettings {
 		elevenlabs: string
 		legnext: string
 		tokenrouter: string
+		token360: string
+		token360AssetGroupId: string
 		mulerouter: string
 		apimart: string
 		lumaToken: string
@@ -166,6 +168,8 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		elevenlabs: '',
 		legnext: '',
 		tokenrouter: '',
+		token360: '',
+		token360AssetGroupId: '',
 		mulerouter: '',
 		apimart: '',
 		lumaToken: '',

--- a/src/token360-asset-flow.ts
+++ b/src/token360-asset-flow.ts
@@ -1,0 +1,105 @@
+import type BragiCanvas from './main'
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+import {
+	type Token360AssetCreds,
+	getToken360Asset,
+	isToken360AssetNotFound,
+	uploadToken360Asset,
+	waitForToken360AssetActive,
+} from './providers/token360-assets'
+
+const PROVIDER_KEY = 'token360'
+const IMAGE_EXTS = /\.(png|jpe?g|webp)$/i
+
+function imageExtToMime(ext: string): string {
+	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+	if (ext === 'webp') return 'image/webp'
+	return 'image/png'
+}
+
+function getImageFileInfo(filePath: string): { ext: string; mime: string; filename: string } {
+	const filename = filePath.split('/').pop() || 'ref.png'
+	const ext = (filename.split('.').pop() || '').toLowerCase()
+	if (!IMAGE_EXTS.test(filePath)) {
+		throw new Error(`Token360 assets support PNG, JPG, JPEG, or WebP images only: ${filename}`)
+	}
+	return { ext: ext || 'png', mime: imageExtToMime(ext || 'png'), filename }
+}
+
+function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
+	for (const node of canvas.nodes.values()) {
+		const d = node.getData() as { type?: string; file?: string }
+		if (d.type === 'file' && d.file === filePath) return node
+	}
+	return null
+}
+
+export function getToken360AssetCreds(plugin: BragiCanvas): Token360AssetCreds | null {
+	const providers = plugin.settings.providers
+	const apiKey = (providers.token360 || '').trim()
+	const groupId = (providers.token360AssetGroupId || '').trim()
+	if (!apiKey || !groupId) return null
+	return { apiKey, groupId }
+}
+
+function getCachedAssetId(node: CanvasNode): string | null {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	return d.bragiAssetIds?.[PROVIDER_KEY] || null
+}
+
+function setCachedAssetId(node: CanvasNode, assetId: string): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	const map = { ...(d.bragiAssetIds || {}), [PROVIDER_KEY]: assetId }
+	node.setData({ ...d, bragiAssetIds: map })
+}
+
+function clearCachedAssetId(node: CanvasNode): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	if (!d.bragiAssetIds) return
+	const rest = { ...d.bragiAssetIds }
+	delete rest[PROVIDER_KEY]
+	node.setData({ ...d, bragiAssetIds: rest })
+}
+
+export async function ensureToken360Asset(
+	plugin: BragiCanvas,
+	canvas: Canvas,
+	filePath: string,
+	creds: Token360AssetCreds,
+): Promise<string> {
+	const { mime, filename } = getImageFileInfo(filePath)
+	const node = findNodeByPath(canvas, filePath)
+
+	if (node) {
+		const cached = getCachedAssetId(node)
+		if (cached) {
+			try {
+				const { status } = await getToken360Asset(creds, cached)
+				if (status === 'Active') return `asset://${cached}`
+				if (status === 'Processing') {
+					await waitForToken360AssetActive(creds, cached)
+					return `asset://${cached}`
+				}
+				clearCachedAssetId(node)
+				if (status === 'Rejected') {
+					throw new Error(`Reference image rejected by Token360 review: ${filename}`)
+				}
+				if (status === 'Inactive') {
+					throw new Error(`Reference image inactive in Token360: ${filename}`)
+				}
+			} catch (err: unknown) {
+				if (isToken360AssetNotFound(err)) {
+					clearCachedAssetId(node)
+				} else {
+					throw err
+				}
+			}
+		}
+	}
+
+	const binary = await plugin.app.vault.adapter.readBinary(filePath)
+	const assetId = await uploadToken360Asset(creds, filename, mime, binary)
+	await waitForToken360AssetActive(creds, assetId)
+	if (node) setCachedAssetId(node, assetId)
+	return `asset://${assetId}`
+}


### PR DESCRIPTION
## Summary
- add Token360 as a Seedance provider for existing seedance-2.0 and seedance-2.0-fast models
- support Token360 video task creation, polling, and download
- support optional Token360 asset group uploads for RealFace / Virtual Portrait image refs
- pair with nextbound/bragi-canvas-skill feat/token360-seedance

## Tests
- npm run lint:obsidian
- npm run build
- npm run sync:check from monorepo root
- Token360 connection smoke returned HTTP 200
- Token360 video smoke completed and downloaded output
- Token360 asset smoke uploaded to configured asset group, reached active, generated video, and downloaded output