### PR TITLE
Fix Token360 asset uploads for WebP refs

### DIFF
--- a/src/providers/token360-assets.ts
+++ b/src/providers/token360-assets.ts
@@ -70,8 +70,8 @@ function parseBody(resp: { text?: string; json?: unknown }): JsonRecord | null {
 function extractError(resp: { status: number; text?: string; json?: unknown }): string {
 	const body = parseBody(resp)
 	const error = asRecord(body?.error)
-	const msg = stringValue(error?.message || body?.message || body?.error || resp.text, `HTTP ${resp.status}`)
-	const code = stringValue(error?.code || error?.type || body?.code, '')
+	const msg = stringValue(error?.message || body?.msg || body?.message || body?.error || resp.text, `HTTP ${resp.status}`)
+	const code = stringValue(error?.code || error?.type || body?.serviceCode || body?.code, '')
 	return `${code ? code + ' - ' : ''}${msg}`
 }
 
@@ -79,6 +79,16 @@ function makeError(message: string, status?: number): Error & { status?: number;
 	const err = new Error(message) as Error & { status?: number; code?: string }
 	err.status = status
 	return err
+}
+
+function isSuccessCode(value: unknown): boolean {
+	return value === 0 || value === 200 || value === '0' || value === '200'
+}
+
+function hasApiError(body: JsonRecord): boolean {
+	if (body.success === false) return true
+	if ('code' in body) return !isSuccessCode(body.code)
+	return false
 }
 
 function normalizeStatus(value: unknown): Token360AssetGetResult['status'] {
@@ -128,11 +138,11 @@ export async function uploadToken360Asset(
 		body: concatBytes(parts),
 		throw: false,
 	})
-	if (resp.status < 200 || resp.status >= 300) {
+	const body = parseBody(resp) || {}
+	if (resp.status < 200 || resp.status >= 300 || hasApiError(body)) {
 		throw makeError(`Token360 Upload Asset: ${extractError(resp)}`, resp.status)
 	}
 
-	const body = parseBody(resp) || {}
 	const assetId = extractAssetId(body)
 	if (!assetId) throw new Error('Token360 Upload Asset: no assetId in response')
 	return assetId
@@ -145,11 +155,11 @@ export async function getToken360Asset(creds: Token360AssetCreds, assetId: strin
 		headers: { 'Authorization': `Bearer ${creds.apiKey}` },
 		throw: false,
 	})
-	if (resp.status < 200 || resp.status >= 300) {
+	const body = parseBody(resp) || {}
+	if (resp.status < 200 || resp.status >= 300 || hasApiError(body)) {
 		throw makeError(`Token360 Get Asset: ${extractError(resp)}`, resp.status)
 	}
 
-	const body = parseBody(resp) || {}
 	const nestedData = asRecord(body.data)
 	const result = asRecord(body.result) || asRecord(body.Result)
 	const source = nestedData || result || body

--- a/src/token360-asset-flow.ts
+++ b/src/token360-asset-flow.ts
@@ -9,21 +9,85 @@ import {
 } from './providers/token360-assets'
 
 const PROVIDER_KEY = 'token360'
-const IMAGE_EXTS = /\.(png|jpe?g|webp)$/i
-
 function imageExtToMime(ext: string): string {
 	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
 	if (ext === 'webp') return 'image/webp'
 	return 'image/png'
 }
 
-function getImageFileInfo(filePath: string): { ext: string; mime: string; filename: string } {
-	const filename = filePath.split('/').pop() || 'ref.png'
-	const ext = (filename.split('.').pop() || '').toLowerCase()
-	if (!IMAGE_EXTS.test(filePath)) {
-		throw new Error(`Token360 assets support PNG, JPG, JPEG, or WebP images only: ${filename}`)
+function sniffImageExt(bytes: ArrayBuffer): 'png' | 'jpg' | 'webp' | null {
+	const b = new Uint8Array(bytes)
+	if (b.length >= 8 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'png'
+	if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'jpg'
+	if (
+		b.length >= 12 &&
+		b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+		b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+	) return 'webp'
+	return null
+}
+
+function basenameWithoutExt(filename: string): string {
+	const index = filename.lastIndexOf('.')
+	return index > 0 ? filename.slice(0, index) : filename
+}
+
+function getImageFileInfo(filePath: string, bytes: ArrayBuffer): { ext: 'png' | 'jpg' | 'webp'; mime: string; filename: string } {
+	const originalName = filePath.split('/').pop() || 'ref'
+	const ext = sniffImageExt(bytes)
+	if (!ext) throw new Error(`Token360 assets support PNG, JPG, JPEG, or WebP images only: ${originalName}`)
+	return {
+		ext,
+		mime: imageExtToMime(ext),
+		filename: `${basenameWithoutExt(originalName)}.${ext}`,
 	}
-	return { ext: ext || 'png', mime: imageExtToMime(ext || 'png'), filename }
+}
+
+function convertImageToPng(bytes: ArrayBuffer, mime: string): Promise<ArrayBuffer> {
+	return new Promise((resolve, reject) => {
+		const url = URL.createObjectURL(new Blob([bytes], { type: mime }))
+		const image = new Image()
+		image.onload = () => {
+			const width = image.naturalWidth || image.width
+			const height = image.naturalHeight || image.height
+			URL.revokeObjectURL(url)
+			if (!width || !height) {
+				reject(new Error('Token360 asset upload: image has no dimensions'))
+				return
+			}
+			const canvas = createEl('canvas')
+			canvas.width = width
+			canvas.height = height
+			const ctx = canvas.getContext('2d')
+			if (!ctx) {
+				reject(new Error('Token360 asset upload: could not create image canvas'))
+				return
+			}
+			ctx.drawImage(image, 0, 0)
+			canvas.toBlob(blob => {
+				if (!blob) {
+					reject(new Error('Token360 asset upload: could not convert image to PNG'))
+					return
+				}
+				blob.arrayBuffer().then(resolve, reject)
+			}, 'image/png')
+		}
+		image.onerror = () => {
+			URL.revokeObjectURL(url)
+			reject(new Error('Token360 asset upload: could not decode image'))
+		}
+		image.src = url
+	})
+}
+
+async function prepareUploadImage(filePath: string, bytes: ArrayBuffer): Promise<{ bytes: ArrayBuffer; mime: string; filename: string }> {
+	const info = getImageFileInfo(filePath, bytes)
+	if (info.ext !== 'webp') return { bytes, mime: info.mime, filename: info.filename }
+	return {
+		bytes: await convertImageToPng(bytes, info.mime),
+		mime: 'image/png',
+		filename: `${basenameWithoutExt(info.filename)}.png`,
+	}
 }
 
 function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
@@ -67,7 +131,8 @@ export async function ensureToken360Asset(
 	filePath: string,
 	creds: Token360AssetCreds,
 ): Promise<string> {
-	const { mime, filename } = getImageFileInfo(filePath)
+	const binary = await plugin.app.vault.adapter.readBinary(filePath)
+	const upload = await prepareUploadImage(filePath, binary)
 	const node = findNodeByPath(canvas, filePath)
 
 	if (node) {
@@ -82,10 +147,10 @@ export async function ensureToken360Asset(
 				}
 				clearCachedAssetId(node)
 				if (status === 'Rejected') {
-					throw new Error(`Reference image rejected by Token360 review: ${filename}`)
+					throw new Error(`Reference image rejected by Token360 review: ${upload.filename}`)
 				}
 				if (status === 'Inactive') {
-					throw new Error(`Reference image inactive in Token360: ${filename}`)
+					throw new Error(`Reference image inactive in Token360: ${upload.filename}`)
 				}
 			} catch (err: unknown) {
 				if (isToken360AssetNotFound(err)) {
@@ -97,8 +162,7 @@ export async function ensureToken360Asset(
 		}
 	}
 
-	const binary = await plugin.app.vault.adapter.readBinary(filePath)
-	const assetId = await uploadToken360Asset(creds, filename, mime, binary)
+	const assetId = await uploadToken360Asset(creds, upload.filename, upload.mime, upload.bytes)
 	await waitForToken360AssetActive(creds, assetId)
 	if (node) setCachedAssetId(node, assetId)
 	return `asset://${assetId}`


### PR DESCRIPTION
## Summary
- detect image bytes instead of trusting file extensions for Token360 asset uploads
- convert WebP refs to PNG before uploading to Token360 assets
- treat Token360 JSON business errors as failures even when HTTP status is 200

## Tests
- npm run lint:obsidian
- npm run build
- live upload smoke: converted WebP ref uploaded to legacy_rf_9032 and reached active