### PR TITLE
Fix TokenRouter ModelArk shared asset group handling

### DIFF
--- a/.dev-vault-plugin.example
+++ b/.dev-vault-plugin.example
@@ -1,1 +1,1 @@
-/Users/you/vault/.obsidian/plugins/bragi-canvas
+/path/to/your/vault/.obsidian/plugins/bragi-canvas

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:obsidian": "eslint .",
     "test:update-check": "node scripts/verify-update-check.mjs",
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
+    "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },
   "devDependencies": {

--- a/scripts/verify-tokenrouter-modelark-assets.mjs
+++ b/scripts/verify-tokenrouter-modelark-assets.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const settingsSource = readFileSync('src/settings.ts', 'utf8')
+const registrySource = readFileSync('src/providers/registry.ts', 'utf8')
+const assetFlowSource = readFileSync('src/tokenrouter-asset-flow.ts', 'utf8')
+const modelArkAssetSource = readFileSync('src/providers/tokenrouter-modelark-assets.ts', 'utf8')
+const mainSource = readFileSync('src/main.ts', 'utf8')
+
+function assertOrder(source, first, second, message) {
+	const firstIndex = source.indexOf(first)
+	const secondIndex = source.indexOf(second)
+	assert.notEqual(firstIndex, -1, `${message}: missing "${first}"`)
+	assert.notEqual(secondIndex, -1, `${message}: missing "${second}"`)
+	assert.ok(firstIndex < secondIndex, message)
+}
+
+assert.match(
+	settingsSource,
+	/tokenrouterModelArkAssetGroupId: string/,
+	'TokenRouter settings must include optional ModelArk shared asset group id',
+)
+
+assert.match(
+	settingsSource,
+	/tokenrouterModelArkAssetGroupId: ''/,
+	'TokenRouter shared asset group id must default to empty',
+)
+
+assert.match(
+	registrySource,
+	/key: 'tokenrouterModelArkAssetGroupId', label: 'ModelArk asset group ID \(optional\)'/,
+	'TokenRouter provider settings must expose the shared ModelArk asset group field',
+)
+
+assert.match(
+	assetFlowSource,
+	/plugin\.settings\.providers\.tokenrouterModelArkAssetGroupId/,
+	'TokenRouter ModelArk credentials must read the optional shared group id',
+)
+
+assert.match(
+	assetFlowSource,
+	/new WeakMap<Canvas, Promise<string>>\(\)/,
+	'TokenRouter ModelArk group creation must use an in-memory singleflight lock per canvas',
+)
+
+assertOrder(
+	assetFlowSource,
+	'if (sharedGroupId) return sharedGroupId',
+	'const existing = getCachedGroupId(canvas)',
+	'configured shared group must win before canvas-scoped auto-create cache',
+)
+
+assert.match(
+	assetFlowSource,
+	/shared group is only the ModelArk upload container[\s\S]*explicit asset ids collected from the current canvas edges/,
+	'asset flow must document that shared groups are containers, not implicit generation context',
+)
+
+assert.match(
+	assetFlowSource,
+	/isSharedGroupConfigured\(creds\)[\s\S]*shared asset group not found or inaccessible/,
+	'configured shared group not-found errors must be actionable and must not silently recreate a different group',
+)
+
+assert.match(
+	modelArkAssetSource,
+	/TokenRouter ModelArk asset group quota reached/,
+	'TokenRouter ModelArk group quota errors must be translated into an actionable message',
+)
+
+assert.doesNotMatch(
+	modelArkAssetSource,
+	/GET',\s*'\/asset-groups|\/asset-groups\?/,
+	'Bragi must not list/search ModelArk groups and accidentally select unrelated historical state',
+)
+
+assert.match(
+	mainSource,
+	/provider\.generateVideo\(finalPrompt, \{ \.\.\.params, modelId: apiModelId, genMode: mode, refImages, refAudios, refVideos \}\)/,
+	'video generation must pass only the current explicit reference arrays',
+)
+
+assert.doesNotMatch(
+	mainSource,
+	/listModelArk|searchModelArk|assetGroupAssets|groupAssets/,
+	'video generation must not inject implicit assets from a shared group',
+)
+
+console.log('TokenRouter ModelArk asset flow checks passed.')

--- a/scripts/verify-tokenrouter-modelark-assets.mjs
+++ b/scripts/verify-tokenrouter-modelark-assets.mjs
@@ -15,6 +15,10 @@ function assertOrder(source, first, second, message) {
 	assert.ok(firstIndex < secondIndex, message)
 }
 
+function assertContains(source, needle, message) {
+	assert.ok(source.includes(needle), `${message}: missing "${needle}"`)
+}
+
 assert.match(
 	settingsSource,
 	/tokenrouterModelArkAssetGroupId: string/,
@@ -29,8 +33,20 @@ assert.match(
 
 assert.match(
 	registrySource,
-	/key: 'tokenrouterModelArkAssetGroupId', label: 'ModelArk asset group ID \(optional\)'/,
-	'TokenRouter provider settings must expose the shared ModelArk asset group field',
+	/key: 'tokenrouterModelArkAssetGroupId', label: 'Asset group ID \(optional\)'/,
+	'TokenRouter provider settings must expose the shared ModelArk asset group field with the unified label',
+)
+
+assert.match(
+	registrySource,
+	/key: 'byteplusProjectName', label: 'Asset group ID \(optional\)'/,
+	'BytePlus provider settings must use the unified asset group label',
+)
+
+assert.match(
+	registrySource,
+	/key: 'token360AssetGroupId', label: 'Asset group ID \(optional\)'/,
+	'Token360 provider settings must use the unified asset group label',
 )
 
 assert.match(
@@ -39,41 +55,66 @@ assert.match(
 	'TokenRouter ModelArk credentials must read the optional shared group id',
 )
 
-assert.match(
+assertContains(
 	assetFlowSource,
-	/new WeakMap<Canvas, Promise<string>>\(\)/,
-	'TokenRouter ModelArk group creation must use an in-memory singleflight lock per canvas',
+	'if (!apiKey || !groupId) return null',
+	'TokenRouter ModelArk asset credentials must require both API key and configured group id',
 )
 
-assertOrder(
+assert.doesNotMatch(
 	assetFlowSource,
-	'if (sharedGroupId) return sharedGroupId',
-	'const existing = getCachedGroupId(canvas)',
-	'configured shared group must win before canvas-scoped auto-create cache',
+	/createModelArkAssetGroup|getOrCreateGroupId|tokenrouterModelArkGroupId|WeakMap<Canvas/,
+	'TokenRouter must not auto-create or cache ModelArk asset groups when no group id is configured',
 )
 
-assert.match(
+assertContains(
 	assetFlowSource,
-	/shared group is only the ModelArk upload container[\s\S]*explicit asset ids collected from the current canvas edges/,
-	'asset flow must document that shared groups are containers, not implicit generation context',
-)
-
-assert.match(
-	assetFlowSource,
-	/isSharedGroupConfigured\(creds\)[\s\S]*shared asset group not found or inaccessible/,
-	'configured shared group not-found errors must be actionable and must not silently recreate a different group',
+	'createModelArkAsset(creds, creds.groupId, url, assetType)',
+	'TokenRouter ModelArk asset upload must use only the configured group id',
 )
 
 assert.match(
+	assetFlowSource,
+	/asset group not found or inaccessible[\s\S]*creds\.groupId/,
+	'configured ModelArk group not-found errors must be actionable and must not silently recreate a different group',
+)
+
+assert.doesNotMatch(
 	modelArkAssetSource,
-	/TokenRouter ModelArk asset group quota reached/,
-	'TokenRouter ModelArk group quota errors must be translated into an actionable message',
+	/createModelArkAssetGroup|POST',\s*'\/asset-groups'|TokenRouter ModelArk asset group quota reached/,
+	'Bragi must not create TokenRouter ModelArk asset groups',
 )
 
 assert.doesNotMatch(
 	modelArkAssetSource,
 	/GET',\s*'\/asset-groups|\/asset-groups\?/,
 	'Bragi must not list/search ModelArk groups and accidentally select unrelated historical state',
+)
+
+assertOrder(
+	mainSource,
+	'const tokenRouterModelArkCreds = (activeProvider === \'tokenrouter\' && isSeedanceModel && hasSeedanceMediaRefs)',
+	'const supportsSeedanceAssetRefs = isNativeSeedance || !!tokenRouterModelArkCreds',
+	'TokenRouter asset:// refs must only be enabled after configured ModelArk credentials are known',
+)
+
+assertOrder(
+	mainSource,
+	'const supportsSeedanceAssetRefs = isNativeSeedance || !!tokenRouterModelArkCreds',
+	'const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}',
+	'TokenRouter no-groupId path must not read existing tokenrouter asset id cache',
+)
+
+assert.match(
+	mainSource,
+	/else if \(activeProvider === 'tokenrouter' && isSeedanceModel\) \{[\s\S]*uploadRef\(undefined, binary, `ref\.\$\{ext\}`, imageMimeType\(imgPath\)\)/,
+	'TokenRouter Seedance no-groupId image refs must be uploaded as relay URLs, not data URIs or asset:// refs',
+)
+
+assert.match(
+	mainSource,
+	/else if \(tokenRouterModelArkCreds\) \{[\s\S]*ensureTokenRouterModelArkAsset\(this, canvas, imgPath, tokenRouterModelArkCreds\)/,
+	'TokenRouter Seedance configured group path must upload image refs through ModelArk assets',
 )
 
 assert.match(

--- a/src/main.ts
+++ b/src/main.ts
@@ -551,10 +551,7 @@ export default class BragiCanvas extends Plugin {
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7-i2v-spicy'
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
-			const supportsSeedanceAssetRefs = isNativeSeedance || (activeProvider === 'tokenrouter' && isSeedanceModel)
-			const supportsSeedanceUrlRefs = supportsSeedanceAssetRefs || (activeProvider === 'token360' && isSeedanceModel)
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
-			const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
 			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && hasSeedanceMediaRefs)
 				? getBytePlusAssetCreds(this)
@@ -562,6 +559,11 @@ export default class BragiCanvas extends Plugin {
 			const tokenRouterModelArkCreds = (activeProvider === 'tokenrouter' && isSeedanceModel && hasSeedanceMediaRefs)
 				? getTokenRouterModelArkCreds(this)
 				: null
+			const supportsSeedanceAssetRefs = isNativeSeedance || !!tokenRouterModelArkCreds
+			const supportsSeedanceUrlRefs = supportsSeedanceAssetRefs
+				|| (activeProvider === 'tokenrouter' && isSeedanceModel)
+				|| (activeProvider === 'token360' && isSeedanceModel)
+			const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}
 			const token360AssetCreds = (activeProvider === 'token360' && isSeedanceModel && uniqueImages.length > 0)
 				? getToken360AssetCreds(this)
 				: null
@@ -575,6 +577,10 @@ export default class BragiCanvas extends Plugin {
 					refImages.push(await ensureTokenRouterModelArkAsset(this, canvas, imgPath, tokenRouterModelArkCreds))
 				} else if (token360AssetCreds) {
 					refImages.push(await ensureToken360Asset(this, canvas, imgPath, token360AssetCreds))
+				} else if (activeProvider === 'tokenrouter' && isSeedanceModel) {
+					const binary = await this.app.vault.adapter.readBinary(imgPath)
+					const ext = getFileExtension(imgPath, 'png')
+					refImages.push(await uploadRef(undefined, binary, `ref.${ext}`, imageMimeType(imgPath)))
 				} else if (isMuleRouterWan) {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const ext = getFileExtension(imgPath, 'png')

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -232,7 +232,7 @@ export const PROVIDERS: ProviderSpec[] = [
 			{ key: 'byteplus', label: 'ARK API Key', placeholder: '...', type: 'password' },
 			{ key: 'byteplusAccessKey', label: 'Access Key (optional)', placeholder: 'AK...', type: 'password' },
 			{ key: 'byteplusSecretKey', label: 'Secret Key (optional)', placeholder: 'SK...', type: 'password' },
-			{ key: 'byteplusProjectName', label: 'Project Name (optional)', placeholder: 'default', type: 'text' },
+			{ key: 'byteplusProjectName', label: 'Asset group ID (optional)', placeholder: 'default', type: 'text' },
 		],
 		isConfigured: (s) => !!s.providers.byteplus,
 		makeVideo: ({ settings, app, outputDir }) =>
@@ -407,7 +407,7 @@ export const PROVIDERS: ProviderSpec[] = [
 		docUrl: 'https://www.tokenrouter.com',
 		fields: [
 			{ key: 'tokenrouter', label: 'API Key', placeholder: 'sk-...', type: 'password' },
-			{ key: 'tokenrouterModelArkAssetGroupId', label: 'ModelArk asset group ID (optional)', placeholder: 'asset_group_id', type: 'text' },
+			{ key: 'tokenrouterModelArkAssetGroupId', label: 'Asset group ID (optional)', placeholder: 'asset_group_id', type: 'text' },
 		],
 		isConfigured: (s) => !!s.providers.tokenrouter,
 		makeImage: ({ settings, app, outputDir }) =>

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -405,7 +405,10 @@ export const PROVIDERS: ProviderSpec[] = [
 		name: 'TokenRouter',
 		description: 'All-in-one model gateway.',
 		docUrl: 'https://www.tokenrouter.com',
-		fields: [{ key: 'tokenrouter', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
+		fields: [
+			{ key: 'tokenrouter', label: 'API Key', placeholder: 'sk-...', type: 'password' },
+			{ key: 'tokenrouterModelArkAssetGroupId', label: 'ModelArk asset group ID (optional)', placeholder: 'asset_group_id', type: 'text' },
+		],
 		isConfigured: (s) => !!s.providers.tokenrouter,
 		makeImage: ({ settings, app, outputDir }) =>
 			new TokenRouterImageProvider(settings.providers.tokenrouter, app, outputDir, 'https://api.tokenrouter.com/v1'),

--- a/src/providers/tokenrouter-modelark-assets.ts
+++ b/src/providers/tokenrouter-modelark-assets.ts
@@ -9,7 +9,7 @@ type JsonRecord = Record<string, unknown>
 
 export interface TokenRouterModelArkCreds {
 	apiKey: string
-	groupId?: string
+	groupId: string
 }
 
 export interface ModelArkAssetGetResult {
@@ -39,10 +39,6 @@ function makeError(message: string, status?: number): Error & { status?: number;
 	return err
 }
 
-function isAssetGroupQuotaMessage(message: string): boolean {
-	return /maximum\s+limit.*groups|number\s+of\s+groups.*create|asset\s+group.*quota/i.test(message)
-}
-
 async function callModelArk(
 	creds: TokenRouterModelArkCreds,
 	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
@@ -66,26 +62,9 @@ async function callModelArk(
 	const success = parsed?.success
 	if (resp.status < 200 || resp.status >= 300 || success === false) {
 		const msg = stringValue(parsed?.message || parsed?.error || resp.text, `HTTP ${resp.status}`)
-		if (method === 'POST' && path === '/asset-groups' && isAssetGroupQuotaMessage(msg)) {
-			throw makeError(
-				`TokenRouter ModelArk asset group quota reached. Configure a shared ModelArk asset group ID, switch Seedance provider, or ask TokenRouter to delete or raise asset groups. Original: ${msg}`,
-				resp.status,
-			)
-		}
 		throw makeError(`TokenRouter ModelArk ${method} ${path}: ${msg}`, resp.status)
 	}
 	return asRecord(parsed?.data) || parsed || {}
-}
-
-export async function createModelArkAssetGroup(creds: TokenRouterModelArkCreds): Promise<string> {
-	const result = await callModelArk(creds, 'POST', '/asset-groups', {
-		Name: `bragi_${randomHex(8)}`,
-		Description: 'Bragi Canvas',
-		GroupType: 'AIGC',
-	})
-	const groupId = stringValue(result.Id || result.id, '')
-	if (!groupId) throw new Error('TokenRouter ModelArk CreateAssetGroup: no Id in response')
-	return groupId
 }
 
 export async function createModelArkAsset(

--- a/src/providers/tokenrouter-modelark-assets.ts
+++ b/src/providers/tokenrouter-modelark-assets.ts
@@ -9,6 +9,7 @@ type JsonRecord = Record<string, unknown>
 
 export interface TokenRouterModelArkCreds {
 	apiKey: string
+	groupId?: string
 }
 
 export interface ModelArkAssetGetResult {
@@ -38,6 +39,10 @@ function makeError(message: string, status?: number): Error & { status?: number;
 	return err
 }
 
+function isAssetGroupQuotaMessage(message: string): boolean {
+	return /maximum\s+limit.*groups|number\s+of\s+groups.*create|asset\s+group.*quota/i.test(message)
+}
+
 async function callModelArk(
 	creds: TokenRouterModelArkCreds,
 	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
@@ -61,6 +66,12 @@ async function callModelArk(
 	const success = parsed?.success
 	if (resp.status < 200 || resp.status >= 300 || success === false) {
 		const msg = stringValue(parsed?.message || parsed?.error || resp.text, `HTTP ${resp.status}`)
+		if (method === 'POST' && path === '/asset-groups' && isAssetGroupQuotaMessage(msg)) {
+			throw makeError(
+				`TokenRouter ModelArk asset group quota reached. Configure a shared ModelArk asset group ID, switch Seedance provider, or ask TokenRouter to delete or raise asset groups. Original: ${msg}`,
+				resp.status,
+			)
+		}
 		throw makeError(`TokenRouter ModelArk ${method} ${path}: ${msg}`, resp.status)
 	}
 	return asRecord(parsed?.data) || parsed || {}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -104,6 +104,7 @@ export interface BragiSettings {
 		elevenlabs: string
 		legnext: string
 		tokenrouter: string
+		tokenrouterModelArkAssetGroupId: string
 		token360: string
 		token360AssetGroupId: string
 		mulerouter: string
@@ -168,6 +169,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		elevenlabs: '',
 		legnext: '',
 		tokenrouter: '',
+		tokenrouterModelArkAssetGroupId: '',
 		token360: '',
 		token360AssetGroupId: '',
 		mulerouter: '',

--- a/src/tokenrouter-asset-flow.ts
+++ b/src/tokenrouter-asset-flow.ts
@@ -4,7 +4,6 @@ import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { uploadRef } from './providers/upload'
 import {
 	createModelArkAsset,
-	createModelArkAssetGroup,
 	getModelArkAsset,
 	isModelArkAssetNotFound,
 	isModelArkGroupNotFound,
@@ -13,8 +12,6 @@ import {
 import type { TokenRouterModelArkCreds } from './providers/tokenrouter-modelark-assets'
 
 const PROVIDER_KEY = 'tokenrouter'
-const GROUP_ID_KEY = 'tokenrouterModelArkGroupId'
-const groupCreateInFlightByCanvas = new WeakMap<Canvas, Promise<string>>()
 
 type TokenRouterModelArkAssetType = 'Image' | 'Audio' | 'Video'
 
@@ -68,62 +65,8 @@ function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
 export function getTokenRouterModelArkCreds(plugin: BragiCanvas): TokenRouterModelArkCreds | null {
 	const apiKey = (plugin.settings.providers.tokenrouter || '').trim()
 	const groupId = (plugin.settings.providers.tokenrouterModelArkAssetGroupId || '').trim()
-	return apiKey ? { apiKey, ...(groupId ? { groupId } : {}) } : null
-}
-
-function isSharedGroupConfigured(creds: TokenRouterModelArkCreds): boolean {
-	return !!creds.groupId?.trim()
-}
-
-function configuredGroupId(creds: TokenRouterModelArkCreds): string | null {
-	const groupId = creds.groupId?.trim()
-	return groupId || null
-}
-
-function getCachedGroupId(canvas: Canvas): string | null {
-	const data = canvas.getData() as { bragi?: Record<string, unknown> }
-	const existing = data.bragi?.[GROUP_ID_KEY]
-	return typeof existing === 'string' && existing ? existing : null
-}
-
-async function createAndCacheGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
-	const groupId = await createModelArkAssetGroup(creds)
-	const current = canvas.getData() as { bragi?: Record<string, unknown> }
-	canvas.importData({
-		...current,
-		bragi: { ...(current.bragi || {}), [GROUP_ID_KEY]: groupId },
-	} as unknown as Parameters<Canvas['importData']>[0])
-	void canvas.requestSave()
-	return groupId
-}
-
-async function getOrCreateGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
-	// A shared group is only the ModelArk upload container. The generation payload
-	// still uses only the explicit asset ids collected from the current canvas edges.
-	const sharedGroupId = configuredGroupId(creds)
-	if (sharedGroupId) return sharedGroupId
-
-	const existing = getCachedGroupId(canvas)
-	if (existing) return existing
-
-	const inFlight = groupCreateInFlightByCanvas.get(canvas)
-	if (inFlight) return inFlight
-
-	let createPromise: Promise<string>
-	createPromise = createAndCacheGroupId(canvas, creds).finally(() => {
-		if (groupCreateInFlightByCanvas.get(canvas) === createPromise) groupCreateInFlightByCanvas.delete(canvas)
-	})
-	groupCreateInFlightByCanvas.set(canvas, createPromise)
-	return createPromise
-}
-
-function clearGroupId(canvas: Canvas): void {
-	const current = canvas.getData() as { bragi?: Record<string, unknown> }
-	if (!current.bragi?.[GROUP_ID_KEY]) return
-	const rest = { ...current.bragi }
-	delete rest[GROUP_ID_KEY]
-	canvas.importData({ ...current, bragi: rest } as unknown as Parameters<Canvas['importData']>[0])
-	void canvas.requestSave()
+	if (!apiKey || !groupId) return null
+	return { apiKey, groupId }
 }
 
 function getCachedAssetId(node: CanvasNode): string | null {
@@ -185,20 +128,14 @@ export async function ensureTokenRouterModelArkAsset(
 	const binary = await adapter.readBinary(filePath)
 	const url = await uploadRef(undefined, binary, `ref.${ext}`, mime)
 
-	let groupId = await getOrCreateGroupId(canvas, creds)
 	let assetId: string
 	try {
-		assetId = await createModelArkAsset(creds, groupId, url, assetType)
+		assetId = await createModelArkAsset(creds, creds.groupId, url, assetType)
 	} catch (err: unknown) {
 		if (isModelArkGroupNotFound(err)) {
-			if (isSharedGroupConfigured(creds)) {
-				throw new Error(
-					`TokenRouter ModelArk shared asset group not found or inaccessible: ${creds.groupId}. Check the TokenRouter provider settings, switch Seedance provider, or ask TokenRouter to restore or create the group.`,
-				)
-			}
-			clearGroupId(canvas)
-			groupId = await getOrCreateGroupId(canvas, creds)
-			assetId = await createModelArkAsset(creds, groupId, url, assetType)
+			throw new Error(
+				`TokenRouter ModelArk asset group not found or inaccessible: ${creds.groupId}. Check the TokenRouter provider settings, switch Seedance provider, or ask TokenRouter to restore or create the group.`,
+			)
 		} else {
 			throw err
 		}

--- a/src/tokenrouter-asset-flow.ts
+++ b/src/tokenrouter-asset-flow.ts
@@ -14,6 +14,7 @@ import type { TokenRouterModelArkCreds } from './providers/tokenrouter-modelark-
 
 const PROVIDER_KEY = 'tokenrouter'
 const GROUP_ID_KEY = 'tokenrouterModelArkGroupId'
+const groupCreateInFlightByCanvas = new WeakMap<Canvas, Promise<string>>()
 
 type TokenRouterModelArkAssetType = 'Image' | 'Audio' | 'Video'
 
@@ -66,13 +67,26 @@ function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
 
 export function getTokenRouterModelArkCreds(plugin: BragiCanvas): TokenRouterModelArkCreds | null {
 	const apiKey = (plugin.settings.providers.tokenrouter || '').trim()
-	return apiKey ? { apiKey } : null
+	const groupId = (plugin.settings.providers.tokenrouterModelArkAssetGroupId || '').trim()
+	return apiKey ? { apiKey, ...(groupId ? { groupId } : {}) } : null
 }
 
-async function getOrCreateGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
+function isSharedGroupConfigured(creds: TokenRouterModelArkCreds): boolean {
+	return !!creds.groupId?.trim()
+}
+
+function configuredGroupId(creds: TokenRouterModelArkCreds): string | null {
+	const groupId = creds.groupId?.trim()
+	return groupId || null
+}
+
+function getCachedGroupId(canvas: Canvas): string | null {
 	const data = canvas.getData() as { bragi?: Record<string, unknown> }
 	const existing = data.bragi?.[GROUP_ID_KEY]
-	if (typeof existing === 'string' && existing) return existing
+	return typeof existing === 'string' && existing ? existing : null
+}
+
+async function createAndCacheGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
 	const groupId = await createModelArkAssetGroup(creds)
 	const current = canvas.getData() as { bragi?: Record<string, unknown> }
 	canvas.importData({
@@ -81,6 +95,26 @@ async function getOrCreateGroupId(canvas: Canvas, creds: TokenRouterModelArkCred
 	} as unknown as Parameters<Canvas['importData']>[0])
 	void canvas.requestSave()
 	return groupId
+}
+
+async function getOrCreateGroupId(canvas: Canvas, creds: TokenRouterModelArkCreds): Promise<string> {
+	// A shared group is only the ModelArk upload container. The generation payload
+	// still uses only the explicit asset ids collected from the current canvas edges.
+	const sharedGroupId = configuredGroupId(creds)
+	if (sharedGroupId) return sharedGroupId
+
+	const existing = getCachedGroupId(canvas)
+	if (existing) return existing
+
+	const inFlight = groupCreateInFlightByCanvas.get(canvas)
+	if (inFlight) return inFlight
+
+	let createPromise: Promise<string>
+	createPromise = createAndCacheGroupId(canvas, creds).finally(() => {
+		if (groupCreateInFlightByCanvas.get(canvas) === createPromise) groupCreateInFlightByCanvas.delete(canvas)
+	})
+	groupCreateInFlightByCanvas.set(canvas, createPromise)
+	return createPromise
 }
 
 function clearGroupId(canvas: Canvas): void {
@@ -157,6 +191,11 @@ export async function ensureTokenRouterModelArkAsset(
 		assetId = await createModelArkAsset(creds, groupId, url, assetType)
 	} catch (err: unknown) {
 		if (isModelArkGroupNotFound(err)) {
+			if (isSharedGroupConfigured(creds)) {
+				throw new Error(
+					`TokenRouter ModelArk shared asset group not found or inaccessible: ${creds.groupId}. Check the TokenRouter provider settings, switch Seedance provider, or ask TokenRouter to restore or create the group.`,
+				)
+			}
 			clearGroupId(canvas)
 			groupId = await getOrCreateGroupId(canvas, creds)
 			assetId = await createModelArkAsset(creds, groupId, url, assetType)


### PR DESCRIPTION
## Summary
- add an optional TokenRouter ModelArk shared asset group ID provider setting
- reuse the configured group before canvas-scoped auto-create, with a per-canvas singleflight lock for fallback group creation
- translate ModelArk asset group quota failures into an actionable message
- add a regression script that verifies shared groups are treated only as upload containers and generation still receives only the current explicit reference arrays
- sanitize the dev vault plugin example path so the pre-public sweep has no Layer 1-4 blockers

## Consistency boundary
A shared ModelArk group is not used as implicit generation context. Bragi still uploads/validates only the current connected refs and passes only those explicit `asset://...` ids in `refImages`, `refAudios`, and `refVideos`. The code does not list/search group assets or inject historical assets from the shared group.

## Verification
- `npm run test:tokenrouter-modelark-assets`
- `npm run test:text-multimodal`
- `npm run test:gemini-video-text`
- `npm run test:update-check`
- `npm run build`
- `npm run lint:obsidian`
- `~/.claude/scripts/pre-public-sweep.sh /Users/zane/work/storyverse/bragi/worktrees/fix-tokenrouter-modelark-shared-group` (0 Layer 1-4 blockers; warnings only for existing author history / README copyright / CONTRIBUTING)

## Notes
`npm ci` reported existing dependency audit warnings: 3 moderate and 1 high. This PR does not change dependencies.