### PR TITLE
Validate cached Seedance asset refs before use

### DIFF
--- a/scripts/verify-tokenrouter-modelark-assets.mjs
+++ b/scripts/verify-tokenrouter-modelark-assets.mjs
@@ -105,6 +105,27 @@ assertOrder(
 	'TokenRouter no-groupId path must not read existing tokenrouter asset id cache',
 )
 
+assertOrder(
+	mainSource,
+	'if (bytePlusCreds) {',
+	'else if (assetIdMap[imgPath]) {',
+	'BytePlus image refs must validate cached asset ids through ensureBytePlusAsset before direct asset:// fallback',
+)
+
+assertOrder(
+	mainSource,
+	'else if (tokenRouterModelArkCreds) {',
+	'else if (assetIdMap[imgPath]) {',
+	'TokenRouter image refs must validate cached asset ids through ensureTokenRouterModelArkAsset before direct asset:// fallback',
+)
+
+assertOrder(
+	mainSource,
+	'else if (token360AssetCreds) {',
+	'else if (assetIdMap[imgPath]) {',
+	'Token360 image refs must validate cached asset ids through ensureToken360Asset before direct asset:// fallback',
+)
+
 assert.match(
 	mainSource,
 	/else if \(activeProvider === 'tokenrouter' && isSeedanceModel\) \{[\s\S]*uploadRef\(undefined, binary, `ref\.\$\{ext\}`, imageMimeType\(imgPath\)\)/,

--- a/src/main.ts
+++ b/src/main.ts
@@ -570,15 +570,15 @@ export default class BragiCanvas extends Plugin {
 				? getToken360AssetCreds(this)
 				: null
 			for (const imgPath of uniqueImages) {
-				if (assetIdMap[imgPath]) {
-					refImages.push(`asset://${assetIdMap[imgPath]}`)
-				} else if (bytePlusCreds) {
+				if (bytePlusCreds) {
 					// Run through BytePlus asset library so faces can be reviewed+approved
 					refImages.push(await ensureBytePlusAsset(this, canvas, imgPath, bytePlusCreds))
 				} else if (tokenRouterModelArkCreds) {
 					refImages.push(await ensureTokenRouterModelArkAsset(this, canvas, imgPath, tokenRouterModelArkCreds))
 				} else if (token360AssetCreds) {
 					refImages.push(await ensureToken360Asset(this, canvas, imgPath, token360AssetCreds))
+				} else if (assetIdMap[imgPath]) {
+					refImages.push(`asset://${assetIdMap[imgPath]}`)
 				} else if (activeProvider === 'tokenrouter' && isSeedanceModel) {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const ext = getFileExtension(imgPath, 'png')


### PR DESCRIPTION
## Summary
- route BytePlus, TokenRouter ModelArk, and Token360 image refs through their ensure*Asset flows before direct asset:// fallback
- keep Volcengine/bytedance manual asset IDs unchanged
- add static regression checks for managed provider ordering

## Tests
- npm run test:tokenrouter-modelark-assets
- npm run build
- npm run lint:obsidian
- git diff --check

## Notes
- Live Canvas MCP testing was attempted, but the local Bragi MCP endpoint listened on port 17775 without responding and caused the Obsidian renderer to spin. The app was restarted and local provider prefs were restored.
- Current local TokenRouter settings also have no ModelArk asset group id, so that live path needs configured credentials before it can be exercised.