### PR TITLE
Add APIMart Omni-Flash video support

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -70,6 +70,7 @@ This repository is an Obsidian community plugin. Treat Obsidian Community review
 ## Reference Asset Upload Policy
 
 - When a provider needs a publicly fetchable reference asset URL, prefer the built-in Bragi temporary relay path first (`src/providers/upload.ts` + `src/providers/bragi-relay.ts`) and pass the returned public URL into the model request.
+- Before uploading a reference image, preserve PNG/JPEG bytes as-is and convert every other image format to PNG. Keep this normalization in the shared upload preparation helper instead of adding provider-specific WebP/GIF/BMP branches.
 - Keep upload endpoints and model-input URL endpoints conceptually separate. The relay upload API endpoint is only for writing bytes; the model request must receive the returned fetchable asset URL, not the upload endpoint.
 - Use a provider's own upload/File API only when that provider cannot consume a Bragi Relay HTTPS URL, or when it explicitly requires provider-native file IDs/URIs for the requested feature.
 - Do not write provider keys, relay tokens, uploaded asset URLs, or temporary media files into the repository. Keep live-test outputs summarized and redacted.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -1,0 +1,22 @@
+# Model Provider Rules
+
+Use these checks when adding a built-in model/provider pairing:
+
+- Add the model as a `ModelConfig` in `src/models/*`, then register it in `ALL_MODELS`.
+- Put provider-specific model IDs in `supportedProviders`; runtime code should receive the API model ID through `params.modelId`.
+- Add `makeImage`, `makeVideo`, `makeText`, or `makeAudio` on the provider spec only for modalities the provider can actually run.
+- Keep model params aligned with provider validation so saved settings or stale UI state fail with a clear message.
+- For async video, return `{ done: false, taskId }` from `generateVideo`, implement `checkStatus`, and download the completed asset into `outputDir`.
+- Upload local upstream media with the built-in Bragi temporary relay before sending it to providers that require public URLs.
+
+## APIMart Omni-Flash-Ext
+
+- Endpoint: `POST https://api.apimart.ai/v1/videos/generations`.
+- Model ID: `Omni-Flash-Ext`.
+- Task status: `GET https://api.apimart.ai/v1/tasks/{task_id}`.
+- Supported video modes in Bragi: text-to-video, first-frame image-to-video, three-image reference fusion, and one reference video.
+- All APIMart reference media must be sent as Bragi temporary relay URLs. Data URIs and external URLs must be uploaded or re-uploaded with `uploadRef` before they are assigned to `image_urls` or `video_urls`.
+- Reference image count must be 0, 1, or 3. Two images are rejected by the provider.
+- Reference video count must be 0 or 1. When `video_urls` is present, omit `duration`.
+- Supported duration values are 4, 6, 8, and 10 seconds.
+- Supported resolution values are `720p`, `1080p`, and `4k`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:obsidian": "eslint .",
     "test:update-check": "node scripts/verify-update-check.mjs",
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
+    "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },

--- a/scripts/verify-reference-image-upload.mjs
+++ b/scripts/verify-reference-image-upload.mjs
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const helperSource = readFileSync('src/providers/image-upload-prep.ts', 'utf8')
+const uploadSource = readFileSync('src/providers/upload.ts', 'utf8')
+const token360FlowSource = readFileSync('src/token360-asset-flow.ts', 'utf8')
+const openaiSource = readFileSync('src/providers/openai.ts', 'utf8')
+const tokenrouterSource = readFileSync('src/providers/tokenrouter.ts', 'utf8')
+const agentSource = readFileSync('AGENT.md', 'utf8')
+
+function assertOrder(source, first, second, message) {
+	const firstIndex = source.indexOf(first)
+	const secondIndex = source.indexOf(second)
+	assert.notEqual(firstIndex, -1, `${message}: missing "${first}"`)
+	assert.notEqual(secondIndex, -1, `${message}: missing "${second}"`)
+	assert.ok(firstIndex < secondIndex, message)
+}
+
+assert.match(
+	helperSource,
+	/export async function prepareReferenceUpload/,
+	'reference upload helper must expose the shared preparation function',
+)
+
+assert.match(
+	helperSource,
+	/sourceMime\.startsWith\('image\/'\)/,
+	'reference upload helper must detect image uploads before applying image normalization',
+)
+
+assert.match(
+	helperSource,
+	/isPngOrJpeg\(sourceMime\)[\s\S]*contentType: normalizedMime/,
+	'reference upload helper must pass through PNG/JPEG uploads with normalized content type',
+)
+
+assert.match(
+	helperSource,
+	/convertImageToPng\(bytes, sourceMime, context\)[\s\S]*contentType: 'image\/png'/,
+	'reference upload helper must convert non-PNG/JPEG image uploads to PNG',
+)
+
+assert.match(
+	helperSource,
+	/image decode timed out/,
+	'reference upload helper must fail stuck image decodes instead of leaving generation placeholders hanging',
+)
+
+assertOrder(
+	uploadSource,
+	'prepareReferenceUpload(fileData, fileName, contentType',
+	'uploadToBragiRelay(BUILTIN_BRAGI_RELAY, prepared.bytes, prepared.fileName, prepared.contentType)',
+	'Bragi Relay uploads must normalize reference images before sending bytes to the relay',
+)
+
+assert.match(
+	token360FlowSource,
+	/import \{ imageMimeTypeFromFileName, prepareReferenceUpload \} from '\.\/providers\/image-upload-prep'/,
+	'Token360 asset flow must reuse the shared reference upload helper',
+)
+
+assert.doesNotMatch(
+	token360FlowSource,
+	/function (convertImageToPng|sniffImageExt|imageExtToMime)/,
+	'Token360 asset flow must not keep provider-local image conversion helpers',
+)
+
+assert.match(
+	openaiSource,
+	/prepareReferenceUpload\([\s\S]*'OpenAI image edit upload'[\s\S]*appendFile\('image\[\]', prepared\.fileName, prepared\.contentType/,
+	'OpenAI image edit multipart uploads must use the shared image normalization helper',
+)
+
+assert.match(
+	tokenrouterSource,
+	/prepareReferenceUpload\([\s\S]*'TokenRouter image edit upload'[\s\S]*appendMultipartFile\(parts, boundary, 'image\[\]', prepared\.fileName, prepared\.contentType/,
+	'TokenRouter image edit multipart uploads must use the shared image normalization helper',
+)
+
+assert.match(
+	agentSource,
+	/preserve PNG\/JPEG bytes as-is and convert every other image format to PNG/,
+	'AGENT.md must document the reference image upload normalization rule',
+)
+
+console.log('Reference image upload normalization checks passed.')

--- a/src/main.ts
+++ b/src/main.ts
@@ -552,6 +552,7 @@ export default class BragiCanvas extends Plugin {
 			// Seedance can consume provider-specific asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7-i2v-spicy'
+			const supportsApimartVideoRef = activeProvider === 'apimart' && model.id === 'omni-flash-ext'
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
@@ -620,11 +621,14 @@ export default class BragiCanvas extends Plugin {
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
-				if (mode === 'video-ref' && !supportsSeedanceUrlRefs) {
-					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance.')
+				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef) {
+					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance, or APIMart Omni-Flash-Ext.')
 				}
 				if (supportsSeedanceUrlRefs && uniqueVideos.length > 3) {
 					throw new Error('Seedance supports up to 3 reference videos.')
+				}
+				if (supportsApimartVideoRef && uniqueVideos.length > 1) {
+					throw new Error('APIMart Omni-Flash-Ext supports at most 1 reference video.')
 				}
 				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
 					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -11,6 +11,7 @@ import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
 import { lumaUni1 } from './luma'
+import { omniFlashExt } from './omni-flash'
 import {
 	elevenLabsTTS,
 	minimaxTTS,
@@ -46,6 +47,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	veo31,
 	veo31Lite,
 	grokVideo,
+	omniFlashExt,
 	// Text
 	claudeOpus47,
 	claudeSonnet46,

--- a/src/models/omni-flash.ts
+++ b/src/models/omni-flash.ts
@@ -1,0 +1,46 @@
+import type { ModelConfig } from './types'
+
+export const omniFlashExt: ModelConfig = {
+	id: 'omni-flash-ext',
+	name: 'Omni-Flash-Ext',
+	type: 'video',
+	supportedProviders: {
+		apimart: { apiModelId: 'Omni-Flash-Ext' },
+	},
+	modes: ['text-to-video', 'first-frame', 'multi-image-ref', 'video-ref'],
+	params: [
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'select',
+			options: [
+				{ label: '4s', value: '4' },
+				{ label: '6s', value: '6' },
+				{ label: '8s', value: '8' },
+				{ label: '10s', value: '10' },
+			],
+			default: '6',
+		},
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '720p', value: '720p' },
+				{ label: '1080p', value: '1080p' },
+				{ label: '4K', value: '4k' },
+			],
+			default: '720p',
+		},
+		{
+			id: 'aspect_ratio',
+			label: 'Ratio',
+			type: 'select',
+			options: [
+				{ label: '16:9', value: '16:9' },
+				{ label: '9:16', value: '9:16' },
+			],
+			default: '16:9',
+		},
+	],
+}

--- a/src/providers/apimart.ts
+++ b/src/providers/apimart.ts
@@ -1,23 +1,32 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Obsidian Canvas internals and provider payloads are runtime-shaped data that this plugin narrows at use sites. */
-import type { ImageProvider, GenerateImageResult } from './types'
+import type { ImageProvider, GenerateImageResult, GenerateVideoResult, VideoProvider } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
 import { stringParam } from './params'
+import { BUILTIN_BRAGI_RELAY } from './bragi-relay'
+import { uploadRef } from './upload'
 
 /**
- * APIMart image provider.
+ * APIMart provider.
  *
  * APIMart image models share the same async flow:
  *   1. POST /v1/images/generations → { data: [{ task_id, status }] }
  *   2. GET  /v1/tasks/{task_id}    → polls; on "completed" returns result.images[0].url[0]
  *   3. Download that URL and write to the vault.
+ *
+ * Omni-Flash-Ext video generation uses the same task endpoint, with
+ * videos returned at result.videos[0].url[0].
  */
 const DEFAULT_MODEL = 'gpt-image-2'
+const DEFAULT_VIDEO_MODEL = 'Omni-Flash-Ext'
 
 const API_BASE = 'https://api.apimart.ai/v1'
 const POLL_INTERVAL_MS = 3000
 const FIRST_POLL_DELAY_MS = 10000
 const MAX_WAIT_MS = 300000
+const VIDEO_DURATIONS = new Set([4, 6, 8, 10])
+const BRAGI_RELAY_BASE = BUILTIN_BRAGI_RELAY.endpoint.replace(/\/+$/, '')
+type RelayAssetKind = 'image' | 'video'
 
 async function sleep(ms: number): Promise<void> {
 	return new Promise(r => window.setTimeout(r, ms))
@@ -33,8 +42,75 @@ function stringifyDetail(value: unknown): string {
 	}
 }
 
-export class APIMartProvider implements ImageProvider {
-	name = 'APIMart Image'
+function arrayParam(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : []
+}
+
+function parseApimartError(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = resp.json || (() => { try { return JSON.parse(resp.text || '') } catch { return null } })()
+	const detail = body?.error?.message || body?.message || body?.error || resp.text || `HTTP ${resp.status}`
+	const code = body?.error?.code || body?.code || body?.type || ''
+	const msg = stringifyDetail(detail)
+	return `${code ? code + ' — ' : ''}${msg}`
+}
+
+function firstUrl(value: unknown): string {
+	if (typeof value === 'string') return value
+	if (!Array.isArray(value)) return ''
+	return value.find((item): item is string => typeof item === 'string' && item.length > 0) || ''
+}
+
+function videoExtension(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	if (clean.endsWith('.mov')) return 'mov'
+	if (clean.endsWith('.webm')) return 'webm'
+	return 'mp4'
+}
+
+function isBragiRelayUrl(url: string): boolean {
+	return url === BRAGI_RELAY_BASE || url.startsWith(`${BRAGI_RELAY_BASE}/`)
+}
+
+function extensionFromMime(mimeType: string, kind: RelayAssetKind): string {
+	const mime = mimeType.split(';')[0].trim().toLowerCase()
+	if (mime.includes('jpeg') || mime.includes('jpg')) return 'jpg'
+	if (mime.includes('png')) return 'png'
+	if (mime.includes('webp')) return 'webp'
+	if (mime.includes('gif')) return 'gif'
+	if (mime.includes('avif')) return 'avif'
+	if (mime.includes('heic')) return 'heic'
+	if (mime.includes('quicktime')) return 'mov'
+	if (mime.includes('webm')) return 'webm'
+	if (mime.includes('mp4')) return 'mp4'
+	return kind === 'image' ? 'jpg' : 'mp4'
+}
+
+function extensionFromUrl(url: string, kind: RelayAssetKind): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	const match = clean.match(/\.([a-z0-9]+)$/)
+	if (match?.[1]) return match[1]
+	return kind === 'image' ? 'jpg' : 'mp4'
+}
+
+function headerValue(headers: Record<string, string>, name: string): string {
+	const target = name.toLowerCase()
+	const key = Object.keys(headers).find(k => k.toLowerCase() === target)
+	return key ? headers[key] : ''
+}
+
+function isGenericContentType(contentType: string): boolean {
+	const mime = contentType.split(';')[0].trim().toLowerCase()
+	return !mime || mime === 'application/octet-stream' || mime === 'binary/octet-stream'
+}
+
+function fallbackMime(kind: RelayAssetKind, ext: string): string {
+	if (kind === 'image') return ext === 'jpg' ? 'image/jpeg' : `image/${ext}`
+	if (ext === 'mov') return 'video/quicktime'
+	return `video/${ext}`
+}
+
+export class APIMartProvider implements ImageProvider, VideoProvider {
+	name = 'APIMart'
 	private apiKey: string
 	private app: App
 	private outputDir: string
@@ -47,7 +123,7 @@ export class APIMartProvider implements ImageProvider {
 
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
 		const modelId = stringParam(params?.modelId, DEFAULT_MODEL)
-		const refImages: string[] = params?.refImages || []
+		const refImages = arrayParam(params?.refImages)
 
 		const size = stringParam(params?.aspectRatio, '1:1')
 		const tier = stringParam(params?.imageSize, '2K')
@@ -65,7 +141,7 @@ export class APIMartProvider implements ImageProvider {
 			body.quality = params.quality
 		}
 		if (refImages.length > 0) {
-			body.image_urls = refImages.slice(0, 16)
+			body.image_urls = await Promise.all(refImages.slice(0, 16).map(ref => this.ensureRelayUrl(ref, 'image')))
 		}
 
 		// Submit
@@ -98,6 +174,95 @@ export class APIMartProvider implements ImageProvider {
 		// Poll
 		const imageUrl = await this.poll(first.task_id)
 		return this.downloadAndWrite(imageUrl)
+	}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const modelId = stringParam(params?.modelId, DEFAULT_VIDEO_MODEL)
+		const resolution = stringParam(params?.resolution, '720p').toLowerCase()
+		const aspectRatio = stringParam(params?.aspect_ratio || params?.aspectRatio || params?.ratio, '16:9')
+		const refImages = arrayParam(params?.refImages)
+		const refVideos = arrayParam(params?.refVideos)
+
+		if (refImages.length !== 0 && refImages.length !== 1 && refImages.length !== 3) {
+			throw new Error('APIMart Omni-Flash-Ext supports 0, 1, or 3 reference images.')
+		}
+		if (refVideos.length > 1) {
+			throw new Error('APIMart Omni-Flash-Ext supports at most 1 reference video.')
+		}
+
+		const body: Record<string, unknown> = {
+			model: modelId,
+			prompt,
+			resolution,
+			aspect_ratio: aspectRatio,
+		}
+
+		if (refVideos.length === 0) {
+			const duration = Number.parseInt(stringParam(params?.duration || params?.durationSeconds, '6'), 10)
+			if (!VIDEO_DURATIONS.has(duration)) {
+				throw new Error('APIMart Omni-Flash-Ext duration must be one of 4, 6, 8, or 10 seconds.')
+			}
+			body.duration = duration
+		}
+		if (refImages.length > 0) {
+			body.image_urls = await Promise.all(refImages.map(ref => this.ensureRelayUrl(ref, 'image')))
+		}
+		if (refVideos.length > 0) {
+			body.video_urls = await Promise.all(refVideos.map(ref => this.ensureRelayUrl(ref, 'video')))
+		}
+
+		const resp = await requestUrl({
+			url: `${API_BASE}/videos/generations`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status === 401 || resp.status === 403) throw new Error('APIMart: invalid API key')
+		if (resp.status >= 400) throw new Error(`APIMart: ${parseApimartError(resp)}`)
+
+		const submitData = resp.json
+		const first = submitData?.data?.[0]
+		const taskId = first?.task_id || first?.id
+		if (!taskId) {
+			throw new Error(`APIMart: no task_id in video submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const resp = await requestUrl({
+			url: `${API_BASE}/tasks/${encodeURIComponent(taskId)}`,
+			method: 'GET',
+			headers: { 'Authorization': `Bearer ${this.apiKey}` },
+			throw: false,
+		})
+
+		if (resp.status === 401 || resp.status === 403) throw new Error('APIMart: invalid API key')
+		if (resp.status >= 400) throw new Error(`APIMart: ${parseApimartError(resp)}`)
+
+		const data = resp.json?.data
+		if (!data) {
+			throw new Error(`APIMart: malformed task response — ${JSON.stringify(resp.json).substring(0, 200)}`)
+		}
+		const status = data.status as string
+		if (status === 'completed') {
+			const videoUrl = firstUrl(data.result?.videos?.[0]?.url)
+			if (!videoUrl) {
+				throw new Error('APIMart: completed task has no video URL')
+			}
+			const filePath = await this.downloadVideo(videoUrl)
+			return { done: true, filePath }
+		}
+		if (status === 'failed') {
+			const detail = stringifyDetail(data.error) || stringifyDetail(data.message) || 'no reason provided'
+			throw new Error(`APIMart: task failed — ${detail}`)
+		}
+		return { done: false, taskId }
 	}
 
 	private async poll(taskId: string): Promise<string> {
@@ -153,6 +318,44 @@ export class APIMartProvider implements ImageProvider {
 		}
 		await adapter.writeBinary(filePath, bytes.buffer)
 		return { filePath }
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const resp = await requestUrl({ url })
+		const fileName = `apimart_video_${Date.now()}.${videoExtension(url)}`
+		const filePath = `${this.outputDir}/${fileName}`
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) {
+			await adapter.mkdir(this.outputDir)
+		}
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return filePath
+	}
+
+	private async ensureRelayUrl(ref: string, kind: RelayAssetKind): Promise<string> {
+		if (isBragiRelayUrl(ref)) return ref
+
+		const dataUri = ref.match(/^data:([^;]+);base64,(.+)$/)
+		if (dataUri) {
+			const mime = dataUri[1]
+			const bytes = Uint8Array.from(atob(dataUri[2]), c => c.charCodeAt(0))
+			const ext = extensionFromMime(mime, kind)
+			return uploadRef(undefined, bytes.buffer, `apimart-ref.${ext}`, mime)
+		}
+
+		if (/^https?:\/\//i.test(ref)) {
+			const resp = await requestUrl({ url: ref, throw: false })
+			if (resp.status >= 400) {
+				throw new Error(`APIMart: failed to fetch reference ${kind} for relay upload — HTTP ${resp.status}`)
+			}
+			const contentType = headerValue(resp.headers, 'content-type')
+			const useContentType = contentType && !isGenericContentType(contentType)
+			const ext = useContentType ? extensionFromMime(contentType, kind) : extensionFromUrl(ref, kind)
+			const mime = useContentType ? contentType : fallbackMime(kind, ext)
+			return uploadRef(undefined, resp.arrayBuffer, `apimart-ref.${ext}`, mime)
+		}
+
+		throw new Error(`APIMart: unsupported reference ${kind} format; expected a data URI or http(s) URL.`)
 	}
 }
 

--- a/src/providers/image-upload-prep.ts
+++ b/src/providers/image-upload-prep.ts
@@ -1,0 +1,166 @@
+export interface PreparedUpload {
+	bytes: ArrayBuffer
+	fileName: string
+	contentType: string
+}
+
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+	avif: 'image/avif',
+	bmp: 'image/bmp',
+	gif: 'image/gif',
+	heic: 'image/heic',
+	heif: 'image/heif',
+	jpeg: 'image/jpeg',
+	jpg: 'image/jpeg',
+	png: 'image/png',
+	svg: 'image/svg+xml',
+	tif: 'image/tiff',
+	tiff: 'image/tiff',
+	webp: 'image/webp',
+}
+
+function normalizeContentType(contentType: string): string {
+	return contentType.split(';')[0]?.trim().toLowerCase() || ''
+}
+
+function getFileExtension(fileName: string): string {
+	return fileName.split(/[?#]/)[0]?.split('.').pop()?.toLowerCase() || ''
+}
+
+function basenameWithoutExt(fileName: string): string {
+	const clean = fileName.split(/[?#]/)[0] || fileName
+	const slash = clean.lastIndexOf('/')
+	const leaf = slash >= 0 ? clean.slice(slash + 1) : clean
+	const dot = leaf.lastIndexOf('.')
+	return dot > 0 ? leaf.slice(0, dot) : (leaf || 'ref')
+}
+
+function ascii(bytes: Uint8Array, start: number, length: number): string {
+	let result = ''
+	for (let i = start; i < start + length && i < bytes.length; i++) {
+		result += String.fromCharCode(bytes[i])
+	}
+	return result
+}
+
+function sniffImageMime(bytes: ArrayBuffer): string | null {
+	const b = new Uint8Array(bytes)
+	if (b.length >= 8 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'image/png'
+	if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'image/jpeg'
+	if (b.length >= 12 && ascii(b, 0, 4) === 'RIFF' && ascii(b, 8, 4) === 'WEBP') return 'image/webp'
+	if (b.length >= 6 && (ascii(b, 0, 6) === 'GIF87a' || ascii(b, 0, 6) === 'GIF89a')) return 'image/gif'
+	if (b.length >= 2 && b[0] === 0x42 && b[1] === 0x4d) return 'image/bmp'
+	if (b.length >= 4 && ((b[0] === 0x49 && b[1] === 0x49 && b[2] === 0x2a && b[3] === 0x00) || (b[0] === 0x4d && b[1] === 0x4d && b[2] === 0x00 && b[3] === 0x2a))) return 'image/tiff'
+	if (b.length >= 12 && ascii(b, 4, 4) === 'ftyp') {
+		const brand = ascii(b, 8, 4).toLowerCase()
+		if (brand === 'avif' || brand === 'avis') return 'image/avif'
+		if (brand === 'heic' || brand === 'heix' || brand === 'hevc' || brand === 'hevx' || brand === 'mif1' || brand === 'msf1') return 'image/heic'
+	}
+	return null
+}
+
+function inferImageMime(fileName: string, contentType: string, bytes: ArrayBuffer): string {
+	const sniffed = sniffImageMime(bytes)
+	if (sniffed) return sniffed
+	const normalized = normalizeContentType(contentType)
+	if (normalized.startsWith('image/')) return normalized === 'image/jpg' ? 'image/jpeg' : normalized
+	if (normalized && normalized !== 'application/octet-stream') return normalized
+	const fromExt = IMAGE_MIME_BY_EXT[getFileExtension(fileName)]
+	return fromExt || normalized
+}
+
+function isPngOrJpeg(mimeType: string): boolean {
+	return mimeType === 'image/png' || mimeType === 'image/jpeg' || mimeType === 'image/jpg'
+}
+
+function normalizePassthroughFileName(fileName: string, mimeType: string): string {
+	const ext = getFileExtension(fileName)
+	if (mimeType === 'image/png' && ext === 'png') return fileName
+	if ((mimeType === 'image/jpeg' || mimeType === 'image/jpg') && (ext === 'jpg' || ext === 'jpeg')) return fileName
+	return `${basenameWithoutExt(fileName)}.${mimeType === 'image/png' ? 'png' : 'jpg'}`
+}
+
+function convertImageToPng(bytes: ArrayBuffer, mimeType: string, context: string): Promise<ArrayBuffer> {
+	return new Promise((resolve, reject) => {
+		const url = URL.createObjectURL(new Blob([bytes], { type: mimeType || 'application/octet-stream' }))
+		const image = new Image()
+		let settled = false
+		let timeout: number
+		const finish = (fn: () => void) => {
+			if (settled) return
+			settled = true
+			window.clearTimeout(timeout)
+			URL.revokeObjectURL(url)
+			fn()
+		}
+		timeout = window.setTimeout(() => {
+			finish(() => reject(new Error(`${context}: image decode timed out`)))
+		}, 15000)
+		image.onload = () => {
+			finish(() => {
+				const width = image.naturalWidth || image.width
+				const height = image.naturalHeight || image.height
+				if (!width || !height) {
+					reject(new Error(`${context}: image has no dimensions`))
+					return
+				}
+
+				const canvas = createEl('canvas')
+				canvas.width = width
+				canvas.height = height
+				const ctx = canvas.getContext('2d')
+				if (!ctx) {
+					reject(new Error(`${context}: could not create image canvas`))
+					return
+				}
+				ctx.drawImage(image, 0, 0)
+				canvas.toBlob(blob => {
+					if (!blob) {
+						reject(new Error(`${context}: could not convert image to PNG`))
+						return
+					}
+					blob.arrayBuffer().then(resolve, reject)
+				}, 'image/png')
+			})
+		}
+		image.onerror = () => {
+			finish(() => reject(new Error(`${context}: could not decode image for PNG upload`)))
+		}
+		image.src = url
+	})
+}
+
+export function imageMimeTypeFromFileName(fileName: string): string {
+	return IMAGE_MIME_BY_EXT[getFileExtension(fileName)] || ''
+}
+
+/**
+ * Prepare a reference upload. Image uploads preserve PNG/JPEG and convert any
+ * other image format to PNG so providers see a conservative input format.
+ */
+export async function prepareReferenceUpload(
+	bytes: ArrayBuffer,
+	fileName: string,
+	contentType: string,
+	context = 'Reference image upload',
+): Promise<PreparedUpload> {
+	const sourceMime = inferImageMime(fileName, contentType, bytes)
+	if (!sourceMime.startsWith('image/')) {
+		return { bytes, fileName, contentType }
+	}
+
+	if (isPngOrJpeg(sourceMime)) {
+		const normalizedMime = sourceMime === 'image/png' ? 'image/png' : 'image/jpeg'
+		return {
+			bytes,
+			fileName: normalizePassthroughFileName(fileName, normalizedMime),
+			contentType: normalizedMime,
+		}
+	}
+
+	return {
+		bytes: await convertImageToPng(bytes, sourceMime, context),
+		fileName: `${basenameWithoutExt(fileName)}.png`,
+		contentType: 'image/png',
+	}
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -4,6 +4,7 @@ import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
 import { resolveOpenAIImageSize } from './openai-image-size'
 import { stringParam } from './params'
+import { prepareReferenceUpload } from './image-upload-prep'
 
 export class OpenAIProvider implements ImageProvider {
 	name = 'GPT Image'
@@ -103,7 +104,13 @@ export class OpenAIProvider implements ImageProvider {
 			const mime = match[1]
 			const bytes = Uint8Array.from(atob(match[2]), c => c.charCodeAt(0))
 			const ext = mime.includes('png') ? 'png' : mime.includes('webp') ? 'webp' : 'jpg'
-			appendFile('image[]', `ref${i}.${ext}`, mime, bytes)
+			const prepared = await prepareReferenceUpload(
+				bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+				`ref${i}.${ext}`,
+				mime,
+				'OpenAI image edit upload',
+			)
+			appendFile('image[]', prepared.fileName, prepared.contentType, new Uint8Array(prepared.bytes))
 		}
 
 		parts.push(enc.encode(`--${boundary}--\r\n`))

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -450,11 +450,13 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'apimart',
 		name: 'APIMart',
-		description: 'GPT text and GPT Image 2 gateway.',
-		docUrl: 'https://docs.apimart.ai/en/api-reference/texts/general/chat-completions-nostream',
+		description: 'GPT text, GPT Image 2, and Omni-Flash video gateway.',
+		docUrl: 'https://docs.apimart.ai/en/api-reference/videos/omni-flash-ext/generation',
 		fields: [{ key: 'apimart', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.apimart,
 		makeImage: ({ settings, app, outputDir }) =>
+			new APIMartProvider(settings.providers.apimart, app, outputDir),
+		makeVideo: ({ settings, app, outputDir }) =>
 			new APIMartProvider(settings.providers.apimart, app, outputDir),
 		makeText: ({ settings }) =>
 			new APIMartTextProvider(settings.providers.apimart, 'https://api.apimart.ai/v1'),

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -5,6 +5,7 @@ import type { GenerateImageResult, GenerateVideoResult, ImageProvider, VideoProv
 import type { TextGenProvider, TextGenResult } from './text-gen'
 import { uploadRef } from './upload'
 import { resolveOpenAIImageSize } from './openai-image-size'
+import { prepareReferenceUpload } from './image-upload-prep'
 
 const DEFAULT_BASE_URL = 'https://api.tokenrouter.com/v1'
 const IMAGE_GENERATION_MODELS = new Set([
@@ -412,7 +413,8 @@ export class TokenRouterImageProvider implements ImageProvider {
 			const mime = match[1]
 			const bytes = Uint8Array.from(atob(match[2]), c => c.charCodeAt(0))
 			const ext = mime.includes('webp') ? 'webp' : mime.includes('png') ? 'png' : 'jpg'
-			appendMultipartFile(parts, boundary, 'image[]', `ref${i}.${ext}`, mime, bytes)
+			const prepared = await prepareReferenceUpload(copyToArrayBuffer(bytes), `ref${i}.${ext}`, mime, 'TokenRouter image edit upload')
+			appendMultipartFile(parts, boundary, 'image[]', prepared.fileName, prepared.contentType, new Uint8Array(prepared.bytes))
 		}
 		parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
 

--- a/src/providers/upload.ts
+++ b/src/providers/upload.ts
@@ -1,4 +1,5 @@
 import { uploadToBragiRelay, BUILTIN_BRAGI_RELAY } from './bragi-relay'
+import { prepareReferenceUpload } from './image-upload-prep'
 
 /**
  * Upload a reference asset via the built-in Bragi temporary storage worker and return its public URL.
@@ -13,5 +14,6 @@ export async function uploadRef(
 	fileName: string,
 	contentType: string,
 ): Promise<string> {
-	return uploadToBragiRelay(BUILTIN_BRAGI_RELAY, fileData, fileName, contentType)
+	const prepared = await prepareReferenceUpload(fileData, fileName, contentType, 'Bragi temporary storage upload')
+	return uploadToBragiRelay(BUILTIN_BRAGI_RELAY, prepared.bytes, prepared.fileName, prepared.contentType)
 }

--- a/src/token360-asset-flow.ts
+++ b/src/token360-asset-flow.ts
@@ -7,86 +7,19 @@ import {
 	uploadToken360Asset,
 	waitForToken360AssetActive,
 } from './providers/token360-assets'
+import { imageMimeTypeFromFileName, prepareReferenceUpload } from './providers/image-upload-prep'
 
 const PROVIDER_KEY = 'token360'
-function imageExtToMime(ext: string): string {
-	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
-	if (ext === 'webp') return 'image/webp'
-	return 'image/png'
-}
-
-function sniffImageExt(bytes: ArrayBuffer): 'png' | 'jpg' | 'webp' | null {
-	const b = new Uint8Array(bytes)
-	if (b.length >= 8 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'png'
-	if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'jpg'
-	if (
-		b.length >= 12 &&
-		b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
-		b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
-	) return 'webp'
-	return null
-}
-
-function basenameWithoutExt(filename: string): string {
-	const index = filename.lastIndexOf('.')
-	return index > 0 ? filename.slice(0, index) : filename
-}
-
-function getImageFileInfo(filePath: string, bytes: ArrayBuffer): { ext: 'png' | 'jpg' | 'webp'; mime: string; filename: string } {
-	const originalName = filePath.split('/').pop() || 'ref'
-	const ext = sniffImageExt(bytes)
-	if (!ext) throw new Error(`Token360 assets support PNG, JPG, JPEG, or WebP images only: ${originalName}`)
-	return {
-		ext,
-		mime: imageExtToMime(ext),
-		filename: `${basenameWithoutExt(originalName)}.${ext}`,
-	}
-}
-
-function convertImageToPng(bytes: ArrayBuffer, mime: string): Promise<ArrayBuffer> {
-	return new Promise((resolve, reject) => {
-		const url = URL.createObjectURL(new Blob([bytes], { type: mime }))
-		const image = new Image()
-		image.onload = () => {
-			const width = image.naturalWidth || image.width
-			const height = image.naturalHeight || image.height
-			URL.revokeObjectURL(url)
-			if (!width || !height) {
-				reject(new Error('Token360 asset upload: image has no dimensions'))
-				return
-			}
-			const canvas = createEl('canvas')
-			canvas.width = width
-			canvas.height = height
-			const ctx = canvas.getContext('2d')
-			if (!ctx) {
-				reject(new Error('Token360 asset upload: could not create image canvas'))
-				return
-			}
-			ctx.drawImage(image, 0, 0)
-			canvas.toBlob(blob => {
-				if (!blob) {
-					reject(new Error('Token360 asset upload: could not convert image to PNG'))
-					return
-				}
-				blob.arrayBuffer().then(resolve, reject)
-			}, 'image/png')
-		}
-		image.onerror = () => {
-			URL.revokeObjectURL(url)
-			reject(new Error('Token360 asset upload: could not decode image'))
-		}
-		image.src = url
-	})
-}
 
 async function prepareUploadImage(filePath: string, bytes: ArrayBuffer): Promise<{ bytes: ArrayBuffer; mime: string; filename: string }> {
-	const info = getImageFileInfo(filePath, bytes)
-	if (info.ext !== 'webp') return { bytes, mime: info.mime, filename: info.filename }
+	const originalName = filePath.split('/').pop() || 'ref'
+	const contentType = imageMimeTypeFromFileName(originalName)
+	if (!contentType) throw new Error(`Token360 assets support image files only: ${originalName}`)
+	const prepared = await prepareReferenceUpload(bytes, originalName, contentType, 'Token360 asset upload')
 	return {
-		bytes: await convertImageToPng(bytes, info.mime),
-		mime: 'image/png',
-		filename: `${basenameWithoutExt(info.filename)}.png`,
+		bytes: prepared.bytes,
+		mime: prepared.contentType,
+		filename: prepared.fileName,
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize reference image uploads before relay/provider upload
- add APIMart Omni-Flash-Ext video model/provider support
- enforce APIMart relay-only image/video reference URLs
- document model/provider rules for APIMart refs

## Tests
- npm run test:reference-image-upload
- npm run build
- npm run lint:obsidian
- git diff --check
- npm run sync:check