### PR TITLE
Fix canvas inline annotation mode regressions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -55,6 +55,11 @@ This repository is an Obsidian community plugin. Treat Obsidian Community review
 - For tools that directly operate on a canvas node, prefer `CanvasInlineToolSession` over a modal or full-screen overlay.
 - The standard flow is: toolbar entry -> create inline session -> focus target node -> lock non-target canvas interaction -> replace the floating topbar -> mount a temporary node layer -> save or cancel -> fully clean up classes, datasets, listeners, observers, and temporary DOM.
 - Keep tool-specific state and rendering in the feature module. The inline session should own focus, viewport restore, selection restore, interaction gating, and topbar lifecycle.
+- Focus must use the inline session's safe-rect viewport targeting so the floating toolbar and bottom canvas controls do not cover the target node. Do not center solely on the node bbox.
+- Focus animation should direct-fit to the final safe rect before it starts: compute visible size from rendered DOM using Canvas `scale`, convert the target scale back to Canvas `zoom`/`tZoom`, and keep `node.focus()` only as a fallback. Rendered correction is a small safety pass, not the normal second animation step.
+- Inline sessions are scoped by canvas wrapper. Closing must make the session inactive before restoring the viewport or native toolbar, and non-target canvas chrome must sit behind the target node while interactions are locked.
+- Keyboard shortcuts, pointer gates, toolbar queries, native topbar suppression, and connection-point hiding must be scoped to the active session's wrapper or session-tagged menu. Do not use body-level selectors or document-level handlers to block interaction in other canvases.
+- When restoring the native topbar after inline tool exit, force an `auto-above` selection-menu reposition during reveal so transient inline/restore placement does not leave the topbar below the node.
 - Editing coordinates may use the node's displayed dimensions. When writing a media file, map annotations or edits back to the original asset dimensions so saved outputs preserve the source resolution.
 - New inline tools must run `npm run build`, `npm run lint:obsidian`, and `git diff --check`, and should be manually checked for enter/exit behavior, topbar restoration, interaction lock, connection-point suppression, and cleanup after repeated open/close cycles.
 

--- a/src/canvas-inline-tool.ts
+++ b/src/canvas-inline-tool.ts
@@ -1,6 +1,14 @@
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 
 export type CanvasInlineToolToolbarPhase = 'hidden' | 'ready'
+export type CanvasInlineToolSessionState = 'opening' | 'active' | 'closing' | 'closed'
+
+export type CanvasInlineToolFocusOptions = {
+	maxZoom?: number
+	topMarginPx?: number
+	bottomMarginPx?: number
+	sideMarginPx?: number
+}
 
 export type CanvasInlineToolContext<TAction> = {
 	readonly id: string
@@ -24,8 +32,10 @@ export type CanvasInlineToolSessionOptions<TAction> = {
 	onAction: (action: TAction, context: CanvasInlineToolContext<TAction>) => void
 	mountLayer?: (context: CanvasInlineToolContext<TAction>) => void
 	isToolEventTarget?: (target: EventTarget | null) => boolean
+	onKeyDown?: (event: KeyboardEvent, context: CanvasInlineToolContext<TAction>) => void
 	onReady?: (context: CanvasInlineToolContext<TAction>) => void
 	onClose?: (context: CanvasInlineToolContext<TAction>) => void
+	focusOptions?: CanvasInlineToolFocusOptions
 	legacyModeClass?: string
 	legacyTargetClass?: string
 	legacyBodyClass?: string
@@ -39,6 +49,25 @@ type CanvasViewportTarget = {
 	x: number
 	y: number
 	zoom: number
+	scale: number
+}
+
+type CanvasTargetGeometry = {
+	center: {
+		x: number
+		y: number
+	}
+	width: number
+	height: number
+}
+
+type ScreenRect = {
+	left: number
+	top: number
+	right: number
+	bottom: number
+	width: number
+	height: number
 }
 
 type CanvasViewportInternals = Canvas & {
@@ -59,16 +88,29 @@ type CanvasViewportInternals = Canvas & {
 	}
 }
 
-const MAX_CANVAS_ZOOM = 1
+const DEFAULT_INLINE_TOOL_MAX_ZOOM = 1
+const MIN_INLINE_TOOL_ZOOM = 0.1
+const DEFAULT_INLINE_TOOL_SIDE_MARGIN_PX = 32
+const DEFAULT_INLINE_TOOL_TOOLBAR_HEIGHT_PX = 44
+const INLINE_TOOL_TOOLBAR_GAP_PX = 24
+const INLINE_TOOL_TOOLBAR_TOP_GAP_PX = 12
+const INLINE_TOOL_BOTTOM_GAP_PX = 32
+const INLINE_TOOL_RENDERED_FIT_PADDING_PX = 12
+const INLINE_TOOL_RENDERED_CORRECTION_PASSES = 2
 const VIEWPORT_ANIMATION_TIMEOUT_MS = 900
 const VIEWPORT_FALLBACK_TOOLBAR_DELAY_MS = 350
 const VIEWPORT_KEYS = ['x', 'y', 'tx', 'ty', 'zoom', 'tZoom', 'scale'] as const
 const GATED_EVENTS = ['pointerdown', 'pointermove', 'pointerup', 'click', 'dblclick', 'wheel', 'contextmenu'] as const
 
-let activeInlineToolSession: CanvasInlineToolSession<unknown> | null = null
+const activeInlineToolSessions = new WeakMap<HTMLElement, CanvasInlineToolSession<unknown>>()
 
-function setActiveInlineToolSession(session: CanvasInlineToolSession<unknown>): void {
-	activeInlineToolSession = session
+function setActiveInlineToolSession(wrapper: HTMLElement, session: CanvasInlineToolSession<unknown>): void {
+	activeInlineToolSessions.set(wrapper, session)
+}
+
+function clearActiveInlineToolSession(wrapper: HTMLElement | null, session: CanvasInlineToolSession<unknown>): void {
+	if (!wrapper) return
+	if (activeInlineToolSessions.get(wrapper) === session) activeInlineToolSessions.delete(wrapper)
 }
 
 function createId(): string {
@@ -95,7 +137,7 @@ function animateViewportTo(canvas: Canvas, x: number, y: number, zoom: number): 
 	internals.finishViewportAnimation = false
 	internals.markViewportChanged()
 	void canvas.requestFrame()
-	return { x, y, zoom }
+	return { x, y, zoom, scale: resolveViewportScale(zoom, internals.scale) }
 }
 
 function readViewport(canvas: Canvas): CanvasViewportTarget | null {
@@ -110,7 +152,12 @@ function readViewport(canvas: Canvas): CanvasViewportTarget | null {
 	) {
 		return null
 	}
-	return { x: internals.x, y: internals.y, zoom: internals.zoom }
+	return {
+		x: internals.x,
+		y: internals.y,
+		zoom: internals.zoom,
+		scale: resolveViewportScale(internals.zoom, internals.scale),
+	}
 }
 
 function isViewportAtTarget(canvas: Canvas, target: CanvasViewportTarget): boolean {
@@ -186,6 +233,313 @@ function getNodeBBox(node: CanvasNode): { minX: number; minY: number; maxX: numb
 	}
 }
 
+function finiteNumber(value: number | undefined, fallback: number): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function resolveViewportScale(zoom: number, scale: number | undefined): number {
+	if (typeof scale === 'number' && Number.isFinite(scale) && scale > 0) return scale
+	return Math.max(0.001, Math.pow(2, zoom))
+}
+
+function isLogarithmicZoom(viewport: Pick<CanvasViewportTarget, 'zoom' | 'scale'>): boolean {
+	return Math.abs(Math.log2(viewport.scale) - viewport.zoom) <= 0.05
+}
+
+function scaleToZoom(scale: number, reference: Pick<CanvasViewportTarget, 'zoom' | 'scale'> | null): number {
+	const safeScale = Math.max(0.001, scale)
+	if (!reference || isLogarithmicZoom(reference)) return Math.log2(safeScale)
+	if (reference.zoom > 0 && Math.abs(reference.scale - reference.zoom) <= Math.max(0.02, reference.scale * 0.05)) {
+		return safeScale
+	}
+	return Math.log2(safeScale)
+}
+
+function zoomToScale(zoom: number, reference: Pick<CanvasViewportTarget, 'zoom' | 'scale'> | null): number {
+	if (!reference || isLogarithmicZoom(reference)) return Math.pow(2, zoom)
+	if (reference.zoom > 0 && Math.abs(reference.scale - reference.zoom) <= Math.max(0.02, reference.scale * 0.05)) {
+		return Math.max(0.001, zoom)
+	}
+	return Math.pow(2, zoom)
+}
+
+function screenRectFromBounds(left: number, top: number, right: number, bottom: number): ScreenRect {
+	return {
+		left,
+		top,
+		right,
+		bottom,
+		width: Math.max(1, right - left),
+		height: Math.max(1, bottom - top),
+	}
+}
+
+function screenRectFromDomRect(rect: DOMRect): ScreenRect {
+	return screenRectFromBounds(rect.left, rect.top, rect.right, rect.bottom)
+}
+
+function getWindowViewportRect(doc: Document): ScreenRect {
+	const view = doc.defaultView || window
+	const layoutRect = screenRectFromBounds(0, 0, view.innerWidth, view.innerHeight)
+	const visualViewport = view.visualViewport
+	if (!visualViewport) return layoutRect
+	const visualRect = screenRectFromBounds(
+		visualViewport.offsetLeft,
+		visualViewport.offsetTop,
+		visualViewport.offsetLeft + visualViewport.width,
+		visualViewport.offsetTop + visualViewport.height,
+	)
+	const left = Math.max(layoutRect.left, visualRect.left)
+	const top = Math.max(layoutRect.top, visualRect.top)
+	const right = Math.min(layoutRect.right, visualRect.right)
+	const bottom = Math.min(layoutRect.bottom, visualRect.bottom)
+	if (right <= left || bottom <= top) return layoutRect
+	return screenRectFromBounds(left, top, right, bottom)
+}
+
+function getVisibleViewportRect(wrapper: HTMLElement): ScreenRect {
+	const wrapperRect = wrapper.getBoundingClientRect()
+	const viewportRect = getWindowViewportRect(wrapper.ownerDocument || activeDocument)
+	const left = Math.max(wrapperRect.left, viewportRect.left)
+	const top = Math.max(wrapperRect.top, viewportRect.top)
+	const right = Math.min(wrapperRect.right, viewportRect.right)
+	const bottom = Math.min(wrapperRect.bottom, viewportRect.bottom)
+	if (right <= left || bottom <= top) return screenRectFromDomRect(wrapperRect)
+	return screenRectFromBounds(left, top, right, bottom)
+}
+
+function getSelectionMenuEl(canvas: Canvas): HTMLElement | null {
+	const menu = (canvas as CanvasViewportInternals).menu
+	return menu?.menuEl
+		|| menu?.containerEl?.querySelector<HTMLElement>('.bragi-canvas-menu')
+		|| canvas.wrapperEl?.querySelector<HTMLElement>('.bragi-canvas-menu')
+		|| null
+}
+
+function getInlineToolbarEl(canvas: Canvas): HTMLElement | null {
+	const menuEl = getSelectionMenuEl(canvas)
+	const sessionId = canvas.wrapperEl?.dataset.bragiInlineToolSessionId
+	if (
+		menuEl?.classList.contains('bragi-inline-tool-menu-inline')
+		&& (!sessionId || menuEl.dataset.bragiInlineToolSessionId === sessionId)
+	) {
+		return menuEl
+	}
+	if (!sessionId) return null
+	return activeDocument.querySelector<HTMLElement>(
+		`.bragi-canvas-menu.bragi-inline-tool-menu-inline[data-bragi-inline-tool-session-id="${sessionId}"]`,
+	)
+}
+
+function measureElementHeight(el: HTMLElement | null): number {
+	if (!el) return 0
+	const rect = el.getBoundingClientRect()
+	return Number.isFinite(rect.height) ? rect.height : 0
+}
+
+function measureInlineToolbarHeight(canvas: Canvas): number {
+	return measureElementHeight(getInlineToolbarEl(canvas))
+		|| measureElementHeight(getSelectionMenuEl(canvas))
+		|| DEFAULT_INLINE_TOOL_TOOLBAR_HEIGHT_PX
+}
+
+function measureInlineToolbarBottom(canvas: Canvas, wrapper: HTMLElement): number {
+	const toolbarEl = getInlineToolbarEl(canvas)
+	if (toolbarEl) {
+		const rect = toolbarEl.getBoundingClientRect()
+		if (rect.width > 0 && rect.height > 0 && Number.isFinite(rect.bottom)) return rect.bottom
+	}
+	return calculateToolbarTop(wrapper) + measureInlineToolbarHeight(canvas)
+}
+
+function measureTopChromeOverlap(wrapper: HTMLElement): number {
+	const wrapperRect = wrapper.getBoundingClientRect()
+	let overlap = 0
+	for (const el of activeDocument.querySelectorAll<HTMLElement>('.workspace-tab-header-container, .view-header, .titlebar')) {
+		const rect = el.getBoundingClientRect()
+		if (rect.width <= 0 || rect.height <= 0) continue
+		const intersectsHorizontally = rect.right > wrapperRect.left && rect.left < wrapperRect.right
+		if (!intersectsHorizontally || rect.bottom <= wrapperRect.top) continue
+		overlap = Math.max(overlap, rect.bottom - wrapperRect.top)
+	}
+	return Math.max(0, overlap)
+}
+
+function measureBottomChromeTop(wrapper: HTMLElement, visibleRect: ScreenRect): number {
+	const wrapperRect = wrapper.getBoundingClientRect()
+	let chromeTop = visibleRect.bottom
+	for (const el of wrapper.querySelectorAll<HTMLElement>('.canvas-card-menu:not(.bragi-canvas-menu)')) {
+		const rect = el.getBoundingClientRect()
+		if (rect.width <= 0 || rect.height <= 0) continue
+		const intersectsHorizontally = rect.right > wrapperRect.left && rect.left < wrapperRect.right
+		if (!intersectsHorizontally) continue
+		if (rect.top < visibleRect.top || rect.top > visibleRect.bottom) continue
+		chromeTop = Math.min(chromeTop, rect.top)
+	}
+	return chromeTop
+}
+
+function calculateToolbarTop(wrapper: HTMLElement): number {
+	const visibleRect = getVisibleViewportRect(wrapper)
+	return Math.max(
+		INLINE_TOOL_TOOLBAR_TOP_GAP_PX,
+		visibleRect.top + measureTopChromeOverlap(wrapper) + INLINE_TOOL_TOOLBAR_TOP_GAP_PX,
+	)
+}
+
+function setInlineToolbarTop(wrapper: HTMLElement): void {
+	const top = `${Math.round(calculateToolbarTop(wrapper))}px`
+	wrapper.setCssProps({ '--bragi-inline-tool-toolbar-top': top })
+	activeDocument.body.setCssProps({ '--bragi-inline-tool-toolbar-top': top })
+}
+
+function clearInlineToolbarTop(wrapper: HTMLElement | null): void {
+	wrapper?.style.removeProperty('--bragi-inline-tool-toolbar-top')
+	activeDocument.body.style.removeProperty('--bragi-inline-tool-toolbar-top')
+}
+
+function calculateSafeScreenRect(canvas: Canvas, wrapper: HTMLElement, focusOptions: CanvasInlineToolFocusOptions | undefined): ScreenRect {
+	const visibleRect = getVisibleViewportRect(wrapper)
+	const toolbarBottom = measureInlineToolbarBottom(canvas, wrapper)
+	const sideMargin = finiteNumber(focusOptions?.sideMarginPx, DEFAULT_INLINE_TOOL_SIDE_MARGIN_PX)
+	const bottomChromeTop = measureBottomChromeTop(wrapper, visibleRect)
+	const top = focusOptions?.topMarginPx !== undefined
+		? visibleRect.top + focusOptions.topMarginPx
+		: toolbarBottom + INLINE_TOOL_TOOLBAR_GAP_PX
+	const viewportBottom = focusOptions?.bottomMarginPx !== undefined
+		? visibleRect.bottom - focusOptions.bottomMarginPx
+		: visibleRect.bottom - INLINE_TOOL_BOTTOM_GAP_PX
+	const bottom = Math.min(viewportBottom, bottomChromeTop - INLINE_TOOL_BOTTOM_GAP_PX)
+	const left = visibleRect.left + sideMargin
+	const right = visibleRect.right - sideMargin
+	return screenRectFromBounds(
+		Math.min(left, right - 1),
+		Math.min(top, bottom - 1),
+		right,
+		bottom,
+	)
+}
+
+function calculateFocusTarget(
+	canvas: Canvas,
+	node: CanvasNode,
+	wrapper: HTMLElement,
+	focusOptions: CanvasInlineToolFocusOptions | undefined,
+): CanvasViewportTarget {
+	const bbox = getNodeBBox(node)
+	const wrapperRect = wrapper.getBoundingClientRect()
+	const safeRect = calculateSafeScreenRect(canvas, wrapper, focusOptions)
+	const current = readViewport(canvas)
+	const maxZoom = finiteNumber(focusOptions?.maxZoom, DEFAULT_INLINE_TOOL_MAX_ZOOM)
+	const maxScale = zoomToScale(maxZoom, current)
+	const targetGeometry = getRenderedTargetGeometry(canvas, node, wrapper) || getBboxTargetGeometry(bbox)
+	const paddedSafeWidth = Math.max(1, safeRect.width - INLINE_TOOL_RENDERED_FIT_PADDING_PX * 2)
+	const paddedSafeHeight = Math.max(1, safeRect.height - INLINE_TOOL_RENDERED_FIT_PADDING_PX * 2)
+	const fitScale = Math.min(maxScale, paddedSafeWidth / targetGeometry.width, paddedSafeHeight / targetGeometry.height)
+	const scale = Math.max(zoomToScale(MIN_INLINE_TOOL_ZOOM, current), fitScale)
+	const zoom = scaleToZoom(scale, current)
+	const wrapperCenter = {
+		x: wrapperRect.left + wrapperRect.width / 2,
+		y: wrapperRect.top + wrapperRect.height / 2,
+	}
+	const safeCenter = {
+		x: safeRect.left + safeRect.width / 2,
+		y: safeRect.top + safeRect.height / 2,
+	}
+	return {
+		x: targetGeometry.center.x - (safeCenter.x - wrapperCenter.x) / scale,
+		y: targetGeometry.center.y - (safeCenter.y - wrapperCenter.y) / scale,
+		zoom,
+		scale,
+	}
+}
+
+function getBboxTargetGeometry(bbox: { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number }): CanvasTargetGeometry {
+	const bboxWidth = Math.max(1, bbox.width || bbox.maxX - bbox.minX)
+	const bboxHeight = Math.max(1, bbox.height || bbox.maxY - bbox.minY)
+	return {
+		center: {
+			x: (bbox.minX + bbox.maxX) / 2,
+			y: (bbox.minY + bbox.maxY) / 2,
+		},
+		width: bboxWidth,
+		height: bboxHeight,
+	}
+}
+
+function getRenderedTargetGeometry(canvas: Canvas, node: CanvasNode, wrapper: HTMLElement): CanvasTargetGeometry | null {
+	const current = readViewport(canvas)
+	if (!current || current.scale <= 0) return null
+	const contentRect = node.contentEl.getBoundingClientRect()
+	const nodeElRect = node.nodeEl.getBoundingClientRect()
+	const renderedRect = contentRect.width > 0 && contentRect.height > 0 ? contentRect : nodeElRect
+	if (renderedRect.width <= 0 || renderedRect.height <= 0) return null
+
+	const bbox = getNodeBBox(node)
+	const bboxGeometry = getBboxTargetGeometry(bbox)
+	const renderedContentWidth = contentRect.width > 0 ? contentRect.width / current.scale : 0
+	const renderedContentHeight = contentRect.height > 0 ? contentRect.height / current.scale : 0
+	const renderedNodeWidth = nodeElRect.width > 0 ? nodeElRect.width / current.scale : 0
+	const renderedNodeHeight = nodeElRect.height > 0 ? nodeElRect.height / current.scale : 0
+
+	const wrapperRect = wrapper.getBoundingClientRect()
+	const wrapperCenter = {
+		x: wrapperRect.left + wrapperRect.width / 2,
+		y: wrapperRect.top + wrapperRect.height / 2,
+	}
+	return {
+		center: {
+			x: current.x + (renderedRect.left + renderedRect.width / 2 - wrapperCenter.x) / current.scale,
+			y: current.y + (renderedRect.top + renderedRect.height / 2 - wrapperCenter.y) / current.scale,
+		},
+		width: Math.max(1, bboxGeometry.width, renderedContentWidth, renderedNodeWidth),
+		height: Math.max(1, bboxGeometry.height, renderedContentHeight, renderedNodeHeight),
+	}
+}
+
+function calculateRenderedCorrectionTarget(
+	canvas: Canvas,
+	node: CanvasNode,
+	wrapper: HTMLElement,
+	focusOptions: CanvasInlineToolFocusOptions | undefined,
+): CanvasViewportTarget | null {
+	const current = readViewport(canvas)
+	if (!current) return null
+	const contentRect = node.contentEl.getBoundingClientRect()
+	const nodeRect = contentRect.width > 0 && contentRect.height > 0 ? contentRect : node.nodeEl.getBoundingClientRect()
+	if (nodeRect.width <= 0 || nodeRect.height <= 0) return null
+	const safeRect = calculateSafeScreenRect(canvas, wrapper, focusOptions)
+	const maxZoom = finiteNumber(focusOptions?.maxZoom, DEFAULT_INLINE_TOOL_MAX_ZOOM)
+	const maxScale = zoomToScale(maxZoom, current)
+	const paddedSafeWidth = Math.max(1, safeRect.width - INLINE_TOOL_RENDERED_FIT_PADDING_PX * 2)
+	const paddedSafeHeight = Math.max(1, safeRect.height - INLINE_TOOL_RENDERED_FIT_PADDING_PX * 2)
+	const fitRatio = Math.min(1, paddedSafeWidth / nodeRect.width, paddedSafeHeight / nodeRect.height)
+	const overlapsSafeRect = nodeRect.top < safeRect.top
+		|| nodeRect.bottom > safeRect.bottom
+		|| nodeRect.left < safeRect.left
+		|| nodeRect.right > safeRect.right
+	if (fitRatio >= 0.999 && !overlapsSafeRect) return null
+
+	const targetGeometry = getRenderedTargetGeometry(canvas, node, wrapper) || getBboxTargetGeometry(getNodeBBox(node))
+	const scale = Math.max(zoomToScale(MIN_INLINE_TOOL_ZOOM, current), Math.min(maxScale, current.scale * fitRatio))
+	const zoom = scaleToZoom(scale, current)
+	const wrapperRect = wrapper.getBoundingClientRect()
+	const wrapperCenter = {
+		x: wrapperRect.left + wrapperRect.width / 2,
+		y: wrapperRect.top + wrapperRect.height / 2,
+	}
+	const safeCenter = {
+		x: safeRect.left + safeRect.width / 2,
+		y: safeRect.top + safeRect.height / 2,
+	}
+	return {
+		x: targetGeometry.center.x - (safeCenter.x - wrapperCenter.x) / scale,
+		y: targetGeometry.center.y - (safeCenter.y - wrapperCenter.y) / scale,
+		zoom,
+		scale,
+	}
+}
+
 function legacyKey(prefix: string, suffix: string): string {
 	return `${prefix}${suffix}`
 }
@@ -196,7 +550,8 @@ export class CanvasInlineToolSession<TAction> {
 	private previousSelectionIds: string[] = []
 	private viewportSnapshot: CanvasViewportSnapshot = {}
 	private toolbarPhase: CanvasInlineToolToolbarPhase = 'hidden'
-	private closed = false
+	private sessionState: CanvasInlineToolSessionState = 'closed'
+	private keyboardScopeActive = false
 
 	constructor(private readonly options: CanvasInlineToolSessionOptions<TAction>) {}
 
@@ -220,19 +575,26 @@ export class CanvasInlineToolSession<TAction> {
 		return this.toolbarPhase
 	}
 
+	get state(): CanvasInlineToolSessionState {
+		return this.sessionState
+	}
+
 	get context(): CanvasInlineToolContext<TAction> | null {
 		if (!this.wrapperEl) return null
 		return this.createContext()
 	}
 
-	open(): void {
-		if (activeInlineToolSession && activeInlineToolSession !== this) {
-			activeInlineToolSession.close()
-		}
-		setActiveInlineToolSession(this)
+	isActive(): boolean {
+		return (this.sessionState === 'opening' || this.sessionState === 'active') && this.wrapperEl?.isConnected === true
+	}
 
+	open(): void {
 		const wrapper = this.options.canvas.wrapperEl
 		if (!wrapper) throw new Error('Could not find canvas wrapper')
+		const existingSession = activeInlineToolSessions.get(wrapper)
+		if (existingSession && existingSession !== this) existingSession.close()
+		setActiveInlineToolSession(wrapper, this)
+		this.sessionState = 'opening'
 		this.wrapperEl = wrapper
 		this.previousSelectionIds = Array.from(this.options.canvas.selection || []).map(node => node.id)
 		this.viewportSnapshot = snapshotViewport(this.options.canvas)
@@ -242,6 +604,7 @@ export class CanvasInlineToolSession<TAction> {
 		for (const eventName of GATED_EVENTS) {
 			wrapper.addEventListener(eventName, this.handleCanvasGate, { capture: true, passive: false })
 		}
+		this.installKeyboardListeners()
 
 		this.options.node.nodeEl.classList.add('bragi-inline-tool-target')
 		if (this.options.legacyTargetClass) this.options.node.nodeEl.classList.add(this.options.legacyTargetClass)
@@ -257,10 +620,13 @@ export class CanvasInlineToolSession<TAction> {
 	}
 
 	close(): void {
-		if (this.closed) return
-		this.closed = true
+		if (this.sessionState === 'closing' || this.sessionState === 'closed') return
+		this.sessionState = 'closing'
+		this.suppressNativeToolbar()
+		clearActiveInlineToolSession(this.wrapperEl, this)
 		this.setToolbarPhase('hidden')
 		this.hideToolbarMenu()
+		this.removeKeyboardListeners()
 		this.options.onClose?.(this.createContext())
 		if (this.wrapperEl) {
 			this.wrapperEl.removeEventListener(this.options.actionEvent, this.handleToolAction)
@@ -270,15 +636,34 @@ export class CanvasInlineToolSession<TAction> {
 	}
 
 	renderToolbar(menuEl: HTMLElement): void {
+		this.tagToolbarMenu(menuEl)
 		this.options.renderToolbar(menuEl, this.createContext())
 	}
 
 	hideToolbarMenu(): void {
 		const menu = (this.options.canvas as CanvasViewportInternals).menu
 		const menuEl = menu?.menuEl || menu?.containerEl?.querySelector<HTMLElement>('.bragi-canvas-menu')
+		const inlineMenus = new Set<HTMLElement>()
+		if (menuEl) inlineMenus.add(menuEl)
+		activeDocument.querySelectorAll<HTMLElement>(
+			`.bragi-canvas-menu.bragi-inline-tool-menu-inline[data-bragi-inline-tool-session-id="${this.sessionId}"], .bragi-canvas-menu.bragi-annotation-menu-inline[data-bragi-inline-tool-session-id="${this.sessionId}"]`,
+		)
+			.forEach(el => inlineMenus.add(el))
+		for (const el of inlineMenus) {
+			el.classList.add('bragi-inline-tool-toolbar-hidden')
+			el.classList.add('bragi-annotation-toolbar-hidden')
+			el.querySelectorAll('.bragi-menu-injected').forEach(child => child.remove())
+			el.classList.remove('bragi-inline-tool-menu-inline')
+			el.classList.remove('bragi-annotation-menu-inline')
+			this.clearToolbarMenuTag(el)
+		}
+	}
+
+	primeNativeToolbarFadeIn(): void {
+		const menuEl = getSelectionMenuEl(this.options.canvas)
 		if (!menuEl) return
-		menuEl.classList.add('bragi-inline-tool-toolbar-hidden')
-		menuEl.classList.add('bragi-annotation-toolbar-hidden')
+		menuEl.classList.remove('bragi-native-toolbar-suppressed')
+		menuEl.classList.add('bragi-native-toolbar-fade', 'bragi-native-toolbar-hidden')
 	}
 
 	setToolbarPhase(phase: CanvasInlineToolToolbarPhase): void {
@@ -287,7 +672,7 @@ export class CanvasInlineToolSession<TAction> {
 	}
 
 	refreshToolbar(force = false): void {
-		if (this.closed && !force) return
+		if (!this.isActive() && !force) return
 		try {
 			;(this.options.canvas as CanvasViewportInternals).menu?.render?.(true)
 		} catch (err) {
@@ -318,17 +703,58 @@ export class CanvasInlineToolSession<TAction> {
 	private applyModeState(): void {
 		const wrapper = this.wrapperEl
 		if (!wrapper) return
+		delete wrapper.dataset.bragiInlineToolSuppressNativeToolbar
+		delete wrapper.dataset.bragiInlineToolRevealNativeToolbar
 		activeDocument.body.classList.add('bragi-inline-tool-active')
 		activeDocument.body.dataset.bragiInlineToolId = this.options.id
 		activeDocument.body.dataset.bragiInlineToolSessionId = this.sessionId
 		if (this.options.legacyBodyClass) activeDocument.body.classList.add(this.options.legacyBodyClass)
 		if (this.options.legacyDatasetPrefix) {
+			delete wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'SuppressNativeToolbar')]
+			delete wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'RevealNativeToolbar')]
 			activeDocument.body.dataset[legacyKey(this.options.legacyDatasetPrefix, 'SessionId')] = this.sessionId
 		}
 
+		setInlineToolbarTop(wrapper)
 		wrapper.classList.add('bragi-inline-tool-mode')
 		if (this.options.legacyModeClass) wrapper.classList.add(this.options.legacyModeClass)
 		this.syncDataset()
+	}
+
+	private suppressNativeToolbar(): void {
+		const wrapper = this.wrapperEl
+		if (wrapper) {
+			wrapper.dataset.bragiInlineToolSuppressNativeToolbar = 'true'
+			delete wrapper.dataset.bragiInlineToolRevealNativeToolbar
+			if (this.options.legacyDatasetPrefix) {
+				wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'SuppressNativeToolbar')] = 'true'
+				delete wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'RevealNativeToolbar')]
+			}
+		}
+		const menuEl = getSelectionMenuEl(this.options.canvas)
+		if (menuEl) {
+			menuEl.classList.add('bragi-native-toolbar-suppressed', 'bragi-native-toolbar-hidden')
+			menuEl.classList.remove('bragi-native-toolbar-fade')
+		}
+	}
+
+	private clearNativeToolbarSuppression(): void {
+		const wrapper = this.wrapperEl
+		if (wrapper) {
+			delete wrapper.dataset.bragiInlineToolSuppressNativeToolbar
+			if (this.options.legacyDatasetPrefix) {
+				delete wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'SuppressNativeToolbar')]
+			}
+		}
+	}
+
+	private requestNativeToolbarReveal(): void {
+		const wrapper = this.wrapperEl
+		if (!wrapper) return
+		wrapper.dataset.bragiInlineToolRevealNativeToolbar = 'true'
+		if (this.options.legacyDatasetPrefix) {
+			wrapper.dataset[legacyKey(this.options.legacyDatasetPrefix, 'RevealNativeToolbar')] = 'true'
+		}
 	}
 
 	private syncDataset(): void {
@@ -349,14 +775,11 @@ export class CanvasInlineToolSession<TAction> {
 	}
 
 	private focusTargetNode(): CanvasViewportTarget | null {
-		this.options.node.focus()
-		const bbox = getNodeBBox(this.options.node)
-		const center = {
-			x: (bbox.minX + bbox.maxX) / 2,
-			y: (bbox.minY + bbox.maxY) / 2,
-		}
-		const target = animateViewportTo(this.options.canvas, center.x, center.y, MAX_CANVAS_ZOOM)
+		if (!this.wrapperEl) return null
+		const focusTarget = calculateFocusTarget(this.options.canvas, this.options.node, this.wrapperEl, this.options.focusOptions)
+		const target = animateViewportTo(this.options.canvas, focusTarget.x, focusTarget.y, focusTarget.zoom)
 		if (target) return target
+		this.options.node.focus()
 		if (typeof this.options.canvas.zoomToSelection === 'function') {
 			this.options.canvas.zoomToSelection()
 			void this.options.canvas.requestFrame()
@@ -367,7 +790,20 @@ export class CanvasInlineToolSession<TAction> {
 	private async showToolbarAfterFocus(target: CanvasViewportTarget | null): Promise<void> {
 		await waitForViewport(this.options.canvas, target, VIEWPORT_FALLBACK_TOOLBAR_DELAY_MS)
 		await waitForAnimationFrames(2)
-		if (this.closed) return
+		if (this.sessionState !== 'opening') return
+		for (let pass = 0; pass < INLINE_TOOL_RENDERED_CORRECTION_PASSES; pass++) {
+			const correctionTarget = this.wrapperEl
+				? calculateRenderedCorrectionTarget(this.options.canvas, this.options.node, this.wrapperEl, this.options.focusOptions)
+				: null
+			if (!correctionTarget) break
+			const appliedCorrection = animateViewportTo(this.options.canvas, correctionTarget.x, correctionTarget.y, correctionTarget.zoom)
+			await waitForViewport(this.options.canvas, appliedCorrection)
+			await waitForAnimationFrames(2)
+			if (this.sessionState !== 'opening') return
+		}
+		if (this.sessionState !== 'opening') return
+		this.sessionState = 'active'
+		if (this.wrapperEl) setInlineToolbarTop(this.wrapperEl)
 		this.setToolbarPhase('ready')
 		this.options.onReady?.(this.createContext())
 		this.refreshToolbar()
@@ -375,7 +811,7 @@ export class CanvasInlineToolSession<TAction> {
 
 	private readonly handleToolAction = (event: Event): void => {
 		const action = (event as CustomEvent<TAction>).detail
-		if (!action || this.closed) return
+		if (!action || !this.isActive()) return
 		this.options.onAction(action, this.createContext())
 	}
 
@@ -386,15 +822,83 @@ export class CanvasInlineToolSession<TAction> {
 		if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation()
 	}
 
+	private readonly handleDocumentScopeEvent = (event: Event): void => {
+		this.keyboardScopeActive = this.isTargetInSessionScope(event.target)
+	}
+
+	private readonly handleDocumentKeyDown = (event: KeyboardEvent): void => {
+		if (!this.options.onKeyDown || !this.isActive() || !this.isKeyboardEventInSessionScope(event)) return
+		this.options.onKeyDown(event, this.createContext())
+	}
+
+	private installKeyboardListeners(): void {
+		if (!this.options.onKeyDown) return
+		this.keyboardScopeActive = true
+		activeDocument.addEventListener('keydown', this.handleDocumentKeyDown, true)
+		activeDocument.addEventListener('pointerdown', this.handleDocumentScopeEvent, true)
+		activeDocument.addEventListener('focusin', this.handleDocumentScopeEvent, true)
+	}
+
+	private removeKeyboardListeners(): void {
+		if (!this.options.onKeyDown) return
+		activeDocument.removeEventListener('keydown', this.handleDocumentKeyDown, true)
+		activeDocument.removeEventListener('pointerdown', this.handleDocumentScopeEvent, true)
+		activeDocument.removeEventListener('focusin', this.handleDocumentScopeEvent, true)
+		this.keyboardScopeActive = false
+	}
+
+	private tagToolbarMenu(menuEl: HTMLElement): void {
+		menuEl.dataset.bragiInlineToolId = this.options.id
+		menuEl.dataset.bragiInlineToolSessionId = this.sessionId
+		menuEl.dataset.bragiInlineToolNodeId = this.options.node.id
+	}
+
+	private clearToolbarMenuTag(menuEl: HTMLElement): void {
+		delete menuEl.dataset.bragiInlineToolId
+		delete menuEl.dataset.bragiInlineToolSessionId
+		delete menuEl.dataset.bragiInlineToolNodeId
+	}
+
+	private isKeyboardEventInSessionScope(event: KeyboardEvent): boolean {
+		const targetEl = eventTargetElement(event.target)
+		if (isDocumentLevelTarget(targetEl)) {
+			const activeEl = eventTargetElement(activeDocument.activeElement)
+			if (!isDocumentLevelTarget(activeEl)) return this.isTargetInSessionScope(activeEl)
+			return this.keyboardScopeActive
+		}
+		const inScope = this.isTargetInSessionScope(event.target)
+		this.keyboardScopeActive = inScope
+		return inScope
+	}
+
+	private isTargetInSessionScope(target: EventTarget | null): boolean {
+		const wrapper = this.wrapperEl
+		if (!wrapper) return false
+		const targetEl = eventTargetElement(target)
+		if (!targetEl) return this.keyboardScopeActive
+
+		const targetWrapper = targetEl.closest<HTMLElement>('.canvas-wrapper')
+		if (targetWrapper) return targetWrapper === wrapper
+
+		const canvasMenu = targetEl.closest<HTMLElement>('.bragi-canvas-menu')
+		if (canvasMenu) return canvasMenu.dataset.bragiInlineToolSessionId === this.sessionId
+
+		return this.options.isToolEventTarget?.(target) === true
+	}
+
 	private async finishCloseAfterViewport(target: CanvasViewportTarget | null): Promise<void> {
 		await waitForViewport(this.options.canvas, target)
 		const wrapper = this.wrapperEl
 		const ownsWrapper = !wrapper || wrapper.dataset.bragiInlineToolSessionId === this.sessionId
 		const ownsBody = activeDocument.body.dataset.bragiInlineToolSessionId === this.sessionId
+		if (ownsWrapper) {
+			this.primeNativeToolbarFadeIn()
+		}
 		if (ownsBody) {
 			activeDocument.body.classList.remove('bragi-inline-tool-active')
 			delete activeDocument.body.dataset.bragiInlineToolId
 			delete activeDocument.body.dataset.bragiInlineToolSessionId
+			clearInlineToolbarTop(wrapper)
 			if (this.options.legacyBodyClass) activeDocument.body.classList.remove(this.options.legacyBodyClass)
 			if (this.options.legacyDatasetPrefix) {
 				delete activeDocument.body.dataset[legacyKey(this.options.legacyDatasetPrefix, 'SessionId')]
@@ -405,6 +909,7 @@ export class CanvasInlineToolSession<TAction> {
 				wrapper.removeEventListener(eventName, this.handleCanvasGate, true)
 			}
 			if (ownsWrapper) {
+				clearInlineToolbarTop(wrapper)
 				wrapper.classList.remove('bragi-inline-tool-mode')
 				if (this.options.legacyModeClass) wrapper.classList.remove(this.options.legacyModeClass)
 				delete wrapper.dataset.bragiInlineToolId
@@ -422,23 +927,22 @@ export class CanvasInlineToolSession<TAction> {
 			}
 		}
 		if (!ownsWrapper) {
-			if (activeInlineToolSession !== this) {
+			if (wrapper && activeInlineToolSessions.get(wrapper) !== this) {
 				this.options.node.nodeEl.classList.remove('bragi-inline-tool-target')
 				if (this.options.legacyTargetClass) this.options.node.nodeEl.classList.remove(this.options.legacyTargetClass)
 				if (this.options.legacyContentClass) this.options.node.contentEl.classList.remove(this.options.legacyContentClass)
 			}
+			this.sessionState = 'closed'
 			return
 		}
 		this.options.node.nodeEl.classList.remove('bragi-inline-tool-target')
 		if (this.options.legacyTargetClass) this.options.node.nodeEl.classList.remove(this.options.legacyTargetClass)
 		if (this.options.legacyContentClass) this.options.node.contentEl.classList.remove(this.options.legacyContentClass)
 		this.restoreSelection()
-		activeDocument.body.dataset.bragiInlineToolRevealNativeToolbar = 'true'
-		if (this.options.legacyDatasetPrefix) {
-			activeDocument.body.dataset[legacyKey(this.options.legacyDatasetPrefix, 'RevealNativeToolbar')] = 'true'
-		}
+		this.clearNativeToolbarSuppression()
+		this.requestNativeToolbarReveal()
 		this.refreshToolbar(true)
-		if (activeInlineToolSession === this) activeInlineToolSession = null
+		this.sessionState = 'closed'
 	}
 
 	private restoreSelection(): void {
@@ -457,8 +961,25 @@ export class CanvasInlineToolSession<TAction> {
 	}
 }
 
+function eventTargetElement(target: EventTarget | null): HTMLElement | null {
+	if (target instanceof HTMLElement) return target
+	if (target instanceof SVGElement) return target.closest<HTMLElement>('svg') || target.parentElement
+	return null
+}
+
+function isDocumentLevelTarget(target: HTMLElement | null): boolean {
+	return !target || target === activeDocument.body || target === activeDocument.documentElement
+}
+
 export function getActiveInlineToolSession(canvas?: Canvas): CanvasInlineToolSession<unknown> | null {
-	if (!activeInlineToolSession) return null
-	if (canvas && activeInlineToolSession.canvas !== canvas) return null
-	return activeInlineToolSession
+	const wrapper = canvas?.wrapperEl
+	if (!wrapper) return null
+	const session = activeInlineToolSessions.get(wrapper)
+	if (!session) return null
+	if (!session.isActive()) {
+		activeInlineToolSessions.delete(wrapper)
+		return null
+	}
+	if (session.canvas !== canvas) return null
+	return session
 }

--- a/src/image-annotations.ts
+++ b/src/image-annotations.ts
@@ -431,7 +431,7 @@ function isEditableTarget(target: EventTarget | null): boolean {
 
 function isAnnotationEventTarget(target: EventTarget | null): boolean {
 	if (!(target instanceof HTMLElement)) return false
-	return Boolean(target.closest('.bragi-annotation-layer, .bragi-canvas-menu'))
+	return Boolean(target.closest('.bragi-annotation-layer, .bragi-canvas-menu, .bragi-annotation-color-dropdown'))
 }
 
 const ANNOTATION_COLOR_PRESETS = [
@@ -590,8 +590,10 @@ class ImageAnnotationCanvasMode {
 		}
 		if (isEditableTarget(event.target)) return
 
-		event.stopPropagation()
-		if (event.key === 'Backspace' || event.key === 'Delete' || event.key === ' ') event.preventDefault()
+		if (event.key === 'Backspace' || event.key === 'Delete' || event.key === ' ') {
+			event.preventDefault()
+			event.stopPropagation()
+		}
 	}
 
 	private async load(): Promise<void> {
@@ -605,6 +607,7 @@ class ImageAnnotationCanvasMode {
 			onAction: action => this.handleToolbarAction(action),
 			mountLayer: () => this.buildNodeLayer(),
 			isToolEventTarget: isAnnotationEventTarget,
+			onKeyDown: event => this.handleKeyDown(event),
 			onClose: () => this.cleanupAfterSessionClose(),
 			legacyModeClass: 'bragi-annotation-mode',
 			legacyTargetClass: 'bragi-annotation-target',
@@ -612,7 +615,6 @@ class ImageAnnotationCanvasMode {
 			legacyContentClass: 'bragi-annotation-content',
 			legacyDatasetPrefix: 'bragiAnnotation',
 		})
-		activeDocument.addEventListener('keydown', this.handleKeyDown, true)
 		this.session.open()
 		this.syncToolState()
 		this.render()
@@ -1062,7 +1064,6 @@ class ImageAnnotationCanvasMode {
 	}
 
 	private cleanupAfterSessionClose(): void {
-		activeDocument.removeEventListener('keydown', this.handleKeyDown, true)
 		closeAnnotationDropdown()
 		const wrapper = this.session?.context?.wrapperEl
 		if (wrapper) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -372,7 +372,7 @@ export default class BragiCanvas extends Plugin {
 				console.error('Bragi compose images error:', err)
 				new Notice(`Collage failed: ${err.message || err}`)
 			}),
-			(node) => openImageAnnotationTool(this, canvas, node, 'box'),
+			(node, activeCanvas) => openImageAnnotationTool(this, activeCanvas, node, 'box'),
 		)
 
 		patchPlaceholderContextMenu(canvas)

--- a/src/node-toolbar-position.ts
+++ b/src/node-toolbar-position.ts
@@ -151,19 +151,24 @@ export function positionNodeToolbar(
 
 const pendingMenuSync = new WeakMap<HTMLElement, number>()
 
+type SelectionMenuGapSyncOptions = {
+	placement?: ToolbarPlacementPreference
+	preserveObsidianPlacement?: boolean
+}
+
 /** Re-apply the shared node gap after Obsidian positions the selection menu. */
-export function queueSelectionMenuGapSync(menuEl: HTMLElement, canvas: Canvas): void {
+export function queueSelectionMenuGapSync(menuEl: HTMLElement, canvas: Canvas, options?: SelectionMenuGapSyncOptions): void {
 	const pending = pendingMenuSync.get(menuEl)
 	if (pending) window.cancelAnimationFrame(pending)
 
 	const id = window.requestAnimationFrame(() => {
 		pendingMenuSync.delete(menuEl)
-		syncSelectionMenuGap(menuEl, canvas)
+		syncSelectionMenuGap(menuEl, canvas, options)
 	})
 	pendingMenuSync.set(menuEl, id)
 }
 
-export function syncSelectionMenuGap(menuEl: HTMLElement, canvas: Canvas): void {
+export function syncSelectionMenuGap(menuEl: HTMLElement, canvas: Canvas, options?: SelectionMenuGapSyncOptions): void {
 	if (!canvas.selection?.size) {
 		resetToolbarPosition(menuEl)
 		return
@@ -176,5 +181,5 @@ export function syncSelectionMenuGap(menuEl: HTMLElement, canvas: Canvas): void 
 		return
 	}
 
-	positionNodeToolbar(menuEl, bounds, { preserveObsidianPlacement: true })
+	positionNodeToolbar(menuEl, bounds, options ?? { preserveObsidianPlacement: true })
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -742,8 +742,15 @@
 
 .bragi-canvas-menu.bragi-inline-tool-menu-inline,
 .bragi-canvas-menu.bragi-annotation-menu-inline {
+	position: fixed !important;
+	top: var(--bragi-inline-tool-toolbar-top, 64px) !important;
+	left: 50% !important;
+	right: auto !important;
+	bottom: auto !important;
 	gap: 1px;
 	padding: var(--size-2-1);
+	transform: translateX(-50%) !important;
+	z-index: 1000 !important;
 }
 
 .bragi-canvas-menu .bragi-annotation-separator {
@@ -802,6 +809,14 @@
 	transition: opacity 120ms ease, transform 120ms ease, visibility 0s linear 120ms;
 }
 
+.bragi-canvas-menu.bragi-native-toolbar-suppressed {
+	opacity: 0 !important;
+	visibility: hidden !important;
+	transform: translateY(-4px) !important;
+	pointer-events: none !important;
+	transition: none !important;
+}
+
 .bragi-inline-tool-mode .canvas-node:not(.bragi-inline-tool-target),
 .bragi-annotation-mode .canvas-node:not(.bragi-annotation-target),
 .bragi-inline-tool-mode .canvas-edges,
@@ -812,27 +827,34 @@
 }
 
 .bragi-inline-tool-mode .canvas-controls,
-.bragi-inline-tool-mode .canvas-card-menu,
+.bragi-inline-tool-mode .canvas-card-menu:not(.bragi-canvas-menu),
 .bragi-annotation-mode .canvas-controls,
-.bragi-annotation-mode .canvas-card-menu {
-	opacity: 0.35;
+.bragi-annotation-mode .canvas-card-menu:not(.bragi-canvas-menu) {
+	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
+	z-index: 1 !important;
 }
 
 .bragi-inline-tool-mode .bragi-canvas-menu,
-.bragi-annotation-mode .bragi-canvas-menu {
+.bragi-annotation-mode .bragi-canvas-menu,
+body.bragi-inline-tool-active .bragi-canvas-menu.bragi-inline-tool-menu-inline,
+body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-menu-inline {
 	opacity: 1;
 	visibility: visible;
-	transform: translateY(0);
+	transform: translateX(-50%) translateY(0) !important;
 	pointer-events: auto;
+	z-index: 1000 !important;
 	transition: opacity 140ms ease, transform 140ms ease, visibility 0s linear 0s;
 }
 
 .bragi-inline-tool-mode .bragi-canvas-menu.bragi-inline-tool-toolbar-hidden,
-.bragi-annotation-mode .bragi-canvas-menu.bragi-annotation-toolbar-hidden {
+.bragi-annotation-mode .bragi-canvas-menu.bragi-annotation-toolbar-hidden,
+body.bragi-inline-tool-active .bragi-canvas-menu.bragi-inline-tool-toolbar-hidden,
+body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hidden {
 	opacity: 0;
 	visibility: hidden;
-	transform: translateY(-4px);
+	transform: translateX(-50%) translateY(-4px) !important;
 	pointer-events: none;
 	transition: opacity 120ms ease, transform 120ms ease, visibility 0s linear 120ms;
 }
@@ -841,7 +863,7 @@
 .bragi-annotation-mode .bragi-annotation-target {
 	opacity: 1;
 	pointer-events: auto;
-	z-index: 20;
+	z-index: 50 !important;
 }
 
 .bragi-inline-tool-mode .bragi-inline-tool-target .canvas-node-container,
@@ -889,15 +911,7 @@
 .bragi-annotation-mode .canvas-node-connection-point,
 .bragi-annotation-mode .canvas-node-connection-point::after,
 .bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point,
-.bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point::after,
-body.bragi-inline-tool-active .canvas-node-connection-point,
-body.bragi-inline-tool-active .canvas-node-connection-point::after,
-body.bragi-inline-tool-active .canvas-node-resizer:hover .canvas-node-connection-point,
-body.bragi-inline-tool-active .canvas-node-resizer:hover .canvas-node-connection-point::after,
-body.bragi-annotation-mode-active .canvas-node-connection-point,
-body.bragi-annotation-mode-active .canvas-node-connection-point::after,
-body.bragi-annotation-mode-active .canvas-node-resizer:hover .canvas-node-connection-point,
-body.bragi-annotation-mode-active .canvas-node-resizer:hover .canvas-node-connection-point::after {
+.bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point::after {
 	display: none !important;
 	visibility: hidden !important;
 	opacity: 0 !important;

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -51,15 +51,37 @@ function fadeOutNativeToolbar(menuEl: HTMLElement, onComplete: () => void): void
 }
 
 function clearNativeToolbarFade(menuEl: HTMLElement): void {
-	menuEl.classList.remove('bragi-native-toolbar-fade', 'bragi-native-toolbar-hidden')
+	menuEl.classList.remove('bragi-native-toolbar-fade', 'bragi-native-toolbar-hidden', 'bragi-native-toolbar-suppressed')
 }
 
-function revealNativeToolbarIfRequested(menuEl: HTMLElement): void {
-	const shouldReveal = activeDocument.body.dataset.bragiInlineToolRevealNativeToolbar === 'true'
-		|| activeDocument.body.dataset.bragiAnnotationRevealNativeToolbar === 'true'
+function isNativeToolbarSuppressed(canvas?: Canvas): boolean {
+	return canvas?.wrapperEl?.dataset.bragiInlineToolSuppressNativeToolbar === 'true'
+		|| canvas?.wrapperEl?.dataset.bragiAnnotationSuppressNativeToolbar === 'true'
+}
+
+function suppressNativeToolbar(menuEl: HTMLElement): void {
+	closeBragiDropdown()
+	menuEl.classList.add('bragi-native-toolbar-suppressed', 'bragi-native-toolbar-hidden')
+	menuEl.classList.remove('bragi-native-toolbar-fade')
+}
+
+function revealNativeToolbarIfRequested(menuEl: HTMLElement, canvas?: Canvas): void {
+	if (isNativeToolbarSuppressed(canvas)) {
+		suppressNativeToolbar(menuEl)
+		return
+	}
+	const wrapper = canvas?.wrapperEl
+	const shouldReveal = wrapper?.dataset.bragiInlineToolRevealNativeToolbar === 'true'
+		|| wrapper?.dataset.bragiAnnotationRevealNativeToolbar === 'true'
 	if (!shouldReveal) return
-	delete activeDocument.body.dataset.bragiInlineToolRevealNativeToolbar
-	delete activeDocument.body.dataset.bragiAnnotationRevealNativeToolbar
+	if (wrapper) {
+		delete wrapper.dataset.bragiInlineToolRevealNativeToolbar
+		delete wrapper.dataset.bragiAnnotationRevealNativeToolbar
+	}
+	if (canvas?.selection?.size) {
+		queueSelectionMenuGapSync(menuEl, canvas, { placement: 'auto-above' })
+	}
+	menuEl.classList.remove('bragi-native-toolbar-suppressed')
 	menuEl.classList.add('bragi-native-toolbar-fade', 'bragi-native-toolbar-hidden')
 	window.requestAnimationFrame(() => {
 		window.requestAnimationFrame(() => {
@@ -329,6 +351,9 @@ function addMoreButton(menuEl: HTMLElement): void {
 
 function clearMenuInjection(menuEl: HTMLElement): void {
 	closeBragiDropdown()
+	delete menuEl.dataset.bragiInlineToolId
+	delete menuEl.dataset.bragiInlineToolSessionId
+	delete menuEl.dataset.bragiInlineToolNodeId
 	menuEl.classList.remove('bragi-inline-tool-toolbar-hidden')
 	menuEl.classList.remove('bragi-inline-tool-menu-inline')
 	menuEl.classList.remove('bragi-annotation-toolbar-hidden')
@@ -410,7 +435,12 @@ function revealInlineToolMenuAfterLayout(menuEl: HTMLElement, canvas: Canvas): v
 function renderHiddenInlineToolMenu(menuEl: HTMLElement, canvas: Canvas): void {
 	const session = getActiveInlineToolSession(canvas)
 	if (!session) return
+	const context = session.context
+	if (!context) return
 	hideNativeInlineToolMenuItems(menuEl)
+	menuEl.dataset.bragiInlineToolId = session.id
+	menuEl.dataset.bragiInlineToolSessionId = context.sessionId
+	menuEl.dataset.bragiInlineToolNodeId = session.targetNodeId
 	menuEl.classList.remove('bragi-annotation-menu-split')
 	menuEl.classList.add('bragi-inline-tool-menu-inline')
 	menuEl.classList.add('bragi-annotation-menu-inline')
@@ -427,7 +457,12 @@ function renderHiddenInlineToolMenu(menuEl: HTMLElement, canvas: Canvas): void {
 function renderInlineToolMenu(menuEl: HTMLElement, canvas: Canvas): void {
 	const session = getActiveInlineToolSession(canvas)
 	if (!session) return
+	const context = session.context
+	if (!context) return
 	hideNativeInlineToolMenuItems(menuEl)
+	menuEl.dataset.bragiInlineToolId = session.id
+	menuEl.dataset.bragiInlineToolSessionId = context.sessionId
+	menuEl.dataset.bragiInlineToolNodeId = session.targetNodeId
 	menuEl.classList.remove('bragi-annotation-menu-split')
 	menuEl.classList.add('bragi-inline-tool-menu-inline')
 	menuEl.classList.add('bragi-annotation-menu-inline')
@@ -583,7 +618,7 @@ export function patchCanvasMenu(
 	onPanorama?: (node: CanvasNode) => void,
 	onGridSplit?: (node: CanvasNode) => void,
 	onComposeImages?: (nodes: CanvasNode[]) => void,
-	onAnnotateImage?: (node: CanvasNode) => void,
+	onAnnotateImage?: (node: CanvasNode, canvas: Canvas) => void,
 ): void {
 	if (menuUninstaller) return
 
@@ -606,7 +641,7 @@ export function patchCanvasMenu(
 			const syncMenuGap = () => {
 				if (!canvas?.selection?.size) {
 					resetToolbarPosition(menuEl)
-					revealNativeToolbarIfRequested(menuEl)
+					revealNativeToolbarIfRequested(menuEl, canvas)
 					return
 				}
 				const hasNodes = Array.from(canvas.selection).some(hasCanvasData)
@@ -615,9 +650,15 @@ export function patchCanvasMenu(
 				} else {
 					resetToolbarPosition(menuEl)
 				}
-				revealNativeToolbarIfRequested(menuEl)
+				revealNativeToolbarIfRequested(menuEl, canvas)
 			}
 			clearMenuInjection(menuEl)
+
+			if (isNativeToolbarSuppressed(canvas)) {
+				suppressNativeToolbar(menuEl)
+				syncMenuGap()
+				return result
+			}
 
 			// ── Align button: hover-to-open (native menu) ──
 			if (selSize > 1) {
@@ -689,8 +730,17 @@ export function patchCanvasMenu(
 			const nodeData = selectedNode ? getCanvasData(selectedNode) : null
 			const filePath = nodeData?.file || ''
 			const inlineToolSession = getActiveInlineToolSession(canvas)
+			const inlineToolContext = inlineToolSession?.context
+			const isInlineToolSelection = Boolean(
+				selectedNode
+				&& inlineToolSession
+				&& inlineToolContext
+				&& inlineToolSession.isActive()
+				&& inlineToolSession.targetNodeId === selectedNode.id
+				&& canvas.wrapperEl?.dataset.bragiInlineToolSessionId === inlineToolContext.sessionId,
+			)
 
-			if (selectedNode && inlineToolSession?.targetNodeId === selectedNode.id) {
+			if (isInlineToolSelection && inlineToolSession) {
 				if (inlineToolSession.phase === 'ready') {
 					renderInlineToolMenu(menuEl, canvas)
 				} else {
@@ -781,7 +831,7 @@ export function patchCanvasMenu(
 			if (isImageNode) {
 				if (onAnnotateImage) {
 					const annotateBtn = createMenuButton('bragi-annotate', 'bragi-annotate', 'Annotate image', () => {
-						fadeOutNativeToolbar(menuEl, () => onAnnotateImage(selectedNode))
+						fadeOutNativeToolbar(menuEl, () => onAnnotateImage(selectedNode, canvas))
 					})
 					menuEl.appendChild(annotateBtn)
 				}
@@ -1203,10 +1253,19 @@ export function removeToolbarButtons(): void {
 	activeDocument.querySelectorAll('.canvas-card-menu.bragi-annotation-menu-split').forEach(el => el.classList.remove('bragi-annotation-menu-split'))
 	activeDocument.querySelectorAll('.canvas-card-menu.bragi-native-toolbar-fade').forEach(el => el.classList.remove('bragi-native-toolbar-fade'))
 	activeDocument.querySelectorAll('.canvas-card-menu.bragi-native-toolbar-hidden').forEach(el => el.classList.remove('bragi-native-toolbar-hidden'))
+	activeDocument.querySelectorAll('.canvas-card-menu.bragi-native-toolbar-suppressed').forEach(el => el.classList.remove('bragi-native-toolbar-suppressed'))
 	activeDocument.querySelectorAll('.bragi-canvas-menu.bragi-inline-tool-menu-inline').forEach(el => el.classList.remove('bragi-inline-tool-menu-inline'))
 	activeDocument.querySelectorAll('.bragi-canvas-menu.bragi-annotation-menu-inline').forEach(el => el.classList.remove('bragi-annotation-menu-inline'))
+	activeDocument.querySelectorAll<HTMLElement>('.canvas-card-menu').forEach(el => {
+		delete el.dataset.bragiInlineToolId
+		delete el.dataset.bragiInlineToolSessionId
+		delete el.dataset.bragiInlineToolNodeId
+	})
 	delete activeDocument.body.dataset.bragiInlineToolRevealNativeToolbar
 	delete activeDocument.body.dataset.bragiAnnotationRevealNativeToolbar
+	delete activeDocument.body.dataset.bragiInlineToolSuppressNativeToolbar
+	delete activeDocument.body.dataset.bragiInlineToolSuppressSessionId
+	delete activeDocument.body.dataset.bragiAnnotationSuppressNativeToolbar
 	setInteractionToolDisplaySync(null)
 	teardownCanvasInteractionTool()
 }

--- a/styles.css
+++ b/styles.css
@@ -742,8 +742,15 @@
 
 .bragi-canvas-menu.bragi-inline-tool-menu-inline,
 .bragi-canvas-menu.bragi-annotation-menu-inline {
+	position: fixed !important;
+	top: var(--bragi-inline-tool-toolbar-top, 64px) !important;
+	left: 50% !important;
+	right: auto !important;
+	bottom: auto !important;
 	gap: 1px;
 	padding: var(--size-2-1);
+	transform: translateX(-50%) !important;
+	z-index: 1000 !important;
 }
 
 .bragi-canvas-menu .bragi-annotation-separator {
@@ -802,6 +809,14 @@
 	transition: opacity 120ms ease, transform 120ms ease, visibility 0s linear 120ms;
 }
 
+.bragi-canvas-menu.bragi-native-toolbar-suppressed {
+	opacity: 0 !important;
+	visibility: hidden !important;
+	transform: translateY(-4px) !important;
+	pointer-events: none !important;
+	transition: none !important;
+}
+
 .bragi-inline-tool-mode .canvas-node:not(.bragi-inline-tool-target),
 .bragi-annotation-mode .canvas-node:not(.bragi-annotation-target),
 .bragi-inline-tool-mode .canvas-edges,
@@ -812,27 +827,34 @@
 }
 
 .bragi-inline-tool-mode .canvas-controls,
-.bragi-inline-tool-mode .canvas-card-menu,
+.bragi-inline-tool-mode .canvas-card-menu:not(.bragi-canvas-menu),
 .bragi-annotation-mode .canvas-controls,
-.bragi-annotation-mode .canvas-card-menu {
-	opacity: 0.35;
+.bragi-annotation-mode .canvas-card-menu:not(.bragi-canvas-menu) {
+	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
+	z-index: 1 !important;
 }
 
 .bragi-inline-tool-mode .bragi-canvas-menu,
-.bragi-annotation-mode .bragi-canvas-menu {
+.bragi-annotation-mode .bragi-canvas-menu,
+body.bragi-inline-tool-active .bragi-canvas-menu.bragi-inline-tool-menu-inline,
+body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-menu-inline {
 	opacity: 1;
 	visibility: visible;
-	transform: translateY(0);
+	transform: translateX(-50%) translateY(0) !important;
 	pointer-events: auto;
+	z-index: 1000 !important;
 	transition: opacity 140ms ease, transform 140ms ease, visibility 0s linear 0s;
 }
 
 .bragi-inline-tool-mode .bragi-canvas-menu.bragi-inline-tool-toolbar-hidden,
-.bragi-annotation-mode .bragi-canvas-menu.bragi-annotation-toolbar-hidden {
+.bragi-annotation-mode .bragi-canvas-menu.bragi-annotation-toolbar-hidden,
+body.bragi-inline-tool-active .bragi-canvas-menu.bragi-inline-tool-toolbar-hidden,
+body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hidden {
 	opacity: 0;
 	visibility: hidden;
-	transform: translateY(-4px);
+	transform: translateX(-50%) translateY(-4px) !important;
 	pointer-events: none;
 	transition: opacity 120ms ease, transform 120ms ease, visibility 0s linear 120ms;
 }
@@ -841,7 +863,7 @@
 .bragi-annotation-mode .bragi-annotation-target {
 	opacity: 1;
 	pointer-events: auto;
-	z-index: 20;
+	z-index: 50 !important;
 }
 
 .bragi-inline-tool-mode .bragi-inline-tool-target .canvas-node-container,
@@ -889,15 +911,7 @@
 .bragi-annotation-mode .canvas-node-connection-point,
 .bragi-annotation-mode .canvas-node-connection-point::after,
 .bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point,
-.bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point::after,
-body.bragi-inline-tool-active .canvas-node-connection-point,
-body.bragi-inline-tool-active .canvas-node-connection-point::after,
-body.bragi-inline-tool-active .canvas-node-resizer:hover .canvas-node-connection-point,
-body.bragi-inline-tool-active .canvas-node-resizer:hover .canvas-node-connection-point::after,
-body.bragi-annotation-mode-active .canvas-node-connection-point,
-body.bragi-annotation-mode-active .canvas-node-connection-point::after,
-body.bragi-annotation-mode-active .canvas-node-resizer:hover .canvas-node-connection-point,
-body.bragi-annotation-mode-active .canvas-node-resizer:hover .canvas-node-connection-point::after {
+.bragi-annotation-mode .canvas-node-resizer:hover .canvas-node-connection-point::after {
 	display: none !important;
 	visibility: hidden !important;
 	opacity: 0 !important;


### PR DESCRIPTION
## Summary
- isolate inline annotation mode by canvas wrapper so other canvases keep keyboard shortcuts, controls, and connection points
- direct-fit inline tool focus using rendered DOM scale and safe rect targeting
- fix native topbar restoration after exiting inline mode
- document inline tool mode implementation rules in AGENT.md

## Test Plan
- npm run build
- npm run lint:obsidian
- git diff --check

## Local verification
- Copied main.js, styles.css, and manifest.json to the local Obsidian plugin folder and hash-checked the copied files.