### PR TITLE
feat: add MuleRouter CarrotHub image models

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:obsidian": "eslint .",
     "test:update-check": "node scripts/verify-update-check.mjs",
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
+    "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"

--- a/scripts/verify-mulerouter-carrothub-images.mjs
+++ b/scripts/verify-mulerouter-carrothub-images.mjs
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const modelSource = readFileSync('src/models/wan.ts', 'utf8')
+const modelIndexSource = readFileSync('src/models/index.ts', 'utf8')
+const registrySource = readFileSync('src/providers/registry.ts', 'utf8')
+const providerSource = readFileSync('src/providers/mulerouter.ts', 'utf8')
+
+function assertOrder(source, first, second, message) {
+	const firstIndex = source.indexOf(first)
+	const secondIndex = source.indexOf(second)
+	assert.notEqual(firstIndex, -1, `${message}: missing "${first}"`)
+	assert.notEqual(secondIndex, -1, `${message}: missing "${second}"`)
+	assert.ok(firstIndex < secondIndex, message)
+}
+
+for (const modelId of ['z-image-spicy', 'qwen-image-edit-spicy']) {
+	assert.match(modelSource, new RegExp(`id: '${modelId}'`), `${modelId} must be registered in the model catalogue`)
+	assert.match(
+		modelSource,
+		new RegExp(`mulerouter: \\{ apiModelId: '${modelId}' \\}`),
+		`${modelId} must be connected to MuleRouter`,
+	)
+}
+
+assert.match(modelSource, /modes: \['text-to-image'\]/, 'Z-Image Spicy must expose text-to-image mode')
+assert.match(modelSource, /modes: \['image-ref-to-image'\]/, 'Qwen Image Edit Spicy must expose image-ref-to-image mode')
+assert.match(modelSource, /id: 'aspectRatio'[\s\S]*default: '2:3'/, 'Z-Image Spicy must expose fixed aspect-ratio choices')
+assert.doesNotMatch(modelSource, /id: 'seed'/, 'MuleRouter image models must not expose seed')
+assert.doesNotMatch(modelSource, /id: 'width'|id: 'height'/, 'Z-Image Spicy must not expose free width/height params')
+assertOrder(modelIndexSource, 'zImageSpicy', 'qwenImageEditSpicy', 'MuleRouter image models must be included in image catalogue order')
+
+assert.match(registrySource, /MuleRouterImageProvider/, 'MuleRouter registry must import the image provider')
+assert.match(registrySource, /makeImage: \(\{ settings, app, outputDir \}\) =>[\s\S]*new MuleRouterImageProvider/, 'MuleRouter must expose makeImage')
+
+for (const endpoint of [
+	'/vendors/carrothub/v1/z-image-spicy/generation',
+	'/vendors/carrothub/v1/qwen-image-edit-spicy/generation',
+]) {
+	assert.match(providerSource, new RegExp(endpoint.replace(/[/.]/g, '\\$&')), `provider must call ${endpoint}`)
+}
+assert.match(providerSource, /class MuleRouterImageProvider implements ImageProvider/, 'MuleRouter image provider must implement ImageProvider')
+assert.match(providerSource, /Z_IMAGE_SIZES/, 'MuleRouter image provider must map aspect ratios to fixed Z-Image dimensions')
+assert.doesNotMatch(providerSource, /body\.seed|parseOptionalSeed/, 'MuleRouter image provider must not send seed')
+assert.match(providerSource, /pollImageTask/, 'MuleRouter image provider must poll async image tasks')
+assert.match(providerSource, /extractImageUrl/, 'MuleRouter image provider must extract completed image URLs')
+
+const skillModelsPath = '../skill/bragi-canvas/references/models.md'
+if (existsSync(skillModelsPath)) {
+	const skillModelsSource = readFileSync(skillModelsPath, 'utf8')
+	for (const modelId of ['z-image-spicy', 'qwen-image-edit-spicy']) {
+		assert.match(skillModelsSource, new RegExp(`\`${modelId}\``), `skill docs must mention ${modelId}`)
+	}
+	assert.match(skillModelsSource, /MuleRouter key →/, 'skill docs must keep the MuleRouter provider availability note')
+}
+
+console.log('MuleRouter CarrotHub image model checks passed.')

--- a/src/canvas-ops.ts
+++ b/src/canvas-ops.ts
@@ -65,13 +65,31 @@ function parseAspectRatio(raw?: string): { wRatio: number; hRatio: number } {
 	return { wRatio: w, hRatio: h }
 }
 
+function ratioParam(value: unknown): string | undefined {
+	if (typeof value === 'string' && value.trim()) return value.trim()
+	if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+	return undefined
+}
+
+function positiveIntParam(value: unknown): number | undefined {
+	const parsed = typeof value === 'number' ? value : parseInt(ratioParam(value) || '', 10)
+	if (!Number.isFinite(parsed) || parsed <= 0) return undefined
+	return Math.round(parsed)
+}
+
 /**
  * Pull the user-selected aspect ratio out of PanelResult.params. Accepts both
  * `aspectRatio` (most models) and `aspect_ratio` (kling, grok video) spellings.
+ * Pixel-sized image models can also provide width/height.
  */
 export function readAspectRatio(params?: Record<string, unknown>): string | undefined {
 	if (!params) return undefined
-	return params.aspectRatio || params.aspect_ratio || params.ratio
+	const explicit = ratioParam(params.aspectRatio) || ratioParam(params.aspect_ratio) || ratioParam(params.ratio)
+	if (explicit) return explicit
+	const width = positiveIntParam(params.width)
+	const height = positiveIntParam(params.height)
+	if (width && height) return `${width}:${height}`
+	return undefined
 }
 
 interface BBox { x: number; y: number; w: number; h: number }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,7 +6,7 @@ import { seedance2, seedance2Fast } from './seedance'
 import { kling3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
-import { wan27I2vSpicy } from './wan'
+import { zImageSpicy, qwenImageEditSpicy, wan27I2vSpicy } from './wan'
 import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
@@ -36,6 +36,8 @@ export const ALL_MODELS: ModelConfig[] = [
 	lumaUni1,
 	seedream5,
 	seedream45,
+	zImageSpicy,
+	qwenImageEditSpicy,
 	// Video
 	seedance2,
 	seedance2Fast,

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -1,5 +1,55 @@
 import type { ModelConfig } from './types'
 
+export const zImageSpicy: ModelConfig = {
+	id: 'z-image-spicy',
+	name: 'Z-Image Spicy',
+	type: 'image',
+	supportedProviders: {
+		mulerouter: { apiModelId: 'z-image-spicy' },
+	},
+	modes: ['text-to-image'],
+	params: [
+		{
+			id: 'aspectRatio',
+			label: 'Aspect Ratio',
+			type: 'select',
+			options: [
+				{ label: '1:1', value: '1:1' },
+				{ label: '2:3', value: '2:3' },
+				{ label: '3:2', value: '3:2' },
+				{ label: '3:4', value: '3:4' },
+				{ label: '4:3', value: '4:3' },
+				{ label: '4:5', value: '4:5' },
+				{ label: '5:4', value: '5:4' },
+				{ label: '9:16', value: '9:16' },
+				{ label: '16:9', value: '16:9' },
+			],
+			default: '2:3',
+		},
+		{
+			id: 'prompt_extend',
+			label: 'Prompt extend',
+			type: 'select',
+			options: [
+				{ label: 'On', value: 'true' },
+				{ label: 'Off', value: 'false' },
+			],
+			default: 'true',
+		},
+	],
+}
+
+export const qwenImageEditSpicy: ModelConfig = {
+	id: 'qwen-image-edit-spicy',
+	name: 'Qwen Image Edit Spicy',
+	type: 'image',
+	supportedProviders: {
+		mulerouter: { apiModelId: 'qwen-image-edit-spicy' },
+	},
+	modes: ['image-ref-to-image'],
+	params: [],
+}
+
 export const wan27I2vSpicy: ModelConfig = {
 	id: 'wan-2.7-i2v-spicy',
 	name: 'Wan 2.7 Spicy I2V',

--- a/src/providers/mulerouter.ts
+++ b/src/providers/mulerouter.ts
@@ -1,13 +1,29 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- MuleRouter responses are runtime-shaped and narrowed at the provider boundary. */
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-import type { GenerateVideoResult, VideoProvider } from './types'
+import type { GenerateImageResult, GenerateVideoResult, ImageProvider, VideoProvider } from './types'
 import { uploadRef } from './upload'
 
 const BASE_URL = 'https://api.mulerouter.ai'
+const Z_IMAGE_SPICY_PATH = '/vendors/carrothub/v1/z-image-spicy/generation'
+const QWEN_IMAGE_EDIT_SPICY_PATH = '/vendors/carrothub/v1/qwen-image-edit-spicy/generation'
 const WAN27_I2V_SPICY_PATH = '/vendors/carrothub/v1/wan2.7-i2v-spicy/generation'
+const IMAGE_POLL_INITIAL_DELAY_MS = 10000
+const IMAGE_POLL_INTERVAL_MS = 3000
+const IMAGE_POLL_MAX_WAIT_MS = 300000
 const DONE_STATUSES = new Set(['completed'])
 const FAILED_STATUSES = new Set(['failed'])
+const Z_IMAGE_SIZES: Record<string, { width: number; height: number }> = {
+	'1:1': { width: 1024, height: 1024 },
+	'2:3': { width: 1024, height: 1536 },
+	'3:2': { width: 1536, height: 1024 },
+	'3:4': { width: 1152, height: 1536 },
+	'4:3': { width: 1536, height: 1152 },
+	'4:5': { width: 1024, height: 1280 },
+	'5:4': { width: 1280, height: 1024 },
+	'9:16': { width: 864, height: 1536 },
+	'16:9': { width: 1536, height: 864 },
+}
 
 type JsonRecord = Record<string, unknown>
 
@@ -22,7 +38,11 @@ function stringParam(value: unknown, fallback = ''): string {
 }
 
 function isHttpUrl(value: string): boolean {
-	return /^https:\/\//i.test(value)
+	return /^https?:\/\//i.test(value)
+}
+
+async function sleep(ms: number): Promise<void> {
+	return new Promise(r => window.setTimeout(r, ms))
 }
 
 function extensionForMime(mimeType: string): string {
@@ -32,6 +52,14 @@ function extensionForMime(mimeType: string): string {
 	if (mimeType.includes('wav')) return 'wav'
 	if (mimeType.includes('mpeg') || mimeType.includes('mp3')) return 'mp3'
 	if (mimeType.includes('mp4')) return 'mp4'
+	return 'png'
+}
+
+function imageExtFromUrl(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	if (clean.endsWith('.jpg') || clean.endsWith('.jpeg')) return 'jpg'
+	if (clean.endsWith('.webp')) return 'webp'
+	if (clean.endsWith('.gif')) return 'gif'
 	return 'png'
 }
 
@@ -89,6 +117,16 @@ function extractVideoUrl(data: unknown): string {
 	return stringParam(videos[0], '').trim()
 }
 
+function extractImageUrl(data: unknown): string {
+	const body = asRecord(data) || {}
+	const images = Array.isArray(body.images) ? body.images : []
+	return stringParam(images[0], '').trim()
+}
+
+function parseZImageSize(value: unknown): { width: number; height: number } {
+	return Z_IMAGE_SIZES[stringParam(value, '2:3')] || Z_IMAGE_SIZES['2:3']
+}
+
 function parseDuration(value: unknown): number {
 	const parsed = typeof value === 'number' ? value : parseInt(stringParam(value, '5'), 10)
 	if (!Number.isFinite(parsed)) return 5
@@ -98,6 +136,119 @@ function parseDuration(value: unknown): number {
 function parsePromptExtend(value: unknown): boolean {
 	if (typeof value === 'boolean') return value
 	return stringParam(value, 'true') !== 'false'
+}
+
+export class MuleRouterImageProvider implements ImageProvider {
+	name = 'MuleRouter'
+
+	constructor(
+		private apiKey: string,
+		private app: App,
+		private outputDir: string,
+		private baseUrl = BASE_URL,
+	) {
+		this.baseUrl = this.baseUrl.replace(/\/$/, '')
+	}
+
+	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
+		const modelId = stringParam(params?.modelId, 'z-image-spicy')
+		if (modelId === 'qwen-image-edit-spicy') return this.generateQwenImageEdit(prompt, params)
+		return this.generateZImage(prompt, params)
+	}
+
+	private async generateZImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
+		const size = parseZImageSize(params?.aspectRatio)
+		const body: JsonRecord = {
+			prompt,
+			width: size.width,
+			height: size.height,
+			prompt_extend: parsePromptExtend(params?.prompt_extend),
+		}
+
+		const taskId = await this.submitImageTask(Z_IMAGE_SPICY_PATH, body, 'MuleRouter Z-Image Spicy')
+		const imageUrl = await this.pollImageTask(Z_IMAGE_SPICY_PATH, taskId, 'MuleRouter Z-Image Spicy')
+		return this.downloadImage(imageUrl, 'z_image_spicy')
+	}
+
+	private async generateQwenImageEdit(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages : []
+		if (!refImages[0]) throw new Error('MuleRouter Qwen Image Edit Spicy requires one upstream image.')
+
+		const body: JsonRecord = {
+			image: await this.ensurePublicUrl(refImages[0], 'image', 'MuleRouter Qwen Image Edit Spicy'),
+			prompt,
+		}
+
+		const taskId = await this.submitImageTask(QWEN_IMAGE_EDIT_SPICY_PATH, body, 'MuleRouter Qwen Image Edit Spicy')
+		const imageUrl = await this.pollImageTask(QWEN_IMAGE_EDIT_SPICY_PATH, taskId, 'MuleRouter Qwen Image Edit Spicy')
+		return this.downloadImage(imageUrl, 'qwen_image_edit_spicy')
+	}
+
+	private async submitImageTask(path: string, body: JsonRecord, label: string): Promise<string> {
+		const resp = await requestUrl({
+			url: `${this.baseUrl}${path}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status >= 400) {
+			throw new Error(`${label}: ${providerErrorMessage(resp.json || resp.text, `HTTP ${resp.status}`)}`)
+		}
+		const taskId = extractTaskId(resp.json)
+		if (!taskId) throw new Error(`${label}: task_info.id was not returned`)
+		return taskId
+	}
+
+	private async pollImageTask(path: string, taskId: string, label: string): Promise<string> {
+		await sleep(IMAGE_POLL_INITIAL_DELAY_MS)
+		const deadline = Date.now() + IMAGE_POLL_MAX_WAIT_MS - IMAGE_POLL_INITIAL_DELAY_MS
+
+		while (Date.now() < deadline) {
+			const resp = await requestUrl({
+				url: `${this.baseUrl}${path}/${encodeURIComponent(taskId)}`,
+				method: 'GET',
+				headers: { 'Authorization': `Bearer ${this.apiKey}` },
+				throw: false,
+			})
+
+			if (resp.status >= 400) {
+				throw new Error(`${label}: ${providerErrorMessage(resp.json || resp.text, `HTTP ${resp.status}`)}`)
+			}
+
+			const status = extractStatus(resp.json)
+			if (DONE_STATUSES.has(status)) {
+				const imageUrl = extractImageUrl(resp.json)
+				if (!imageUrl) throw new Error(`${label}: completed task has no image URL`)
+				return imageUrl
+			}
+			if (FAILED_STATUSES.has(status)) {
+				throw new Error(`${label}: ${providerErrorMessage(resp.json, 'Task failed')}`)
+			}
+			await sleep(IMAGE_POLL_INTERVAL_MS)
+		}
+		throw new Error(`${label}: timed out after ${IMAGE_POLL_MAX_WAIT_MS / 1000}s`)
+	}
+
+	private async ensurePublicUrl(ref: string, kind: 'image', label: string): Promise<string> {
+		if (isHttpUrl(ref)) return ref
+		const decoded = dataUriToBytes(ref)
+		if (!decoded) throw new Error(`${label}: unsupported reference ${kind} format`)
+		return uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `ref.${decoded.ext}`, decoded.mimeType)
+	}
+
+	private async downloadImage(url: string, basename: string): Promise<GenerateImageResult> {
+		const resp = await requestUrl({ url })
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) await adapter.mkdir(this.outputDir)
+		const filePath = `${this.outputDir}/mulerouter_${basename}_${Date.now()}.${imageExtFromUrl(url)}`
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return { filePath }
+	}
 }
 
 export class MuleRouterVideoProvider implements VideoProvider {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -17,7 +17,7 @@ import { MiniMaxProvider } from './minimax'
 import { LegnextProvider } from './legnext'
 import { APIMartProvider } from './apimart'
 import { LumaProvider } from './luma'
-import { MuleRouterVideoProvider, testMuleRouterConnection } from './mulerouter'
+import { MuleRouterImageProvider, MuleRouterVideoProvider, testMuleRouterConnection } from './mulerouter'
 import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
 import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProvider } from './tokenrouter'
 import { Token360VideoProvider } from './token360'
@@ -439,10 +439,12 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'mulerouter',
 		name: 'MuleRouter',
-		description: 'Wan 2.7 Spicy image-to-video.',
-		docUrl: 'https://www.mulerouter.ai/docs/api-reference/endpoint/carrothub/wan2.7-i2v-spicy/generation',
+		description: 'CarrotHub image and video models.',
+		docUrl: 'https://www.mulerouter.ai/docs/api-reference/endpoint/carrothub/z-image-spicy/generation',
 		fields: [{ key: 'mulerouter', label: 'API Key', placeholder: 'sk-mr-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.mulerouter,
+		makeImage: ({ settings, app, outputDir }) =>
+			new MuleRouterImageProvider(settings.providers.mulerouter, app, outputDir),
 		makeVideo: ({ settings, app, outputDir }) =>
 			new MuleRouterVideoProvider(settings.providers.mulerouter, app, outputDir),
 		testConnection: (d) => testMuleRouterConnection(d.mulerouter || ''),


### PR DESCRIPTION
## Summary
- Add MuleRouter image provider support for Z-Image Spicy and Qwen Image Edit Spicy
- Register both image models as addable catalogue candidates without auto-enabling them
- Map Z-Image aspect ratios to fixed MuleRouter-safe dimensions and remove seed controls
- Add a static verifier for the MuleRouter CarrotHub image integration

## Paired PR
- Skill documentation PR: https://github.com/nextbound/bragi-canvas-skill/pull/18

## Tests
- npm run test:mulerouter-carrothub
- npm run build
- npm run lint:obsidian
- git diff --check