### PR TITLE
fix(mcp): emit tool inputSchema with top-level type:object

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -253,8 +253,10 @@ function jsonError(id: JsonRpcId, code: number, message: string, data?: unknown)
 }
 
 function toolInputSchema(tool: McpToolDef): unknown {
+	// Emit the schema inline (no `name`) so the top-level object keeps `type: "object"`.
+	// Passing `name` wraps the schema in `{ $ref, definitions }`, which has no top-level
+	// `type` and is rejected by hosts like OpenAI/Codex ("schema must be type object, got None").
 	return zodToJsonSchema(z.object(tool.inputSchema), {
-		name: tool.name,
 		$refStrategy: 'none',
 	})
 }


### PR DESCRIPTION
## Summary
- Fixes MCP tool registration being rejected by OpenAI/Codex with `Invalid schema for function 'arrange_in_grid': schema must be a JSON Schema of 'type: "object"', got 'type: "None"'`.
- Root cause: `toolInputSchema` passed `name` to `zodToJsonSchema`, which wraps the result in `{ "$ref": "#/definitions/<name>", "definitions": { ... } }`. The top-level schema then has no `type`, so hosts that forward it as an OpenAI function `parameters` reject it. This affected **all** tools; Codex just reported the first one (`arrange_in_grid`).
- Fix: drop the `name` option so the schema is emitted inline with `type: "object"` at the root.

## Test plan
- [x] Reproduced before/after with `zod-to-json-schema` on the real `arrange_in_grid` schema: with `name` → top-level `$ref` (no `type`); without `name` → top-level `"type": "object"`.
- [x] `npm run build` (production) succeeds and syncs to the dev vault.
- [ ] In Obsidian: reload Bragi plugin, re-enable MCP, confirm Codex lists tools without the schema error.

Made with [Cursor](https://cursor.com)