### PR TITLE
feat: add SuChuang Gemini Omni provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.19.1
 
+- Added SuChuang as an optional provider for the existing Omni-Flash-Ext video model.
+- Added SuChuang async task submission, result polling, Bragi Relay image reference routing, and defensive final URL extraction.
+- Kept APIMart Omni-Flash-Ext support unchanged, including reference video and 4K behavior.
 - Fixed canvas inline annotation mode regressions introduced by the new image annotation tool.
 - Improved inline tool session state handling, viewport focusing, toolbar suppression/reveal, and exit cleanup.
 - Fixed annotation toolbar interactions for color dropdowns, pointer/focus scope, and native toolbar restoration.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use the MCP server only for trusted local clients that you want to let read or m
 
 ## Providers
 
-Bragi Canvas supports multiple provider integrations, including OpenAI, Anthropic, AWS Bedrock, Google Gemini (Gemini, Imagen, and Veo), Volcengine, BytePlus, Kling, fal.ai, ElevenLabs, MiniMax, Legnext, TokenRouter (`https://api.tokenrouter.com/v1`), APIMart, xAI, and Luma. Availability depends on the models and credentials configured in plugin settings.
+Bragi Canvas supports multiple provider integrations, including OpenAI, Anthropic, AWS Bedrock, Google Gemini (Gemini, Imagen, and Veo), Volcengine, BytePlus, Kling, fal.ai, ElevenLabs, MiniMax, Legnext, TokenRouter (`https://api.tokenrouter.com/v1`), APIMart, SuChuang, xAI, and Luma. Availability depends on the models and credentials configured in plugin settings.
 
 Provider credentials are stored by Obsidian in this plugin's local settings data. They are used only to make the provider requests selected by the user.
 

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -20,3 +20,14 @@ Use these checks when adding a built-in model/provider pairing:
 - Reference video count must be 0 or 1. When `video_urls` is present, omit `duration`.
 - Supported duration values are 4, 6, 8, and 10 seconds.
 - Supported resolution values are `720p`, `1080p`, and `4k`.
+
+## SuChuang Gemini Omni
+
+- Endpoint: `POST https://api.wuyinkeji.com/api/async/video_google_omni`.
+- Result status: `GET https://api.wuyinkeji.com/api/async/detail?id={task_id}`.
+- Send the API key as both `Authorization` and `key` query parameter because the provider docs show both auth paths.
+- Map Bragi `resolution` + `aspect_ratio` to SuChuang `size`: `1280x720` / `720x1280` for 720p, `1920x1080` / `1080x1920` for 1080p.
+- SuChuang does not document 4K output for this endpoint. Reject `4k` clearly instead of silently downscaling.
+- SuChuang reference images must be sent as Bragi temporary relay URLs in the comma-separated `images` field, capped at 7 images.
+- SuChuang does not support reference videos for this endpoint.
+- Treat status `0` / `1` as pending, `2` as success, and `3` as failure.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
+    "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },

--- a/scripts/verify-suchuang-gemini-omni.mjs
+++ b/scripts/verify-suchuang-gemini-omni.mjs
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const modelSource = readFileSync('src/models/omni-flash.ts', 'utf8')
+const registrySource = readFileSync('src/providers/registry.ts', 'utf8')
+const settingsSource = readFileSync('src/settings.ts', 'utf8')
+const migrationsSource = readFileSync('src/settings-migrations.ts', 'utf8')
+const providerSource = readFileSync('src/providers/suchuang.ts', 'utf8')
+const packageSource = readFileSync('package.json', 'utf8')
+
+assert.match(modelSource, /suchuang: \{ apiModelId: 'google_omni' \}/, 'Omni-Flash-Ext must include Suchuang model mapping')
+assert.match(settingsSource, /suchuang: string/, 'settings type must include providers.suchuang')
+assert.match(settingsSource, /suchuang: ''/, 'default settings must include an empty Suchuang key')
+assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = 4/, 'settings schema version must be bumped for the new provider key')
+
+assert.match(registrySource, /SuchuangVideoProvider, testSuchuangConnection/, 'registry must import the Suchuang provider')
+assert.match(registrySource, /id: 'suchuang'[\s\S]*name: 'SuChuang'[\s\S]*makeVideo:/, 'registry must expose SuChuang as a video provider')
+assert.match(registrySource, /testConnection: \(d\) => testSuchuangConnection\(d\.suchuang \|\| ''\)/, 'registry must use the non-billing Suchuang connection test')
+const legacyProviderNamePattern = new RegExp(`id: '${['wu', 'yin'].join('')}'|name: '\\u901f\\u521b API'|name: '\\u901f\\u521bAPI'`)
+assert.doesNotMatch(registrySource, legacyProviderNamePattern, 'registry must expose the provider as suchuang, not a localized or legacy name')
+
+for (const endpoint of ['/video_google_omni', '/detail']) {
+	assert.match(providerSource, new RegExp(endpoint.replace(/[/.]/g, '\\$&')), `Suchuang provider must call ${endpoint}`)
+}
+assert.match(providerSource, /url\.searchParams\.set\('key', apiKey\)/, 'Suchuang requests must include key query auth')
+assert.match(providerSource, /'Authorization': this\.apiKey/, 'Suchuang requests must include Authorization header auth')
+assert.match(providerSource, /body\.images = urls\.join\(','\)/, 'Suchuang image refs must be sent as comma-separated images')
+assert.match(providerSource, /arrayParam\(params\?\.refImages\)\.slice\(0, 7\)/, 'Suchuang must cap reference images at 7')
+assert.match(providerSource, /does not support reference video inputs/, 'Suchuang must reject reference video inputs clearly')
+assert.match(providerSource, /supports 720p and 1080p only/, 'Suchuang must reject 4K with a clear provider-specific error')
+assert.match(providerSource, /status === '0' \|\| status === '1'/, 'Suchuang status parser must treat 0/1 as pending')
+assert.match(providerSource, /status === '2'/, 'Suchuang status parser must treat 2 as success')
+assert.match(providerSource, /status === '3'/, 'Suchuang status parser must treat 3 as failure')
+assert.match(providerSource, /recordParam\(body\?\.data\)/, 'Suchuang status/task parsing must handle object or JSON-string data payloads')
+assert.match(providerSource, /extractSuchuangVideoUrl/, 'Suchuang provider must expose tolerant final URL extraction')
+assert.match(providerSource, /uploadRef\(undefined,[\s\S]*suchuang-ref/, 'Suchuang reference images must route through Bragi Relay')
+
+assert.match(packageSource, /"test:suchuang-gemini-omni": "node scripts\/verify-suchuang-gemini-omni\.mjs"/, 'package script must run Suchuang checks')
+
+const skillModelsPath = '../skill/bragi-canvas/references/models.md'
+if (existsSync(skillModelsPath)) {
+	const skillModelsSource = readFileSync(skillModelsPath, 'utf8')
+	assert.match(skillModelsSource, /Omni-Flash-Ext[\s\S]*APIMart \/ SuChuang/, 'skill docs must list SuChuang for Omni-Flash-Ext')
+	assert.match(skillModelsSource, /SuChuang key → Omni-Flash-Ext/, 'skill docs must include SuChuang provider availability')
+}
+
+console.log('SuChuang Gemini Omni provider checks passed.')

--- a/src/models/omni-flash.ts
+++ b/src/models/omni-flash.ts
@@ -6,6 +6,7 @@ export const omniFlashExt: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		apimart: { apiModelId: 'Omni-Flash-Ext' },
+		suchuang: { apiModelId: 'google_omni' },
 	},
 	modes: ['text-to-video', 'first-frame', 'multi-image-ref', 'video-ref'],
 	params: [

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -16,6 +16,7 @@ import { ElevenLabsProvider } from './elevenlabs'
 import { MiniMaxProvider } from './minimax'
 import { LegnextProvider } from './legnext'
 import { APIMartProvider } from './apimart'
+import { SuchuangVideoProvider, testSuchuangConnection } from './suchuang'
 import { LumaProvider } from './luma'
 import { MuleRouterImageProvider, MuleRouterVideoProvider, testMuleRouterConnection } from './mulerouter'
 import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
@@ -463,6 +464,17 @@ export const PROVIDERS: ProviderSpec[] = [
 		makeText: ({ settings }) =>
 			new APIMartTextProvider(settings.providers.apimart, 'https://api.apimart.ai/v1'),
 		testConnection: (d) => testListModels('https://api.apimart.ai/v1/models', d.apimart || ''),
+	},
+	{
+		id: 'suchuang',
+		name: 'SuChuang',
+		description: 'Gemini Omni video gateway.',
+		docUrl: 'https://api.wuyinkeji.com/doc/72',
+		fields: [{ key: 'suchuang', label: 'API Key', placeholder: 'API key', type: 'password' }],
+		isConfigured: (s) => !!s.providers.suchuang,
+		makeVideo: ({ settings, app, outputDir }) =>
+			new SuchuangVideoProvider(settings.providers.suchuang, app, outputDir),
+		testConnection: (d) => testSuchuangConnection(d.suchuang || ''),
 	},
 	{
 		id: 'xai',

--- a/src/providers/suchuang.ts
+++ b/src/providers/suchuang.ts
@@ -1,0 +1,346 @@
+import type { App } from 'obsidian'
+import { requestUrl } from 'obsidian'
+import { stringParam } from './params'
+import type { GenerateVideoResult, VideoProvider } from './types'
+import { BUILTIN_BRAGI_RELAY } from './bragi-relay'
+import { uploadRef } from './upload'
+
+const API_BASE = 'https://api.wuyinkeji.com/api/async'
+const CREATE_PATH = '/video_google_omni'
+const DETAIL_PATH = '/detail'
+const BRAGI_RELAY_BASE = BUILTIN_BRAGI_RELAY.endpoint.replace(/\/+$/, '')
+
+type JsonRecord = Record<string, unknown>
+
+function asRecord(value: unknown): JsonRecord | null {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null
+}
+
+function recordParam(value: unknown): JsonRecord | null {
+	if (typeof value === 'string') return asRecord(parseJsonText(value))
+	return asRecord(value)
+}
+
+function arrayParam(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : []
+}
+
+function buildUrl(path: string, apiKey: string, params: Record<string, string> = {}): string {
+	const url = new URL(`${API_BASE}${path}`)
+	url.searchParams.set('key', apiKey)
+	for (const [key, value] of Object.entries(params)) {
+		url.searchParams.set(key, value)
+	}
+	return url.toString()
+}
+
+function stringifyDetail(value: unknown): string {
+	if (typeof value === 'string') return value
+	if (value == null) return ''
+	try {
+		return JSON.stringify(value)
+	} catch {
+		return 'unserializable detail'
+	}
+}
+
+function parseJsonText(text: string | undefined): unknown {
+	if (!text) return null
+	try {
+		return JSON.parse(text)
+	} catch {
+		return null
+	}
+}
+
+function providerMessage(value: unknown): string {
+	const body = asRecord(value)
+	if (!body) return stringifyDetail(value)
+	const msg = body.msg || body.message || body.error || body.debug
+	return stringifyDetail(msg) || stringifyDetail(value)
+}
+
+function parseSuchuangError(resp: { status: number; text?: string; json?: unknown }): string {
+	const body = resp.json || parseJsonText(resp.text)
+	const record = asRecord(body)
+	const code = record?.code
+	const codeText = typeof code === 'string' || typeof code === 'number' || typeof code === 'boolean'
+		? String(code)
+		: stringifyDetail(code)
+	const msg = providerMessage(body) || resp.text || `HTTP ${resp.status}`
+	return `${codeText ? `${codeText} — ` : ''}${msg}`
+}
+
+function assertSuccessfulEnvelope(resp: { status: number; text?: string; json?: unknown }, label: string): void {
+	if (resp.status === 401 || resp.status === 403) throw new Error(`${label}: invalid API key`)
+	if (resp.status >= 400) throw new Error(`${label}: ${parseSuchuangError(resp)}`)
+	const body = asRecord(resp.json)
+	const code = body?.code
+	if (typeof code === 'number' && code !== 200) {
+		if (code === 401 || code === 403) throw new Error(`${label}: invalid API key`)
+		throw new Error(`${label}: ${parseSuchuangError(resp)}`)
+	}
+	if (typeof code === 'string' && code.trim() && code !== '200') {
+		if (code === '401' || code === '403') throw new Error(`${label}: invalid API key`)
+		throw new Error(`${label}: ${parseSuchuangError(resp)}`)
+	}
+}
+
+function extractTaskId(value: unknown): string {
+	const body = asRecord(value)
+	const data = recordParam(body?.data)
+	const raw = data?.id || body?.id || body?.task_id || body?.taskId || (typeof body?.data === 'string' ? body.data : '')
+	return stringParam(raw, '').trim()
+}
+
+type TaskState = 'pending' | 'succeeded' | 'failed' | 'unknown'
+
+export function suchuangTaskState(value: unknown): TaskState {
+	const body = asRecord(value)
+	const data = recordParam(body?.data)
+	const raw = data?.status || body?.status
+	const status = stringParam(raw, '').trim().toLowerCase()
+	if (status === '0' || status === '1' || status === 'init' || status === 'initializing' || status === 'pending' || status === 'running' || status === 'processing') return 'pending'
+	if (status === '2' || status === 'success' || status === 'succeeded' || status === 'completed' || status === 'done') return 'succeeded'
+	if (status === '3' || status === 'failed' || status === 'failure' || status === 'error') return 'failed'
+	return 'unknown'
+}
+
+function isHttpUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value)
+}
+
+function findHttpUrl(value: unknown, seen = new WeakSet<object>()): string {
+	if (typeof value === 'string') {
+		const match = value.match(/https?:\/\/[^\s"'<>\\]+/i)
+		return match?.[0] || ''
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const found = findHttpUrl(item, seen)
+			if (found) return found
+		}
+		return ''
+	}
+	if (!value || typeof value !== 'object') return ''
+	if (seen.has(value)) return ''
+	seen.add(value)
+	const record = value as JsonRecord
+	const priorityKeys = ['url', 'video_url', 'videoUrl', 'result_url', 'resultUrl', 'output', 'result', 'urls', 'videos', 'data']
+	for (const key of priorityKeys) {
+		const found = findHttpUrl(record[key], seen)
+		if (found) return found
+	}
+	for (const nested of Object.values(record)) {
+		const found = findHttpUrl(nested, seen)
+		if (found) return found
+	}
+	return ''
+}
+
+export function extractSuchuangVideoUrl(value: unknown): string {
+	const body = asRecord(value)
+	const data = body?.data
+	return findHttpUrl(data) || findHttpUrl(value)
+}
+
+function videoExtension(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	if (clean.endsWith('.mov')) return 'mov'
+	if (clean.endsWith('.webm')) return 'webm'
+	return 'mp4'
+}
+
+function extensionFromMime(mimeType: string): string {
+	const mime = mimeType.split(';')[0].trim().toLowerCase()
+	if (mime.includes('jpeg') || mime.includes('jpg')) return 'jpg'
+	if (mime.includes('png')) return 'png'
+	if (mime.includes('webp')) return 'webp'
+	if (mime.includes('gif')) return 'gif'
+	if (mime.includes('avif')) return 'avif'
+	if (mime.includes('heic')) return 'heic'
+	return 'jpg'
+}
+
+function extensionFromUrl(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	const match = clean.match(/\.([a-z0-9]+)$/)
+	return match?.[1] || 'jpg'
+}
+
+function headerValue(headers: Record<string, string>, name: string): string {
+	const target = name.toLowerCase()
+	const key = Object.keys(headers).find(k => k.toLowerCase() === target)
+	return key ? headers[key] : ''
+}
+
+function fallbackMime(ext: string): string {
+	if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+	if (ext === 'svg') return 'image/svg+xml'
+	return `image/${ext}`
+}
+
+function isGenericContentType(contentType: string): boolean {
+	const mime = contentType.split(';')[0].trim().toLowerCase()
+	return !mime || mime === 'application/octet-stream' || mime === 'binary/octet-stream'
+}
+
+function isBragiRelayUrl(url: string): boolean {
+	return url === BRAGI_RELAY_BASE || url.startsWith(`${BRAGI_RELAY_BASE}/`)
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength)
+	copy.set(bytes)
+	return copy.buffer
+}
+
+function suchuangSize(resolutionValue: unknown, aspectValue: unknown): string {
+	const resolution = stringParam(resolutionValue, '720p').trim().toLowerCase()
+	const aspect = stringParam(aspectValue, '16:9').trim()
+	if (resolution === '4k') {
+		throw new Error('SuChuang Gemini Omni supports 720p and 1080p only. Use APIMart for Omni-Flash-Ext 4K output.')
+	}
+	const portrait = aspect === '9:16'
+	if (resolution === '1080p') return portrait ? '1080x1920' : '1920x1080'
+	return portrait ? '720x1280' : '1280x720'
+}
+
+export class SuchuangVideoProvider implements VideoProvider {
+	name = 'SuChuang'
+
+	constructor(
+		private apiKey: string,
+		private app: App,
+		private outputDir: string,
+	) {}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const refImages = arrayParam(params?.refImages).slice(0, 7)
+		const refVideos = arrayParam(params?.refVideos)
+		if (refVideos.length > 0) {
+			throw new Error('SuChuang Gemini Omni does not support reference video inputs.')
+		}
+
+		const body: JsonRecord = {
+			prompt,
+			size: suchuangSize(params?.resolution, params?.aspect_ratio || params?.aspectRatio || params?.ratio),
+			duration: stringParam(params?.duration || params?.durationSeconds, '10'),
+		}
+
+		if (refImages.length > 0) {
+			const urls = await Promise.all(refImages.map(ref => this.ensureRelayImageUrl(ref)))
+			body.images = urls.join(',')
+		}
+
+		const resp = await requestUrl({
+			url: buildUrl(CREATE_PATH, this.apiKey),
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': this.apiKey,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+		assertSuccessfulEnvelope(resp, 'SuChuang Gemini Omni')
+
+		const taskId = extractTaskId(resp.json)
+		if (!taskId) {
+			throw new Error(`SuChuang Gemini Omni: no task id in response — ${JSON.stringify(resp.json).substring(0, 240)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const resp = await requestUrl({
+			url: buildUrl(DETAIL_PATH, this.apiKey, { id: taskId }),
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': this.apiKey,
+			},
+			throw: false,
+		})
+		assertSuccessfulEnvelope(resp, 'SuChuang Gemini Omni')
+
+		const state = suchuangTaskState(resp.json)
+		if (state === 'pending') return { done: false, taskId }
+		if (state === 'failed') {
+			const data = recordParam(asRecord(resp.json)?.data)
+			const detail = stringifyDetail(data?.message) || providerMessage(resp.json) || 'no reason provided'
+			throw new Error(`SuChuang Gemini Omni: task failed — ${detail}`)
+		}
+
+		const videoUrl = extractSuchuangVideoUrl(resp.json)
+		if (state !== 'succeeded' && !videoUrl) return { done: false, taskId }
+		if (!videoUrl) {
+			throw new Error(`SuChuang Gemini Omni: completed task has no video URL — ${JSON.stringify(resp.json).substring(0, 240)}`)
+		}
+		const filePath = await this.downloadVideo(videoUrl)
+		return { done: true, filePath }
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const resp = await requestUrl({ url })
+		const fileName = `suchuang_google_omni_${Date.now()}.${videoExtension(url)}`
+		const filePath = `${this.outputDir}/${fileName}`
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) {
+			await adapter.mkdir(this.outputDir)
+		}
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return filePath
+	}
+
+	private async ensureRelayImageUrl(ref: string): Promise<string> {
+		if (isBragiRelayUrl(ref)) return ref
+
+		const dataUri = ref.match(/^data:([^;]+);base64,(.+)$/)
+		if (dataUri) {
+			const mime = dataUri[1]
+			const bytes = Uint8Array.from(atob(dataUri[2]), c => c.charCodeAt(0))
+			const ext = extensionFromMime(mime)
+			return uploadRef(undefined, copyToArrayBuffer(bytes), `suchuang-ref.${ext}`, mime)
+		}
+
+		if (isHttpUrl(ref)) {
+			const resp = await requestUrl({ url: ref, throw: false })
+			if (resp.status >= 400) {
+				throw new Error(`SuChuang Gemini Omni: failed to fetch reference image for relay upload — HTTP ${resp.status}`)
+			}
+			const contentType = headerValue(resp.headers, 'content-type')
+			const useContentType = contentType && !isGenericContentType(contentType)
+			const ext = useContentType ? extensionFromMime(contentType) : extensionFromUrl(ref)
+			const mime = useContentType ? contentType : fallbackMime(ext)
+			return uploadRef(undefined, resp.arrayBuffer, `suchuang-ref.${ext}`, mime)
+		}
+
+		throw new Error('SuChuang Gemini Omni: unsupported reference image format; expected a data URI or http(s) URL.')
+	}
+}
+
+export async function testSuchuangConnection(apiKey: string): Promise<{ ok: boolean; message: string }> {
+	if (!apiKey) return { ok: false, message: 'API key is empty.' }
+	try {
+		const resp = await requestUrl({
+			url: buildUrl(DETAIL_PATH, apiKey, { id: 'bragi_connection_test' }),
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': apiKey,
+			},
+			throw: false,
+		})
+		if (resp.status === 401 || resp.status === 403) return { ok: false, message: 'Invalid API key.' }
+		const body = asRecord(resp.json)
+		if (body?.code === 401 || body?.code === 403 || body?.code === '401' || body?.code === '403') {
+			return { ok: false, message: 'Invalid API key.' }
+		}
+		if (resp.status >= 400) return { ok: false, message: `Unexpected status ${resp.status}.` }
+		return { ok: true, message: 'Connected.' }
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err)
+		return { ok: false, message: `Network error: ${message}` }
+	}
+}

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 3
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 4
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -109,6 +109,7 @@ export interface BragiSettings {
 		token360AssetGroupId: string
 		mulerouter: string
 		apimart: string
+		suchuang: string
 		lumaToken: string
 		xai: string
 		dashscope: string
@@ -174,6 +175,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		token360AssetGroupId: '',
 		mulerouter: '',
 		apimart: '',
+		suchuang: '',
 		lumaToken: '',
 		xai: '',
 		dashscope: '',


### PR DESCRIPTION
## Summary
- Add SuChuang as an optional provider for the existing `omni-flash-ext` video model.
- Add the `providers.suchuang` setting, provider registry entry, async video provider implementation, and verification script.
- Preserve APIMart Omni-Flash-Ext behavior, including video refs and 4K handling.

## Paired Skill PR
- https://github.com/nextbound/bragi-canvas-skill/pull/19

## Validation
- `npm run test:suchuang-gemini-omni`
- `npm run lint:obsidian`
- `npm run build`
- `git diff --check`
- root `npm run sync:check`
