### PR TITLE
feat(byteplus): reusable asset group id + per-provider model id overrides

### DIFF
--- a/src/byteplus-asset-flow.ts
+++ b/src/byteplus-asset-flow.ts
@@ -5,7 +5,6 @@ import { uploadRef } from './providers/upload'
 import {
 	BytePlusAssetCreds,
 	createAsset,
-	createAssetGroup,
 	getAsset,
 	isAssetNotFound,
 	isGroupNotFound,
@@ -57,43 +56,20 @@ function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
 	return null
 }
 
-/** Credentials for BytePlus asset library. null if not configured. */
+/**
+ * Credentials for BytePlus asset library. null if not configured.
+ * Requires AK/SK *and* an asset group id — without a group id we fall back to
+ * passing the plain URL to Seedance (no asset library, no face support), matching
+ * the TokenRouter / Token360 behaviour. We never auto-create asset groups, since
+ * each project has a cap on group count.
+ */
 export function getBytePlusAssetCreds(plugin: BragiCanvas): BytePlusAssetCreds | null {
 	const p = plugin.settings.providers
 	const ak = (p.byteplusAccessKey || '').trim()
 	const sk = (p.byteplusSecretKey || '').trim()
-	if (!ak || !sk) return null
-	return {
-		accessKey: ak,
-		secretKey: sk,
-		projectName: (p.byteplusProjectName || 'default').trim(),
-	}
-}
-
-
-async function getOrCreateGroupId(canvas: Canvas, creds: BytePlusAssetCreds): Promise<string> {
-	const data = canvas.getData() as unknown
-	const existing = data?.bragi?.byteplusGroupId as string | undefined
-	if (existing) return existing
-	const groupId = await createAssetGroup(creds)
-	const current = canvas.getData() as unknown
-	canvas.importData({
-		...current,
-		bragi: { ...(current.bragi || {}), byteplusGroupId: groupId },
-	})
-	void canvas.requestSave()
-	return groupId
-}
-
-/** Invalidate the canvas-level group id (e.g. after a group-not-found error). */
-function clearGroupId(canvas: Canvas) {
-	const current = canvas.getData() as unknown
-	if (current?.bragi?.byteplusGroupId) {
-		const rest = { ...current.bragi }
-		delete rest.byteplusGroupId
-		canvas.importData({ ...current, bragi: rest })
-		void canvas.requestSave()
-	}
+	const groupId = (p.byteplusAssetGroupId || '').trim()
+	if (!ak || !sk || !groupId) return null
+	return { accessKey: ak, secretKey: sk, groupId }
 }
 
 function getCachedAssetId(node: CanvasNode): string | null {
@@ -164,19 +140,17 @@ export async function ensureBytePlusAsset(
 	const binary = await adapter.readBinary(filePath)
 	const url = await uploadRef(undefined, binary, `ref.${ext}`, mime)
 
-	// 3. Create the asset (retry once if group was missing)
-	let groupId = await getOrCreateGroupId(canvas, creds)
+	// 3. Create the asset under the configured group
 	let assetId: string
 	try {
-		assetId = await createAsset(creds, groupId, url, assetType)
+		assetId = await createAsset(creds, creds.groupId, url, assetType)
 	} catch (err: unknown) {
 		if (isGroupNotFound(err)) {
-			clearGroupId(canvas)
-			groupId = await getOrCreateGroupId(canvas, creds)
-			assetId = await createAsset(creds, groupId, url, assetType)
-		} else {
-			throw err
+			throw new Error(
+				`BytePlus asset group not found or inaccessible: ${creds.groupId}. Check the BytePlus "Asset group ID" in provider settings, or switch the Seedance provider.`,
+			)
 		}
+		throw err
 	}
 
 	// 4. Poll until Active

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -7,7 +7,7 @@ import type { Canvas, CanvasEdge, CanvasNode, MoveAndResizeOptions } from './typ
 import type { PanelResult } from './panel'
 import { getModelById, getActiveProvider, getEnabledModels } from './models/index'
 import { getTextInputCapability, listSupportedInputLabels, listUnsupportedInputLabels } from './models/text-input-capabilities'
-import { getConnectedConfiguredProviderIds } from './provider-model-prefs'
+import { getConnectedConfiguredProviderIds, resolveApiModelId } from './provider-model-prefs'
 import type { GenerationType, Mode } from './models/types'
 import { getUpstreamInputs } from './edge-parser'
 import { getOrderedTextRefs } from './text-refs'
@@ -436,7 +436,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 						const pref = settings.modelPrefs[m.id]
 						const provider = getActiveProvider(m, pref?.selectedProvider, getConnectedConfiguredProviderIds(settings, m))
 						if (!provider) continue
-						const apiModelId = m.supportedProviders[provider]?.apiModelId
+						const apiModelId = resolveApiModelId(settings, provider, m)
 						const capability = m.type === 'text'
 							? getTextInputCapability(m.id, provider, apiModelId)
 							: null
@@ -514,7 +514,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 				const provider = getActiveProvider(model, pref?.selectedProvider, getConnectedConfiguredProviderIds(settings, model))
 				if (!provider) throw new Error(`No configured provider for model ${modelId}`)
 
-				const apiModelId = model.supportedProviders[provider]?.apiModelId || modelId
+				const apiModelId = resolveApiModelId(settings, provider, model)
 
 				// Read prompt from node
 				const nodeData = node.getData()

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -6,7 +6,7 @@ export const seedance2: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		bytedance: { apiModelId: 'doubao-seedance-2-0-260128' },
-		byteplus: { apiModelId: 'ep-20260423151427-fj6dh' },
+		byteplus: { apiModelId: 'dreamina-seedance-2-0-260128' },
 		fal: { apiModelId: 'bytedance/seedance-2.0' },
 		tokenrouter: { apiModelId: 'dreamina-seedance-2-0-260128' },
 		token360: { apiModelId: 'seedance-2.0' },
@@ -77,7 +77,7 @@ export const seedance2Fast: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		bytedance: { apiModelId: 'doubao-seedance-2-0-fast-260128' },
-		byteplus: { apiModelId: 'ep-20260423151341-p2zm9' },
+		byteplus: { apiModelId: 'dreamina-seedance-2-0-fast-260128' },
 		tokenrouter: { apiModelId: 'dreamina-seedance-2-0-fast-260128' },
 		token360: { apiModelId: 'seedance-2.0-fast' },
 	},

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -3,7 +3,7 @@ import { Notice, App } from 'obsidian'
 import type { ModelConfig, GenerationType, Mode, ModelParam, VoiceSourceMode } from './models/types'
 import { getEnabledModels, getActiveProvider } from './models/index'
 import { getTextInputCapability, textInputKindSupported } from './models/text-input-capabilities'
-import { getConnectedConfiguredProviderIds } from './provider-model-prefs'
+import { getConnectedConfiguredProviderIds, resolveApiModelId } from './provider-model-prefs'
 import { getUpstreamInputs } from './edge-parser'
 import { getOrderedAudios } from './audio-refs'
 import { getOrderedTextRefs } from './text-refs'
@@ -135,7 +135,7 @@ function resolveProvider(
 ): { provider: string; apiModelId: string } {
 	const pref = settings.modelPrefs[model.id]
 	const provider = getActiveProvider(model, pref?.selectedProvider, getConnectedConfiguredProviderIds(settings, model)) || Object.keys(model.supportedProviders)[0]
-	const apiModelId = model.supportedProviders[provider]?.apiModelId || model.id
+	const apiModelId = resolveApiModelId(settings, provider, model)
 	return { provider, apiModelId }
 }
 

--- a/src/provider-model-prefs.ts
+++ b/src/provider-model-prefs.ts
@@ -14,6 +14,44 @@ export function providerSupportsModel(providerId: string, model: ModelConfig): b
 	return model.supportedProviders[providerId] !== undefined
 }
 
+const SUPPORT_TYPE_ORDER = ['text', 'image', 'video', 'audio'] as const
+const SUPPORT_TYPE_LABELS: Record<(typeof SUPPORT_TYPE_ORDER)[number], string> = {
+	text: 'text',
+	image: 'image',
+	video: 'video',
+	audio: 'audio',
+}
+
+/**
+ * One-line summary of how many catalog models of each type a provider supports,
+ * e.g. "5 image, 3 video, 2 text models". Used in place of a static description.
+ */
+export function describeProviderModelSupport(providerId: string): string {
+	const counts: Record<string, number> = {}
+	let total = 0
+	for (const model of ALL_MODELS) {
+		if (model.supportedProviders[providerId]) {
+			counts[model.type] = (counts[model.type] || 0) + 1
+			total++
+		}
+	}
+	if (total === 0) return 'No catalog models'
+	const parts = SUPPORT_TYPE_ORDER
+		.filter(type => counts[type])
+		.map(type => `${counts[type]} ${SUPPORT_TYPE_LABELS[type]}`)
+	return `Supports ${parts.join(', ')} model${total === 1 ? '' : 's'}`
+}
+
+/**
+ * The API model id to send for `model` via `providerId`. Honours a user override
+ * (settings.apiModelIdOverrides), then the catalog default, then the model id.
+ */
+export function resolveApiModelId(settings: BragiSettings, providerId: string, model: ModelConfig): string {
+	return settings.apiModelIdOverrides?.[providerId]?.[model.id]
+		|| model.supportedProviders[providerId]?.apiModelId
+		|| model.id
+}
+
 export function isProviderConnectedToModel(settings: BragiSettings, providerId: string, modelId: string): boolean {
 	const model = getModelById(modelId)
 	return !!model && providerSupportsModel(providerId, model) && settings.providerModelPrefs?.[providerId]?.[modelId] === true

--- a/src/providers/byteplus-assets.ts
+++ b/src/providers/byteplus-assets.ts
@@ -14,8 +14,11 @@ const POLL_TIMEOUT_MS = 300000  // 5 minutes
 export interface BytePlusAssetCreds {
 	accessKey: string
 	secretKey: string
-	projectName: string
+	groupId: string
 }
+
+// All Bragi Canvas assets live in the `default` IAM project.
+const PROJECT_NAME = 'default'
 
 export interface AssetGetResult {
 	status: 'Active' | 'Processing' | 'Failed' | 'Rejected' | 'Unknown'
@@ -61,19 +64,6 @@ async function callUniversal(creds: BytePlusAssetCreds, action: string, body: un
 	return json?.Result ?? json
 }
 
-/** Create a new asset group. Returns the GroupId. */
-export async function createAssetGroup(creds: BytePlusAssetCreds): Promise<string> {
-	const name = randomHex(8)
-	const result = await callUniversal(creds, 'CreateAssetGroup', {
-		Name: name,
-		Description: 'Bragi Canvas',
-		ProjectName: creds.projectName || 'default',
-	})
-	const groupId = result.Id
-	if (!groupId) throw new Error(`BytePlus CreateAssetGroup: no Id in response`)
-	return groupId
-}
-
 /** Create an asset under a group. Returns the AssetId. */
 export async function createAsset(
 	creds: BytePlusAssetCreds,
@@ -87,7 +77,7 @@ export async function createAsset(
 		URL: url,
 		AssetType: assetType,
 		Name: name,
-		ProjectName: creds.projectName || 'default',
+		ProjectName: PROJECT_NAME,
 	})
 	const assetId = result.Id
 	if (!assetId) throw new Error(`BytePlus CreateAsset: no Id in response`)
@@ -98,7 +88,7 @@ export async function createAsset(
 export async function getAsset(creds: BytePlusAssetCreds, assetId: string): Promise<AssetGetResult> {
 	const result = await callUniversal(creds, 'GetAsset', {
 		Id: assetId,
-		ProjectName: creds.projectName || 'default',
+		ProjectName: PROJECT_NAME,
 	})
 	const status = (result.Status || 'Unknown') as AssetGetResult['status']
 	return { status, raw: result }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -54,7 +54,6 @@ export interface TestResult {
 export interface ProviderSpec {
 	id: string
 	name: string
-	description?: string
 	docUrl?: string
 	fields: ProviderField[]
 	isConfigured: (s: BragiSettings) => boolean
@@ -114,7 +113,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'openai',
 		name: 'OpenAI',
-		description: 'GPT and GPT Image models.',
 		docUrl: 'https://platform.openai.com/api-keys',
 		fields: [{ key: 'openai', label: 'API Key', placeholder: 'sk-proj-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.openai,
@@ -127,7 +125,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'anthropic',
 		name: 'Anthropic',
-		description: 'Claude models.',
 		docUrl: 'https://console.anthropic.com/settings/keys',
 		fields: [{ key: 'anthropic', label: 'API Key', placeholder: 'sk-ant-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.anthropic,
@@ -161,7 +158,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'bedrock',
 		name: 'AWS Bedrock',
-		description: 'Claude via AWS.',
 		docUrl: 'https://console.aws.amazon.com/bedrock/',
 		fields: [
 			{ key: 'bedrockAccessKeyId', label: 'Access Key ID', placeholder: 'Access Key ID', type: 'password' },
@@ -179,7 +175,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'gemini',
 		name: 'Google Gemini',
-		description: 'Gemini, Imagen, and Veo.',
 		docUrl: 'https://aistudio.google.com/apikey',
 		fields: [{ key: 'gemini', label: 'API Key', placeholder: 'AIza...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.gemini,
@@ -214,7 +209,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'bytedance',
 		name: 'Volcengine',
-		description: 'Seedream and Seedance.',
 		docUrl: 'https://console.volcengine.com/ark',
 		fields: [{ key: 'bytedance', label: 'ARK API Key', placeholder: '...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.bytedance,
@@ -227,13 +221,12 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'byteplus',
 		name: 'BytePlus',
-		description: 'Seedance on the global endpoint.',
 		docUrl: 'https://console.byteplus.com/ark',
 		fields: [
 			{ key: 'byteplus', label: 'ARK API Key', placeholder: '...', type: 'password' },
 			{ key: 'byteplusAccessKey', label: 'Access Key (optional)', placeholder: 'AK...', type: 'password' },
 			{ key: 'byteplusSecretKey', label: 'Secret Key (optional)', placeholder: 'SK...', type: 'password' },
-			{ key: 'byteplusProjectName', label: 'Asset group ID (optional)', placeholder: 'default', type: 'text' },
+			{ key: 'byteplusAssetGroupId', label: 'Asset group ID (optional)', placeholder: 'group-2026...-xxxxx', type: 'text' },
 		],
 		isConfigured: (s) => !!s.providers.byteplus,
 		makeVideo: ({ settings, app, outputDir }) =>
@@ -243,7 +236,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'kling',
 		name: 'Kling',
-		description: 'Kling video models.',
 		docUrl: 'https://app.klingai.com/global/dev/document-api/',
 		fields: [
 			{ key: 'klingAk', label: 'Access Key', placeholder: 'AK', type: 'password' },
@@ -257,7 +249,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'fal',
 		name: 'fal.ai',
-		description: 'Multi-model gateway.',
 		docUrl: 'https://fal.ai/dashboard/keys',
 		fields: [{ key: 'fal', label: 'API Key', placeholder: 'key-id:secret', type: 'password' }],
 		isConfigured: (s) => !!s.providers.fal,
@@ -289,7 +280,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'elevenlabs',
 		name: 'ElevenLabs',
-		description: 'Speech, music, and sound effects.',
 		docUrl: 'https://elevenlabs.io/app/settings/api-keys',
 		fields: [{ key: 'elevenlabs', label: 'API Key', placeholder: 'sk_...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.elevenlabs,
@@ -325,7 +315,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'minimax',
 		name: 'MiniMax',
-		description: 'Speech and music generation.',
 		docUrl: 'https://platform.minimaxi.com/',
 		fields: [{ key: 'minimax', label: 'Bearer Token', placeholder: 'eyJ...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.minimax,
@@ -355,7 +344,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'dashscope',
 		name: 'DashScope',
-		description: 'Alibaba Cloud official model provider.',
 		docUrl: 'https://dashscope.console.aliyun.com/',
 		fields: [{ key: 'dashscope', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.dashscope,
@@ -389,7 +377,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'legnext',
 		name: 'Legnext',
-		description: 'Midjourney proxy.',
 		docUrl: 'https://legnext.ai',
 		fields: [{ key: 'legnext', label: 'API Key', placeholder: 'key...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.legnext,
@@ -404,7 +391,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'tokenrouter',
 		name: 'TokenRouter',
-		description: 'All-in-one model gateway.',
 		docUrl: 'https://www.tokenrouter.com',
 		fields: [
 			{ key: 'tokenrouter', label: 'API Key', placeholder: 'sk-...', type: 'password' },
@@ -422,7 +408,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'token360',
 		name: 'Token360',
-		description: 'Unified AI gateway for Seedance video.',
 		docUrl: 'https://www.token360.ai/en-US/docs/api-reference/video-generation/submit-video-generation-request',
 		fields: [
 			{ key: 'token360', label: 'API Key', placeholder: 'sk-token360-...', type: 'password' },
@@ -440,7 +425,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'mulerouter',
 		name: 'MuleRouter',
-		description: 'CarrotHub image and video models.',
 		docUrl: 'https://www.mulerouter.ai/docs/api-reference/endpoint/carrothub/z-image-spicy/generation',
 		fields: [{ key: 'mulerouter', label: 'API Key', placeholder: 'sk-mr-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.mulerouter,
@@ -453,7 +437,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'apimart',
 		name: 'APIMart',
-		description: 'GPT text, GPT Image 2, and Omni-Flash video gateway.',
 		docUrl: 'https://docs.apimart.ai/en/api-reference/videos/omni-flash-ext/generation',
 		fields: [{ key: 'apimart', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.apimart,
@@ -468,7 +451,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'suchuang',
 		name: 'SuChuang',
-		description: 'Gemini Omni video gateway.',
 		docUrl: 'https://api.wuyinkeji.com/doc/72',
 		fields: [{ key: 'suchuang', label: 'API Key', placeholder: 'API key', type: 'password' }],
 		isConfigured: (s) => !!s.providers.suchuang,
@@ -479,7 +461,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'xai',
 		name: 'xAI',
-		description: 'Grok text, image, video, and TTS.',
 		docUrl: 'https://console.x.ai',
 		fields: [{ key: 'xai', label: 'API Key', placeholder: 'xai-...', type: 'password' }],
 		isConfigured: (s) => !!s.providers.xai,
@@ -496,7 +477,6 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'luma',
 		name: 'Luma',
-		description: 'Luma Uni-1 image generation.',
 		fields: [
 			{ key: 'lumaToken', label: 'API Key', placeholder: 'API Key', type: 'password' },
 		],

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 4
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 5
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {
@@ -35,6 +35,7 @@ function cloneDefaultSettings(defaults: BragiSettings): BragiSettings {
 		providers: { ...defaults.providers },
 		modelPrefs: {},
 		providerModelPrefs: {},
+		apiModelIdOverrides: {},
 		modelOrder: {
 			image: [],
 			video: [],
@@ -251,6 +252,30 @@ function readProviderModelPrefs(raw: UnknownRecord, settings: BragiSettings, err
 	}
 }
 
+function readApiModelIdOverrides(raw: UnknownRecord, settings: BragiSettings, errors: string[]): void {
+	if (!('apiModelIdOverrides' in raw)) return
+	if (!isRecord(raw.apiModelIdOverrides)) {
+		errors.push('apiModelIdOverrides')
+		return
+	}
+	for (const [providerId, rawOverrides] of Object.entries(raw.apiModelIdOverrides)) {
+		if (!isRecord(rawOverrides)) {
+			errors.push(`apiModelIdOverrides.${providerId}`)
+			continue
+		}
+		const overrides: Record<string, string> = {}
+		for (const [modelId, value] of Object.entries(rawOverrides)) {
+			if (typeof value !== 'string') {
+				errors.push(`apiModelIdOverrides.${providerId}.${modelId}`)
+				continue
+			}
+			const trimmed = value.trim()
+			if (trimmed) overrides[modelId] = trimmed
+		}
+		if (Object.keys(overrides).length > 0) settings.apiModelIdOverrides[providerId] = overrides
+	}
+}
+
 function readModelOrder(raw: UnknownRecord, settings: BragiSettings, errors: string[]): void {
 	if (!('modelOrder' in raw)) return
 	if (!isRecord(raw.modelOrder)) {
@@ -303,6 +328,7 @@ function readSettings(raw: UnknownRecord, defaults: BragiSettings): { settings: 
 
 	readModelPrefs(raw, settings, errors)
 	readProviderModelPrefs(raw, settings, errors)
+	readApiModelIdOverrides(raw, settings, errors)
 	readModelOrder(raw, settings, errors)
 
 	const lastImage = readLastSelection(raw, 'lastImage', errors)
@@ -406,6 +432,18 @@ function migrateDashScopeSettings(settings: BragiSettings, raw: UnknownRecord): 
 	}
 }
 
+function migrateByteplusGroupId(settings: BragiSettings, raw: UnknownRecord): void {
+	// The old `byteplusProjectName` field was mislabelled "Asset group ID" in the UI,
+	// so some users typed a real asset group id into it. Carry those over to the new
+	// `byteplusAssetGroupId` field; plain project names (e.g. "default") are dropped.
+	if (settings.providers.byteplusAssetGroupId) return
+	const rawProviders = isRecord(raw.providers) ? raw.providers : null
+	const legacy = rawProviders?.byteplusProjectName
+	if (typeof legacy === 'string' && /^group-/.test(legacy.trim())) {
+		settings.providers.byteplusAssetGroupId = legacy.trim()
+	}
+}
+
 function migrateProviderPrefs19(settings: BragiSettings): void {
 	if (settings.migrationProviders_1_9) return
 
@@ -469,6 +507,7 @@ const RECOGNIZABLE_KEYS = [
 	'providers',
 	'modelPrefs',
 	'providerModelPrefs',
+	'apiModelIdOverrides',
 	'modelOrder',
 	'mcpEnabled',
 	'mcpPort',
@@ -508,6 +547,7 @@ export function migrateSettings(
 	const previousVersion = settings.settingsSchemaVersion || 0
 
 	migrateDashScopeSettings(settings, raw)
+	migrateByteplusGroupId(settings, raw)
 	migrateProviderPrefs19(settings)
 	migrateProviderModelPrefs(settings, previousVersion)
 	settings.settingsSchemaVersion = CURRENT_SETTINGS_SCHEMA_VERSION

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import { App, Modal, Notice, PluginSettingTab, Setting } from 'obsidian'
 import type BragiCanvas from './main'
 import { getActiveProvider, getEnabledModels } from './models/index'
 import type { GenerationType } from './models/types'
-import { disableModel, getConnectedConfiguredProviderIds, type ProviderCredentialDraft } from './provider-model-prefs'
+import { describeProviderModelSupport, disableModel, getConnectedConfiguredProviderIds, type ProviderCredentialDraft } from './provider-model-prefs'
 import { PROVIDERS } from './providers/registry'
 import { AddProviderModal } from './ui/add-provider-modal'
 import { AddModelModal } from './ui/add-model-modal'
@@ -96,7 +96,7 @@ export interface BragiSettings {
 		byteplus: string
 		byteplusAccessKey: string
 		byteplusSecretKey: string
-		byteplusProjectName: string
+		byteplusAssetGroupId: string
 		klingAk: string
 		klingSk: string
 		fal: string
@@ -118,6 +118,8 @@ export interface BragiSettings {
 	// Per-model preferences
 	modelPrefs: Record<string, ModelPref>
 	providerModelPrefs: Record<string, Record<string, boolean>>
+	/** Per-provider override of the API model id sent for a model. providerId → modelId → apiModelId. */
+	apiModelIdOverrides: Record<string, Record<string, string>>
 
 	// Model display order per type
 	modelOrder: {
@@ -162,7 +164,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		byteplus: '',
 		byteplusAccessKey: '',
 		byteplusSecretKey: '',
-		byteplusProjectName: 'default',
+		byteplusAssetGroupId: '',
 		klingAk: '',
 		klingSk: '',
 		fal: '',
@@ -182,6 +184,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 	},
 	modelPrefs: {},
 	providerModelPrefs: {},
+	apiModelIdOverrides: {},
 	modelOrder: {
 		image: [],
 		video: [],
@@ -361,7 +364,9 @@ export class BragiSettingTab extends PluginSettingTab {
 		})
 
 		const wrap = groupEl.createDiv({ cls: 'setting-items bragi-providers-list' })
-		const configured = PROVIDERS.filter(p => p.isConfigured(this.plugin.settings))
+		const configured = PROVIDERS
+			.filter(p => p.isConfigured(this.plugin.settings))
+			.sort((a, b) => a.name.localeCompare(b.name))
 
 		if (configured.length === 0) {
 			addEmptySetting(wrap, 'No providers have been added. Click + to connect one.')
@@ -371,9 +376,9 @@ export class BragiSettingTab extends PluginSettingTab {
 		for (const spec of configured) {
 			const row = new Setting(wrap)
 				.setName(spec.name)
-				.setDesc(spec.description || '')
+				.setDesc(describeProviderModelSupport(spec.id))
 				.addExtraButton(btn => btn
-					.setIcon('list-checks')
+					.setIcon('package')
 					.setTooltip('Manage models')
 					.onClick(() => {
 						new ProviderModelsModal(this.plugin, {
@@ -383,7 +388,7 @@ export class BragiSettingTab extends PluginSettingTab {
 						}).open()
 					}))
 				.addExtraButton(btn => btn
-					.setIcon('pencil')
+					.setIcon('settings-2')
 					.setTooltip('Edit')
 					.onClick(() => {
 						new AddProviderModal(this.plugin, {
@@ -392,7 +397,7 @@ export class BragiSettingTab extends PluginSettingTab {
 						}).open()
 					}))
 				.addExtraButton(btn => btn
-					.setIcon('x')
+					.setIcon('trash-2')
 					.setTooltip('Remove')
 					.onClick(() => {
 						removeProvider(this.plugin, spec.id, () => this.display())

--- a/src/styles.css
+++ b/src/styles.css
@@ -2158,15 +2158,23 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	right: 6px;
 	top: 50%;
 	transform: translateY(-50%);
-	background: transparent;
-	border: none;
-	box-shadow: none;
 	padding: 4px;
 	cursor: pointer;
 	color: var(--bragi-text-muted);
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+/* Strip native button chrome across all states (some themes add bg/border/shadow on hover/active/focus). */
+.bragi-eye-btn,
+.bragi-eye-btn:hover,
+.bragi-eye-btn:active,
+.bragi-eye-btn:focus,
+.bragi-eye-btn:focus-visible {
+	background: transparent;
+	border: none;
+	box-shadow: none;
 }
 
 .bragi-eye-btn:hover {
@@ -2536,6 +2544,9 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 .bragi-provider-models-modal .modal-content {
 	max-height: 70vh;
 	overflow-y: auto;
+	/* overflow-y:auto makes this a scroll container that also clips overflow-x at the
+	   padding box; the extra inline padding gives button focus rings room not to be cut. */
+	padding-inline: 4px;
 }
 
 .bragi-provider-models-desc {
@@ -2580,16 +2591,13 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	cursor: pointer;
 }
 
-.bragi-provider-models-row:hover {
-	background: var(--bragi-hover);
-}
-
 .bragi-provider-models-row input[type="checkbox"] {
 	flex-shrink: 0;
 }
 
 .bragi-provider-models-info {
 	min-width: 0;
+	flex: 1;
 }
 
 .bragi-provider-models-name {
@@ -2600,13 +2608,50 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	white-space: nowrap;
 }
 
-.bragi-provider-models-id {
+.bragi-provider-models-id-line {
 	margin-top: 2px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+.bragi-provider-models-id {
 	color: var(--bragi-text-muted);
 	font-size: 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.bragi-model-id-badge {
+	flex-shrink: 0;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	padding: 1px 6px;
+	border-radius: 20px;
+	color: var(--bragi-accent, var(--interactive-accent));
+	background: var(--bragi-hover);
+}
+
+.bragi-model-id-edit-btn {
+	flex-shrink: 0;
+	opacity: 0.55;
+	margin-left: auto;
+}
+
+.bragi-model-id-edit-btn:hover {
+	opacity: 1;
+}
+
+.bragi-provider-models-id-input {
+	flex: 1;
+	min-width: 0;
+	font-size: 12px;
+	font-family: var(--font-monospace, monospace);
+	padding: 2px 6px;
 }
 
 /* ── Hide vault-level _bragi folder from file tree ──────────────────── */

--- a/src/ui/add-provider-modal.ts
+++ b/src/ui/add-provider-modal.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment -- Obsidian Canvas internals and provider payloads are runtime-shaped data that this plugin narrows at use sites. */
 import { Modal, Setting, Notice, setIcon, setTooltip } from 'obsidian'
 import type BragiCanvas from '../main'
-import { settingsWithProviderCredentialDraft, type ProviderCredentialDraft } from '../provider-model-prefs'
+import { describeProviderModelSupport, settingsWithProviderCredentialDraft, type ProviderCredentialDraft } from '../provider-model-prefs'
 import { PROVIDERS, type ProviderSpec } from '../providers/registry'
 
 export interface AddProviderModalOptions {
@@ -88,7 +88,9 @@ export class AddProviderModal extends Modal {
 		})
 		const listEl = contentEl.createDiv({ cls: 'bragi-add-modal-list' })
 
-		const candidates = PROVIDERS.filter(p => !p.isConfigured(this.plugin.settings))
+		const candidates = PROVIDERS
+			.filter(p => !p.isConfigured(this.plugin.settings))
+			.sort((a, b) => a.name.localeCompare(b.name))
 		if (candidates.length === 0) {
 			listEl.createEl('p', { text: 'All supported providers are already added.', cls: 'mod-muted' })
 			return
@@ -97,9 +99,7 @@ export class AddProviderModal extends Modal {
 		const render = (query: string) => {
 			listEl.empty()
 			const q = query.trim().toLowerCase()
-			const matches = candidates.filter(p =>
-				!q || p.name.toLowerCase().includes(q) || (p.description || '').toLowerCase().includes(q)
-			)
+			const matches = candidates.filter(p => !q || p.name.toLowerCase().includes(q))
 			if (matches.length === 0) {
 				listEl.createEl('p', { text: 'No matches.', cls: 'mod-muted' })
 				return
@@ -108,9 +108,7 @@ export class AddProviderModal extends Modal {
 				const row = listEl.createDiv({ cls: 'bragi-add-modal-row' })
 				const info = row.createDiv({ cls: 'bragi-add-modal-row-info' })
 				info.createDiv({ cls: 'bragi-add-modal-row-name', text: spec.name })
-				if (spec.description) {
-					info.createDiv({ cls: 'bragi-add-modal-row-desc', text: spec.description })
-				}
+				info.createDiv({ cls: 'bragi-add-modal-row-desc', text: describeProviderModelSupport(spec.id) })
 				const btn = row.createEl('button', { text: 'Add', cls: 'mod-cta' })
 				btn.addEventListener('click', () => this.renderForm(spec, true))
 			}
@@ -152,11 +150,11 @@ export class AddProviderModal extends Modal {
 				cls: 'setting-item-description bragi-add-provider-desc',
 				text: 'Pick a provider that supports this model and add its credentials.',
 			})
-		} else if (currentSpec.description || currentSpec.docUrl) {
+		} else {
+			// Non-dropdown mode has no provider switcher, so currentSpec is fixed here.
 			const p = contentEl.createEl('p', { cls: 'setting-item-description bragi-add-provider-desc' })
-			if (currentSpec.description) p.appendText(currentSpec.description)
+			p.appendText('Enter your credentials to connect. ')
 			if (currentSpec.docUrl) {
-				if (currentSpec.description) p.appendText(' ')
 				const link = p.createEl('a', { text: 'Get key →', href: currentSpec.docUrl, cls: 'bragi-add-modal-doclink' })
 				link.addEventListener('click', (e) => {
 					e.preventDefault()
@@ -210,7 +208,7 @@ export class AddProviderModal extends Modal {
 							// Toggle-visibility eye button
 							const control = t.inputEl.parentElement
 							if (control) {
-								const eye = control.createEl('button', { cls: 'bragi-eye-btn' })
+								const eye = control.createEl('button', { cls: 'clickable-icon bragi-eye-btn' })
 								setIcon(eye, 'eye-off')
 								setTooltip(eye, 'Show')
 								eye.addEventListener('click', (e) => {

--- a/src/ui/provider-models-modal.ts
+++ b/src/ui/provider-models-modal.ts
@@ -1,4 +1,4 @@
-import { Modal, Notice } from 'obsidian'
+import { Modal, Notice, setIcon, setTooltip } from 'obsidian'
 import type BragiCanvas from '../main'
 import { ALL_MODELS, getActiveProvider, type GenerationType, type ModelConfig } from '../models'
 import {
@@ -8,6 +8,7 @@ import {
 	getConnectedConfiguredProviderIds,
 	getReplacementProvider,
 	isProviderConnectedToModel,
+	resolveApiModelId,
 	type ProviderCredentialDraft,
 } from '../provider-model-prefs'
 import { getProvider } from '../providers/registry'
@@ -125,8 +126,8 @@ export class ProviderModelsModal extends Modal {
 		})
 
 		const toolbar = contentEl.createDiv({ cls: 'bragi-provider-models-toolbar' })
-		const selectAll = toolbar.createEl('button', { text: 'Select all' })
-		const clear = toolbar.createEl('button', { text: 'Clear' })
+		const selectAll = toolbar.createEl('button', { text: 'Select all', attr: { type: 'button' } })
+		const clear = toolbar.createEl('button', { text: 'Clear', attr: { type: 'button' } })
 
 		const list = contentEl.createDiv({ cls: 'bragi-provider-models-list' })
 		for (const type of TYPE_ORDER) {
@@ -184,6 +185,12 @@ export class ProviderModelsModal extends Modal {
 			void this.requestApply(candidates)
 		})
 		sync()
+
+		// Don't leave focus on "Select all" (it would show a focus ring as if pre-selected).
+		window.setTimeout(() => {
+			const active = this.contentEl.ownerDocument.activeElement
+			if (active instanceof HTMLElement && this.contentEl.contains(active)) active.blur()
+		}, 0)
 	}
 
 	private renderModelRow(parent: HTMLElement, model: ModelConfig) {
@@ -198,7 +205,102 @@ export class ProviderModelsModal extends Modal {
 
 		const info = row.createDiv({ cls: 'bragi-provider-models-info' })
 		info.createDiv({ cls: 'bragi-provider-models-name', text: model.name })
-		info.createDiv({ cls: 'bragi-provider-models-id', text: model.id })
+		const idLine = info.createDiv({ cls: 'bragi-provider-models-id-line' })
+		this.renderIdDisplay(idLine, model)
+	}
+
+	private catalogApiModelId(model: ModelConfig): string {
+		return model.supportedProviders[this.opts.providerId]?.apiModelId || model.id
+	}
+
+	private isOverridden(model: ModelConfig): boolean {
+		return !!this.plugin.settings.apiModelIdOverrides?.[this.opts.providerId]?.[model.id]
+	}
+
+	/** Display mode: effective api model id + "Modified" badge + a pencil to edit. */
+	private renderIdDisplay(idLine: HTMLElement, model: ModelConfig) {
+		idLine.empty()
+		const effective = resolveApiModelId(this.plugin.settings, this.opts.providerId, model)
+		idLine.createSpan({ cls: 'bragi-provider-models-id', text: effective })
+		if (this.isOverridden(model)) {
+			idLine.createSpan({ cls: 'bragi-model-id-badge', text: 'Modified' })
+		}
+		const edit = idLine.createEl('button', { cls: 'clickable-icon bragi-model-id-edit-btn' })
+		setIcon(edit, 'pencil')
+		setTooltip(edit, 'Edit API model id')
+		// The row is a <label>; stop the click from toggling the checkbox.
+		edit.addEventListener('click', (e) => {
+			e.preventDefault()
+			e.stopPropagation()
+			this.renderIdEditor(idLine, model)
+		})
+	}
+
+	/** Edit mode: text input + save/cancel, plus reset-to-default when overridden. */
+	private renderIdEditor(idLine: HTMLElement, model: ModelConfig) {
+		idLine.empty()
+		const effective = resolveApiModelId(this.plugin.settings, this.opts.providerId, model)
+		const input = idLine.createEl('input', {
+			type: 'text',
+			cls: 'bragi-provider-models-id-input',
+			value: effective,
+		})
+		input.placeholder = this.catalogApiModelId(model)
+		// Clicks/keys inside the editor must not toggle the row's checkbox.
+		const swallow = (e: Event) => e.stopPropagation()
+		idLine.addEventListener('click', (e) => e.preventDefault())
+		input.addEventListener('click', swallow)
+
+		const save = idLine.createEl('button', { cls: 'clickable-icon' })
+		setIcon(save, 'check')
+		setTooltip(save, 'Save')
+		const cancel = idLine.createEl('button', { cls: 'clickable-icon' })
+		setIcon(cancel, 'x')
+		setTooltip(cancel, 'Cancel')
+
+		const commit = () => { void this.saveOverride(model, input.value); this.renderIdDisplay(idLine, model) }
+		save.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); commit() })
+		cancel.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); this.renderIdDisplay(idLine, model) })
+		input.addEventListener('keydown', (e) => {
+			e.stopPropagation()
+			if (e.key === 'Enter') { e.preventDefault(); commit() }
+			else if (e.key === 'Escape') { e.preventDefault(); this.renderIdDisplay(idLine, model) }
+		})
+
+		if (this.isOverridden(model)) {
+			const reset = idLine.createEl('button', { cls: 'clickable-icon' })
+			setIcon(reset, 'rotate-ccw')
+			setTooltip(reset, 'Reset to default')
+			reset.addEventListener('click', (e) => {
+				e.preventDefault()
+				e.stopPropagation()
+				void this.saveOverride(model, '')
+				this.renderIdDisplay(idLine, model)
+			})
+		}
+
+		input.focus()
+		input.select()
+	}
+
+	/** Persist (or clear, when empty / equal to catalog default) the api model id override. */
+	private async saveOverride(model: ModelConfig, rawValue: string): Promise<void> {
+		const value = rawValue.trim()
+		const providerId = this.opts.providerId
+		const overrides = this.plugin.settings.apiModelIdOverrides || (this.plugin.settings.apiModelIdOverrides = {})
+		const isDefault = !value || value === this.catalogApiModelId(model)
+
+		if (isDefault) {
+			const map = overrides[providerId]
+			if (map) {
+				delete map[model.id]
+				if (Object.keys(map).length === 0) delete overrides[providerId]
+			}
+		} else {
+			if (!overrides[providerId]) overrides[providerId] = {}
+			overrides[providerId][model.id] = value
+		}
+		await this.plugin.saveSettings()
 	}
 
 	private computeActiveDisconnectImpact(candidates: ModelConfig[]): ActiveDisconnectImpact {

--- a/src/ui/remove-provider-modal.ts
+++ b/src/ui/remove-provider-modal.ts
@@ -63,29 +63,14 @@ export async function applyRemoval(plugin: BragiCanvas, providerId: string, impa
 }
 
 /**
- * Remove a provider. If any models would be unlisted, pops a confirm modal first.
- * Otherwise applies silently (with a Notice if models got switched).
+ * Remove a provider. Always pops a confirm modal first — removing a provider
+ * clears its credentials, so we confirm even when no models are affected.
  */
 export function removeProvider(plugin: BragiCanvas, providerId: string, onDone: () => void) {
 	const spec = getProvider(providerId)
 	if (!spec) return
 
 	const impact = computeRemovalImpact(plugin, providerId)
-
-	if (impact.disappearing.length === 0) {
-		// Silent removal (possibly with auto-switch Notice)
-		void applyRemoval(plugin, providerId, impact).then(() => {
-			if (impact.switching.length > 0) {
-				new Notice(`${spec.name} removed — ${impact.switching.length} model${impact.switching.length === 1 ? '' : 's'} switched provider`)
-			} else {
-				new Notice(`${spec.name} removed`)
-			}
-			onDone()
-		})
-		return
-	}
-
-	// Has disappearing models: confirm modal
 	new RemoveProviderConfirmModal(plugin, spec.name, providerId, impact, onDone).open()
 }
 
@@ -104,6 +89,10 @@ class RemoveProviderConfirmModal extends Modal {
 		const { contentEl, titleEl, modalEl } = this
 		modalEl.classList.add('bragi-modal')
 		titleEl.setText(`Remove ${this.providerName}?`)
+
+		if (this.impact.disappearing.length === 0 && this.impact.switching.length === 0) {
+			contentEl.createEl('p', { text: `This clears ${this.providerName}'s saved credentials. You can add it again anytime.` })
+		}
 
 		if (this.impact.disappearing.length > 0) {
 			const p = contentEl.createEl('p', { cls: 'mod-warning' })

--- a/styles.css
+++ b/styles.css
@@ -2158,15 +2158,23 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	right: 6px;
 	top: 50%;
 	transform: translateY(-50%);
-	background: transparent;
-	border: none;
-	box-shadow: none;
 	padding: 4px;
 	cursor: pointer;
 	color: var(--bragi-text-muted);
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+/* Strip native button chrome across all states (some themes add bg/border/shadow on hover/active/focus). */
+.bragi-eye-btn,
+.bragi-eye-btn:hover,
+.bragi-eye-btn:active,
+.bragi-eye-btn:focus,
+.bragi-eye-btn:focus-visible {
+	background: transparent;
+	border: none;
+	box-shadow: none;
 }
 
 .bragi-eye-btn:hover {
@@ -2536,6 +2544,9 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 .bragi-provider-models-modal .modal-content {
 	max-height: 70vh;
 	overflow-y: auto;
+	/* overflow-y:auto makes this a scroll container that also clips overflow-x at the
+	   padding box; the extra inline padding gives button focus rings room not to be cut. */
+	padding-inline: 4px;
 }
 
 .bragi-provider-models-desc {
@@ -2580,16 +2591,13 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	cursor: pointer;
 }
 
-.bragi-provider-models-row:hover {
-	background: var(--bragi-hover);
-}
-
 .bragi-provider-models-row input[type="checkbox"] {
 	flex-shrink: 0;
 }
 
 .bragi-provider-models-info {
 	min-width: 0;
+	flex: 1;
 }
 
 .bragi-provider-models-name {
@@ -2600,13 +2608,50 @@ body.bragi-annotation-mode-active .bragi-canvas-menu.bragi-annotation-toolbar-hi
 	white-space: nowrap;
 }
 
-.bragi-provider-models-id {
+.bragi-provider-models-id-line {
 	margin-top: 2px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+.bragi-provider-models-id {
 	color: var(--bragi-text-muted);
 	font-size: 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.bragi-model-id-badge {
+	flex-shrink: 0;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	padding: 1px 6px;
+	border-radius: 20px;
+	color: var(--bragi-accent, var(--interactive-accent));
+	background: var(--bragi-hover);
+}
+
+.bragi-model-id-edit-btn {
+	flex-shrink: 0;
+	opacity: 0.55;
+	margin-left: auto;
+}
+
+.bragi-model-id-edit-btn:hover {
+	opacity: 1;
+}
+
+.bragi-provider-models-id-input {
+	flex: 1;
+	min-width: 0;
+	font-size: 12px;
+	font-family: var(--font-monospace, monospace);
+	padding: 2px 6px;
 }
 
 /* ── Hide vault-level _bragi folder from file tree ──────────────────── */


### PR DESCRIPTION
## What

Reworks the BytePlus provider and tidies provider-settings UX, after reviewing the BytePlus flow against the official ModelArk docs (CreateAsset API + Virtual Portrait Library tutorial) and verifying against a live account.

### BytePlus asset library — reuse a group instead of sprawling
- Now mirrors TokenRouter/Token360: requires an **Asset group ID** in settings and reuses it for every canvas. Previously it auto-created a new asset group per canvas, which sprawls against the per-project group cap.
- Without a group id (or AK/SK), it falls back to passing the plain URL to Seedance (no asset library, no face support) — same behaviour as the other ModelArk gateways.
- Settings: `byteplusProjectName` → `byteplusAssetGroupId`; `ProjectName` is fixed to `default`. Migration **v4→5** carries over any `group-*` value that users had typed into the old mislabelled field.
- Ship the **standard public** Seedance ids as defaults (`dreamina-seedance-2-0-260128` / `-fast-260128`) instead of a private finetune endpoint that only works under one account.

### Per-provider API model id overrides
- New `settings.apiModelIdOverrides` (provider → model → apiModelId), resolved through a shared `resolveApiModelId()` helper used by panel + MCP.
- Editable **inline** in the Manage-models modal: pencil → text input + save/cancel/reset, with a "Modified" badge. Lets finetune aliases (e.g. a private `ep-...` endpoint) be configured per provider without code changes.

### Provider settings UX
- Provider rows + add-provider picker show a dynamic **"Supports N image, M video models"** line (static `description` field removed entirely).
- Provider lists sorted A–Z.
- Unified key-input intro text.
- **Removing a provider always confirms first** (previously silent when no models were affected).
- Icons: `package` (manage models), `settings-2` (edit), `trash-2` (remove), `rotate-ccw` (reset); borderless `clickable-icon` buttons; dropped the row hover tint and fixed the modal clipping button focus rings.

## Test
- `npm run build` (esbuild gate) passes; eslint clean on changed files.
- Manual: BytePlus settings show a single Asset group ID field; with a group id set, generations reuse it (verified via a local asset-library viewer — group count stays at 1). Manage-models pencil edits the api id, shows Modified, resets to default; works across providers and doesn't toggle the checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)