### PR TITLE
feat(seedream): add Seedream 5.0 Lite on Volcengine + BytePlus

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,7 +1,7 @@
 import type { ModelConfig, GenerationType } from './types'
 import { gptImage } from './gpt-image'
 import { nanoBananaPro, nanoBanana2 } from './nano-banana'
-import { seedream5, seedream45 } from './seedream'
+import { seedream5, seedream5Lite, seedream45 } from './seedream'
 import { seedance2, seedance2Fast } from './seedance'
 import { kling3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
@@ -35,6 +35,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	midjourneyNiji7,
 	lumaUni1,
 	seedream5,
+	seedream5Lite,
 	seedream45,
 	zImageSpicy,
 	qwenImageEditSpicy,

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -40,6 +40,37 @@ export const seedream5: ModelConfig = {
 	],
 }
 
+export const seedream5Lite: ModelConfig = {
+	id: 'seedream-5.0-lite',
+	name: 'Seedream 5.0 Lite',
+	type: 'image',
+	supportedProviders: {
+		bytedance: { apiModelId: 'doubao-seedream-5-0-lite-260128' },
+		byteplus: { apiModelId: 'seedream-5-0-lite-260128' },
+	},
+	modes: ['text-to-image'],
+	params: [
+		{
+			id: 'aspectRatio',
+			label: 'Aspect Ratio',
+			type: 'select',
+			options: SEEDREAM_RATIOS,
+			default: '1:1',
+		},
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '2K', value: '2K' },
+				{ label: '3K', value: '3K' },
+				{ label: '4K', value: '4K' },
+			],
+			default: '2K',
+		},
+	],
+}
+
 export const seedream45: ModelConfig = {
 	id: 'seedream-4.5',
 	name: 'Seedream 4.5',

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -229,6 +229,8 @@ export const PROVIDERS: ProviderSpec[] = [
 			{ key: 'byteplusAssetGroupId', label: 'Asset group ID (optional)', placeholder: 'group-2026...-xxxxx', type: 'text' },
 		],
 		isConfigured: (s) => !!s.providers.byteplus,
+		makeImage: ({ settings, app, outputDir }) =>
+			new SeedreamProvider(settings.providers.byteplus, app, outputDir, 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'),
 		makeVideo: ({ settings, app, outputDir }) =>
 			new SeedanceProvider(settings.providers.byteplus, app, outputDir, 'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks'),
 		testConnection: (d) => testListModels('https://ark.ap-southeast.bytepluses.com/api/v3/models', d.byteplus || ''),

--- a/src/providers/seedream.ts
+++ b/src/providers/seedream.ts
@@ -11,16 +11,20 @@ const SIZE_MAP: Record<string, Record<string, string>> = {
 	'4K': { '1:1': '4096x4096', '4:3': '4704x3520', '3:4': '3520x4704', '16:9': '5504x3040', '9:16': '3040x5504', '3:2': '4992x3328', '2:3': '3328x4992', '21:9': '6240x2656' },
 }
 
+const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3/images/generations'
+
 export class SeedreamProvider implements ImageProvider {
 	name = 'Seedream'
 	private apiKey: string
 	private app: App
 	private outputDir: string
+	private baseUrl: string
 
-	constructor(apiKey: string, app: App, outputDir: string) {
+	constructor(apiKey: string, app: App, outputDir: string, baseUrl?: string) {
 		this.apiKey = apiKey
 		this.app = app
 		this.outputDir = outputDir
+		this.baseUrl = baseUrl || DEFAULT_BASE_URL
 	}
 
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
@@ -48,7 +52,7 @@ export class SeedreamProvider implements ImageProvider {
 		}
 
 		const response = await requestUrl({
-			url: 'https://ark.cn-beijing.volces.com/api/v3/images/generations',
+			url: this.baseUrl,
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',


### PR DESCRIPTION
## What

Adds a new image model **Seedream 5.0 Lite** (`seedream-5.0-lite`), available on both providers:
- **Volcengine** (`bytedance`): `doubao-seedream-5-0-lite-260128`, domestic endpoint
- **BytePlus**: `seedream-5-0-lite-260128`, global endpoint

This is a distinct SKU from the full Seedream 5.0 we already ship (which stays bytedance-only).

## Notes
- **BytePlus model ids require the version suffix.** The bare `seedream-5-0-lite` returns `404 InvalidEndpointOrModel.NotFound`; `seedream-5-0-lite-260128` works (verified against the live `/models` list and a probe request).
- `SeedreamProvider` now takes an optional `baseUrl` (mirrors `SeedanceProvider`) so BytePlus image generation hits the global `images/generations` endpoint; bytedance keeps the default domestic endpoint.
- `registry`: added `makeImage` to the byteplus provider spec (previously video-only).
- Resolution **2K/3K/4K** via the existing `SIZE_MAP` pixel mapping; aspect-ratio dropdown unchanged.
- Web search (`tools`) was explored but dropped — the BytePlus image API does not accept a `tools` field (it 400s), and it isn't needed.

## Test
- `npm run build` (esbuild gate) passes; eslint clean.
- Live probe against BytePlus: `seedream-5-0-lite-260128` + `size:2048x2048` → HTTP 200.
- Manual: model appears in the list; selectable on BytePlus/Volcengine; text-to-image generates on both endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)