### PR TITLE
Skip ModelArk asset moderation prefilter

### DIFF
--- a/src/providers/byteplus-assets.ts
+++ b/src/providers/byteplus-assets.ts
@@ -78,6 +78,9 @@ export async function createAsset(
 		AssetType: assetType,
 		Name: name,
 		ProjectName: PROJECT_NAME,
+		Moderation: {
+			Strategy: 'Skip',
+		},
 	})
 	const assetId = result.Id
 	if (!assetId) throw new Error(`BytePlus CreateAsset: no Id in response`)

--- a/src/providers/tokenrouter-modelark-assets.ts
+++ b/src/providers/tokenrouter-modelark-assets.ts
@@ -78,6 +78,9 @@ export async function createModelArkAsset(
 		URL: url,
 		AssetType: assetType,
 		Name: `bragi_${randomHex(6)}`,
+		Moderation: {
+			Strategy: 'Skip',
+		},
 	})
 	const assetId = stringValue(result.Id || result.id, '')
 	if (!assetId) throw new Error('TokenRouter ModelArk CreateAsset: no Id in response')


### PR DESCRIPTION
## Summary
- add `Moderation.Strategy = Skip` to BytePlus CreateAsset requests
- add the same moderation skip payload to TokenRouter ModelArk asset creation

## Verification
- `npm run build` passed
- `npm run test:tokenrouter-modelark-assets` currently fails on an existing assertion expecting the legacy `byteplusProjectName` provider field instead of `byteplusAssetGroupId`
