### PR TITLE
fix: send TokenRouter video URLs as video parts

### DIFF
--- a/scripts/verify-gemini-video-text.mjs
+++ b/scripts/verify-gemini-video-text.mjs
@@ -81,6 +81,12 @@ assert.match(
 )
 
 assert.match(
+	tokenRouterSource,
+	/private videoContentPart\(ref: string, basename: string\): unknown \{[\s\S]*if \(isHttpUrl\(ref\)\) \{[\s\S]*type: 'video_url'[\s\S]*video_url: \{ url: ref \}[\s\S]*return this\.fileContentPart\(ref, basename\)/,
+	'TokenRouter text provider must send relay video URLs as video_url parts',
+)
+
+assert.match(
 	mcpToolRegistrySource,
 	/audios: upstream\.audios[\s\S]*pdfs: upstream\.pdfs/,
 	'MCP get_upstream must expose audio and PDF refs',

--- a/scripts/verify-text-multimodal.mjs
+++ b/scripts/verify-text-multimodal.mjs
@@ -169,8 +169,8 @@ assert.match(
 
 assert.match(
 	tokenRouterSource,
-	/if \(isHttpUrl\(ref\)\) \{[\s\S]*file_data: ref[\s\S]*return \{[\s\S]*file_id: ref/,
-	'TokenRouter text provider must send relay URLs as file_data, not file_id',
+	/private videoContentPart\(ref: string, basename: string\): unknown \{[\s\S]*if \(isHttpUrl\(ref\)\) \{[\s\S]*type: 'video_url'[\s\S]*video_url: \{ url: ref \}[\s\S]*return this\.fileContentPart\(ref, basename\)/,
+	'TokenRouter text provider must send relay video URLs as video_url parts',
 )
 
 assert.match(

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -290,7 +290,7 @@ export class TokenRouterTextProvider implements TextGenProvider {
 			content.push({ type: 'image_url', image_url: { url: ref } })
 		}
 		for (let i = 0; i < refVideos.length; i++) {
-			content.push(this.fileContentPart(refVideos[i], `video-${i + 1}`))
+			content.push(this.videoContentPart(refVideos[i], `video-${i + 1}`))
 		}
 		for (let i = 0; i < refAudios.length; i++) {
 			content.push(this.fileContentPart(refAudios[i], `audio-${i + 1}`))
@@ -322,6 +322,13 @@ export class TokenRouterTextProvider implements TextGenProvider {
 		const text = extractText(resp.json)
 		if (!text) throw new Error('TokenRouter: No text in response')
 		return { text }
+	}
+
+	private videoContentPart(ref: string, basename: string): unknown {
+		if (isHttpUrl(ref)) {
+			return { type: 'video_url', video_url: { url: ref } }
+		}
+		return this.fileContentPart(ref, basename)
 	}
 
 	private fileContentPart(ref: string, basename: string): unknown {


### PR DESCRIPTION
## Summary
- send TokenRouter text-generation video URLs as `video_url` content parts
- keep non-video file refs on the existing file content path
- add static checks for Gemini video text coverage

## Verification
- `npm run test:gemini-video-text`
- `npm run test:text-multimodal`
- `npm run build`
- live TokenRouter checks: Gemini 3.1 Pro, Gemini 3 Flash, and Gemini 3.5 Flash accepted a `cdn.bragi.now` video URL and returned video token usage