### PR TITLE
feat: add DashScope Wan 2.7 video modes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { validateTextInputs } from './models/text-input-capabilities'
 import { prepareTextInputs } from './text-input-prep'
 import { checkForPluginUpdate, markUpdatePrompted, shouldShowAutomaticUpdatePrompt, type AvailablePluginUpdate } from './update-check'
 import { UpdateReminderModal } from './ui/update-modal'
+import { dashScopeRegion } from './providers/dashscope'
 
 type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
 
@@ -554,6 +555,7 @@ export default class BragiCanvas extends Plugin {
 			// Seedance can consume provider-specific asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7-i2v-spicy'
+			const isDashScopeWan = activeProvider === 'dashscope' && model.id === 'wan-2.7'
 			const supportsApimartVideoRef = activeProvider === 'apimart' && model.id === 'omni-flash-ext'
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
@@ -586,7 +588,7 @@ export default class BragiCanvas extends Plugin {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const ext = getFileExtension(imgPath, 'png')
 					refImages.push(await uploadRef(undefined, binary, `ref.${ext}`, imageMimeType(imgPath)))
-				} else if (isMuleRouterWan) {
+				} else if (isMuleRouterWan || isDashScopeWan) {
 					const binary = await this.app.vault.adapter.readBinary(imgPath)
 					const ext = getFileExtension(imgPath, 'png')
 					refImages.push(await uploadRef(undefined, binary, `ref.${ext}`, imageMimeType(imgPath)))
@@ -599,8 +601,8 @@ export default class BragiCanvas extends Plugin {
 				}
 			}
 
-			// Upload reference audios for Seedance and MuleRouter Wan I2V.
-			if ((supportsSeedanceUrlRefs || isMuleRouterWan) && uniqueAudios.length > 0) {
+			// Upload reference audios for providers/models that need public media URLs.
+			if ((supportsSeedanceUrlRefs || isMuleRouterWan || isDashScopeWan) && uniqueAudios.length > 0) {
 				if (supportsSeedanceUrlRefs && uniqueAudios.length > 3) {
 					throw new Error('Seedance supports up to 3 reference audio files.')
 				}
@@ -623,8 +625,8 @@ export default class BragiCanvas extends Plugin {
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
-				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef) {
-					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance, or APIMart Omni-Flash-Ext.')
+				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !isDashScopeWan) {
+					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance, APIMart Omni-Flash-Ext, or DashScope Wan 2.7.')
 				}
 				if (supportsSeedanceUrlRefs && uniqueVideos.length > 3) {
 					throw new Error('Seedance supports up to 3 reference videos.')
@@ -635,7 +637,7 @@ export default class BragiCanvas extends Plugin {
 				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
 					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')
 				}
-				const shouldUseVideos = supportsSeedanceUrlRefs || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref'
+				const shouldUseVideos = supportsSeedanceUrlRefs || isDashScopeWan || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref'
 				if (shouldUseVideos) {
 					for (const videoPath of uniqueVideos) {
 						if (isNativeSeedance && bytePlusCreds) {
@@ -768,10 +770,10 @@ export default class BragiCanvas extends Plugin {
 				let customVoiceRecord: CustomVoiceRecord | null = null
 				if (mode === 'tts' && voiceMode === 'reference') {
 					const refIndex = readVoiceRefAudioIndex(audioParams.voiceRefAudioIndex)
-					customVoiceRecord = await applyUpstreamVoiceReference(this.app, canvas, provider, activeProvider, audioModelId, getOrderedAudios(canvas, node), refIndex, audioParams)
+					customVoiceRecord = await applyUpstreamVoiceReference(this.app, canvas, provider, activeProvider, this.settings, audioModelId, getOrderedAudios(canvas, node), refIndex, audioParams)
 				} else if (mode === 'tts' && voiceMode === 'design') {
 					const promptIndex = readVoiceDesignTextIndex(audioParams.voiceDesignTextIndex)
-					customVoiceRecord = await applyVoiceDesign(provider, activeProvider, audioModelId, upstreamPrompts, promptIndex, finalPrompt, audioParams)
+					customVoiceRecord = await applyVoiceDesign(provider, activeProvider, this.settings, audioModelId, upstreamPrompts, promptIndex, finalPrompt, audioParams)
 				}
 				delete audioParams.voiceMode
 				delete audioParams.voiceRefAudioIndex
@@ -1237,8 +1239,8 @@ function modelIdForVoiceMode(model: PanelResult['model'], defaultModelId: string
 	return model.voiceConfig?.modelIds?.[voiceMode] || defaultModelId
 }
 
-function voiceCloneRegionForProvider(activeProvider: string): string {
-	return activeProvider === 'dashscope' ? 'cn-beijing' : 'global'
+function voiceCloneRegionForProvider(activeProvider: string, settings: BragiSettings): string {
+	return activeProvider === 'dashscope' ? dashScopeRegion(settings.providers.dashscopeBaseUrl) : 'global'
 }
 
 function reusableVoiceRecord(
@@ -1277,6 +1279,7 @@ async function applyUpstreamVoiceReference(
 	canvas: Canvas,
 	provider: AudioProvider,
 	activeProvider: string,
+	settings: BragiSettings,
 	modelId: string,
 	upstreamAudios: string[],
 	voiceRefAudioIndex: number,
@@ -1300,7 +1303,7 @@ async function applyUpstreamVoiceReference(
 
 	const binary = await app.vault.adapter.readBinary(sourcePath)
 	const sourceHash = await sha256Hex(binary)
-	const region = voiceCloneRegionForProvider(activeProvider)
+	const region = voiceCloneRegionForProvider(activeProvider, settings)
 	const existing = reusableVoiceRecord(audioNode, activeProvider, region, modelId, sourceHash)
 
 	if (existing) {
@@ -1349,6 +1352,7 @@ async function applyUpstreamVoiceReference(
 async function applyVoiceDesign(
 	provider: AudioProvider,
 	activeProvider: string,
+	settings: BragiSettings,
 	modelId: string,
 	upstreamPrompts: string[],
 	voiceDesignTextIndex: number,
@@ -1378,7 +1382,7 @@ async function applyVoiceDesign(
 	const record: CustomVoiceRecord = {
 		kind: 'design',
 		provider: activeProvider,
-		region: 'cn-beijing',
+		region: voiceCloneRegionForProvider(activeProvider, settings),
 		modelId,
 		promptHash,
 		voicePrompt,

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -455,7 +455,9 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 								label: p.label,
 								type: p.type,
 								default: p.default,
+								...(p.modes ? { modes: p.modes } : {}),
 								...(p.options ? { options: p.options } : {}),
+								...(p.optionsByMode ? { optionsByMode: p.optionsByMode } : {}),
 								...(p.min !== undefined ? { min: p.min, max: p.max, step: p.step, unit: p.unit } : {}),
 							})),
 						})
@@ -527,13 +529,14 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 				}
 				if (!prompt) throw new Error('Node contains no prompt text')
 
-				// Resolve params with defaults
+				const selectedMode = (mode as Mode) || model.modes[0] || null
+
+				// Resolve params with defaults, but only for params visible in this mode.
 				const resolvedParams: Record<string, string | number> = { ...(params || {}) }
 				for (const p of model.params) {
+					if (p.modes && (!selectedMode || !p.modes.includes(selectedMode))) continue
 					resolvedParams[p.id] = resolvedParams[p.id] ?? p.default
 				}
-
-				const selectedMode = (mode as Mode) || model.modes[0] || null
 
 				const panelResult: PanelResult = {
 					prompt,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,7 +6,7 @@ import { seedance2, seedance2Fast } from './seedance'
 import { kling3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
-import { zImageSpicy, qwenImageEditSpicy, wan27I2vSpicy } from './wan'
+import { zImageSpicy, qwenImageEditSpicy, wan27, wan27I2vSpicy } from './wan'
 import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
@@ -46,6 +46,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	kling26,
 	happyHorseT2V,
 	happyHorseI2V,
+	wan27,
 	wan27I2vSpicy,
 	veo31,
 	veo31Lite,

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -17,6 +17,11 @@ export interface ModelParam {
 	id: string
 	label: string
 	type: 'select' | 'number' | 'range'
+	/**
+	 * Restrict this parameter to specific generation modes. Omit for parameters
+	 * that apply to every mode on the model.
+	 */
+	modes?: Mode[]
 	options?: ParamOption[]
 	/**
 	 * Mode-specific option overrides. When the user picks one of these modes, the

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -50,6 +50,80 @@ export const qwenImageEditSpicy: ModelConfig = {
 	params: [],
 }
 
+export const wan27: ModelConfig = {
+	id: 'wan-2.7',
+	name: 'Wan 2.7',
+	type: 'video',
+	supportedProviders: {
+		dashscope: { apiModelId: 'wan-2.7' },
+	},
+	modes: [
+		'text-to-video',
+		'first-frame',
+		'first-last-frame',
+		'image-ref',
+		'video-ref',
+		'video-extend',
+		'video-edit',
+	],
+	params: [
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '720P', value: '720P' },
+				{ label: '1080P', value: '1080P' },
+			],
+			default: '720P',
+		},
+		{
+			id: 'ratio',
+			label: 'Ratio',
+			type: 'select',
+			options: [
+				{ label: '16:9', value: '16:9' },
+				{ label: '9:16', value: '9:16' },
+				{ label: '1:1', value: '1:1' },
+				{ label: '4:3', value: '4:3' },
+				{ label: '3:4', value: '3:4' },
+			],
+			default: '16:9',
+		},
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'range',
+			default: 5,
+			min: 2,
+			max: 15,
+			step: 1,
+			unit: 's',
+		},
+		{
+			id: 'prompt_extend',
+			label: 'Prompt Extend',
+			type: 'select',
+			options: [
+				{ label: 'On', value: 'true' },
+				{ label: 'Off', value: 'false' },
+			],
+			default: 'true',
+		},
+		{
+			id: 'audio_setting',
+			label: 'Edit Audio',
+			type: 'select',
+			modes: ['video-edit'],
+			options: [
+				{ label: 'Auto', value: 'auto' },
+				{ label: 'Original', value: 'origin' },
+			],
+			default: 'auto',
+		},
+	],
+}
+
 export const wan27I2vSpicy: ModelConfig = {
 	id: 'wan-2.7-i2v-spicy',
 	name: 'Wan 2.7 Spicy I2V',

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -30,7 +30,7 @@ const MODE_LABELS: Record<string, string> = {
 	'image-ref': 'Ref Image',
 	'first-last-frame': 'First + Last Frame',
 	'multi-image-ref': 'Multi Image Ref',
-	'video-ref': 'Reference video',
+	'video-ref': 'Ref Video',
 	'video-extend': 'Extend Video',
 	'video-edit': 'Edit Video',
 	'text-to-text': 'Text → Text',
@@ -71,6 +71,14 @@ function voiceDisplayLabel(
 
 function rangeParamValueLabel(param: ModelParam, value: string | number): string {
 	return `${value}${param.unit || ''}`
+}
+
+function paramVisibleForMode(param: ModelParam, mode: Mode | null): boolean {
+	return !param.modes || (!!mode && param.modes.includes(mode))
+}
+
+function paramsVisibleForMode(model: ModelConfig, mode: Mode | null): ModelParam[] {
+	return model.params.filter(param => paramVisibleForMode(param, mode))
 }
 
 function renderRangeParamDropdown(
@@ -646,7 +654,7 @@ export function showGenerateBar(
 	function rebuildParams() {
 		paramsEl.innerHTML = ''
 		if (!selectedModel) return
-		for (const param of selectedModel.params) {
+		for (const param of paramsVisibleForMode(selectedModel, selectedMode)) {
 			if (param.type === 'select' && param.options) {
 				// Pick mode-specific options if declared; otherwise the base list.
 				const effectiveOptions = (selectedMode && param.optionsByMode?.[selectedMode]) || param.options
@@ -750,6 +758,18 @@ export function showGenerateBar(
 				paramsEl.appendChild(input)
 			}
 		}
+	}
+
+	function currentVisibleParamValues(): Record<string, string | number> {
+		if (!selectedModel) return {}
+		const visibleIds = new Set(paramsVisibleForMode(selectedModel, selectedMode).map(param => param.id))
+		const result: Record<string, string | number> = {}
+		for (const [key, value] of Object.entries(paramValues)) {
+			if (visibleIds.has(key) || key === 'voiceLabel' || key === 'voiceMode' || key === 'voiceRefAudioIndex' || key === 'voiceDesignTextIndex') {
+				result[key] = value
+			}
+		}
+		return result
 	}
 
 	/**
@@ -1006,9 +1026,10 @@ export function showGenerateBar(
 
 			// Save to global memory
 			const lastKey = lastSelectionKey(currentType)
+			const submitParams = currentVisibleParamValues()
 			;(settings as unknown)[lastKey] = {
 				modelId: selectedModel.id,
-				params: { ...paramValues },
+				params: { ...submitParams },
 				batchCount,
 			}
 			onSaveSettings?.()
@@ -1018,7 +1039,7 @@ export function showGenerateBar(
 			const bragiLastGen = currentNodeData.bragiLastGen || currentNodeData.ovidLastGen || {}
 			bragiLastGen[currentType] = {
 				modelId: selectedModel.id,
-				params: { ...paramValues },
+				params: { ...submitParams },
 				batchCount,
 			}
 			// Write new key, drop the legacy one so it doesn't silently drift
@@ -1029,7 +1050,7 @@ export function showGenerateBar(
 			// Resolve active provider and API model ID
 			const { provider, apiModelId } = resolveProvider(selectedModel, settings)
 
-			onSubmit({ prompt, model: selectedModel, activeProvider: provider, apiModelId, mode: selectedMode, params: paramValues, batchCount })
+			onSubmit({ prompt, model: selectedModel, activeProvider: provider, apiModelId, mode: selectedMode, params: submitParams, batchCount })
 		})()
 	})
 
@@ -1212,7 +1233,7 @@ export function showBatchGenerateBar(
 	function rebuildParams() {
 		paramsEl.innerHTML = ''
 		if (!selectedModel) return
-		for (const param of selectedModel.params) {
+		for (const param of paramsVisibleForMode(selectedModel, selectedMode)) {
 			if (param.type === 'select' && param.options) {
 				const effectiveOptions = (selectedMode && param.optionsByMode?.[selectedMode]) || param.options
 				const currentValue = String(paramValues[param.id] ?? param.default)
@@ -1289,6 +1310,16 @@ export function showBatchGenerateBar(
 		}
 	}
 
+	function currentVisibleParamValues(): Record<string, string | number> {
+		if (!selectedModel) return {}
+		const visibleIds = new Set(paramsVisibleForMode(selectedModel, selectedMode).map(param => param.id))
+		const result: Record<string, string | number> = {}
+		for (const [key, value] of Object.entries(paramValues)) {
+			if (visibleIds.has(key) || key === 'voiceLabel') result[key] = value
+		}
+		return result
+	}
+
 	function rebuildModelList() {
 		modelSelect.innerHTML = ''
 		models = getModelsForType(currentType)
@@ -1352,9 +1383,10 @@ export function showBatchGenerateBar(
 
 		const batchCount = parseInt(batchSelect.value) || 1
 		const lastKey = lastSelectionKey(currentType)
+		const submitParams = currentVisibleParamValues()
 		;(settings as unknown)[lastKey] = {
 			modelId: selectedModel.id,
-			params: { ...paramValues },
+			params: { ...submitParams },
 			batchCount,
 		}
 		onSaveSettings?.()
@@ -1367,7 +1399,7 @@ export function showBatchGenerateBar(
 			activeProvider: provider,
 			apiModelId,
 			mode: selectedMode,
-			params: paramValues,
+			params: submitParams,
 			batchCount,
 		})
 	})

--- a/src/providers/dashscope-text.ts
+++ b/src/providers/dashscope-text.ts
@@ -2,8 +2,9 @@ import { requestUrl } from 'obsidian'
 import { stringParam } from './params'
 import { uploadRef } from './upload'
 import type { TextGenProvider, TextGenResult } from './text-gen'
+import { DEFAULT_DASHSCOPE_BASE_URL, dashScopeUrl } from './dashscope'
 
-const MULTIMODAL_URL = 'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation'
+const MULTIMODAL_PATH = '/services/aigc/multimodal-generation/generation'
 
 const SYSTEM_PROMPT = `You are a helpful assistant on a visual canvas. Follow the user's instructions precisely.
 If the user asks you to produce multiple separate items (e.g. "split into 3 chapters", "give me 5 titles", "break this into sections"), output each item separated by a line containing only ---SPLIT--- on its own. Do NOT use ---SPLIT--- for any other purpose. If the output is a single piece of content, do not use ---SPLIT--- at all.`
@@ -66,9 +67,11 @@ async function buildContentParts(
 export class DashScopeTextProvider implements TextGenProvider {
 	name = 'DashScope'
 	private apiKey: string
+	private baseUrl: string
 
-	constructor(apiKey: string) {
+	constructor(apiKey: string, baseUrl = DEFAULT_DASHSCOPE_BASE_URL) {
 		this.apiKey = apiKey
+		this.baseUrl = baseUrl
 	}
 
 	async generateText(prompt: string, params?: Record<string, unknown>): Promise<TextGenResult> {
@@ -81,7 +84,7 @@ export class DashScopeTextProvider implements TextGenProvider {
 		const content = await buildContentParts(prompt, refImages, refVideos, refAudios, refPdfs)
 
 		const response = await requestUrl({
-			url: MULTIMODAL_URL,
+			url: dashScopeUrl(this.baseUrl, MULTIMODAL_PATH),
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/src/providers/dashscope.ts
+++ b/src/providers/dashscope.ts
@@ -3,7 +3,9 @@ import { normalizePath, requestUrl } from 'obsidian'
 import type {
 	AudioProvider,
 	GenerateAudioResult,
+	GenerateVideoResult,
 	ListVoicesOptions,
+	VideoProvider,
 	VoiceCloneOptions,
 	VoiceCloneResult,
 	VoiceDesignOptions,
@@ -11,13 +13,44 @@ import type {
 	VoiceOption,
 } from './types'
 import { optionalStringParam, stringParam } from './params'
+import { uploadRef } from './upload'
 
-const BASE_URL = 'https://dashscope.aliyuncs.com/api/v1'
-const QWEN_TTS_URL = `${BASE_URL}/services/aigc/multimodal-generation/generation`
-const COSY_TTS_URL = `${BASE_URL}/services/audio/tts/SpeechSynthesizer`
-const CUSTOMIZATION_URL = `${BASE_URL}/services/audio/tts/customization`
+export const DEFAULT_DASHSCOPE_BASE_URL = 'https://dashscope.aliyuncs.com/api/v1'
+const QWEN_TTS_PATH = '/services/aigc/multimodal-generation/generation'
+const COSY_TTS_PATH = '/services/audio/tts/SpeechSynthesizer'
+const CUSTOMIZATION_PATH = '/services/audio/tts/customization'
+const VIDEO_SYNTHESIS_PATH = '/services/aigc/video-generation/video-synthesis'
+const TASK_PATH = '/tasks'
+const WAN27_T2V = 'wan2.7-t2v-2026-04-25'
+const WAN27_I2V = 'wan2.7-i2v-2026-04-25'
+const WAN27_R2V = 'wan2.7-r2v'
+const WAN27_VIDEOEDIT = 'wan2.7-videoedit'
+const VIDEO_DONE_STATUSES = new Set(['SUCCEEDED', 'SUCCESS', 'COMPLETED'])
+const VIDEO_FAILED_STATUSES = new Set(['FAILED', 'FAILURE', 'ERROR', 'CANCELED', 'CANCELLED', 'UNKNOWN'])
 
 type UnknownRecord = Record<string, unknown>
+
+export function normalizeDashScopeBaseUrl(baseUrl?: string): string {
+	const trimmed = (baseUrl || '').trim()
+	return (trimmed || DEFAULT_DASHSCOPE_BASE_URL).replace(/\/+$/, '')
+}
+
+export function dashScopeUrl(baseUrl: string | undefined, path: string): string {
+	const normalizedPath = path.startsWith('/') ? path : `/${path}`
+	return `${normalizeDashScopeBaseUrl(baseUrl)}${normalizedPath}`
+}
+
+export function dashScopeRegion(baseUrl?: string): string {
+	try {
+		const host = new URL(normalizeDashScopeBaseUrl(baseUrl)).hostname
+		const match = host.match(/\.([a-z]+-[a-z]+-\d+)\.maas\.aliyuncs\.com$/)
+		if (match?.[1]) return match[1]
+		if (host === 'dashscope.aliyuncs.com') return 'cn-beijing'
+		return host
+	} catch {
+		return 'cn-beijing'
+	}
+}
 
 function isRecord(value: unknown): value is UnknownRecord {
 	return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -147,6 +180,144 @@ function outputFilePath(outputDir: string, fileName: string): string {
 	return normalizePath(`${outputDirectoryPath(outputDir)}/${fileName}`)
 }
 
+function stringList(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function optionalBooleanParam(value: unknown): boolean | undefined {
+	if (typeof value === 'boolean') return value
+	if (typeof value === 'number') return value !== 0
+	if (typeof value !== 'string') return undefined
+	const normalized = value.trim().toLowerCase()
+	if (!normalized) return undefined
+	if (['false', '0', 'off', 'no'].includes(normalized)) return false
+	return true
+}
+
+function optionalNumberParam(value: unknown): number | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value !== 'string') return undefined
+	const parsed = Number(value)
+	return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function boundedInt(value: unknown, fallback: number, min: number, max: number): number {
+	const parsed = optionalNumberParam(value)
+	const n = parsed === undefined ? fallback : Math.round(parsed)
+	return Math.min(Math.max(n, min), max)
+}
+
+function normalizeResolution(value: unknown): string {
+	const text = stringParam(value, '720P').trim().toUpperCase()
+	return text === '1080P' ? '1080P' : '720P'
+}
+
+function normalizeRatio(value: unknown): string | undefined {
+	const ratio = stringParam(value, '').trim()
+	return ['16:9', '9:16', '1:1', '4:3', '3:4'].includes(ratio) ? ratio : undefined
+}
+
+function isHttpUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value)
+}
+
+function extensionForMime(mimeType: string, kind: 'image' | 'audio' | 'video'): string {
+	if (mimeType.includes('webp')) return 'webp'
+	if (mimeType.includes('bmp')) return 'bmp'
+	if (mimeType.includes('jpeg') || mimeType.includes('jpg')) return 'jpg'
+	if (mimeType.includes('png')) return 'png'
+	if (mimeType.includes('quicktime')) return 'mov'
+	if (mimeType.includes('webm')) return 'webm'
+	if (mimeType.includes('mp4')) return 'mp4'
+	if (mimeType.includes('wav')) return 'wav'
+	if (mimeType.includes('flac')) return 'flac'
+	if (mimeType.includes('aac')) return 'aac'
+	if (mimeType.includes('ogg')) return 'ogg'
+	if (mimeType.includes('opus')) return 'opus'
+	if (mimeType.includes('mpeg') || mimeType.includes('mp3')) return 'mp3'
+	return kind === 'video' ? 'mp4' : kind === 'audio' ? 'mp3' : 'png'
+}
+
+function dataUriToBytes(dataUri: string, kind: 'image' | 'audio' | 'video'): { bytes: Uint8Array; ext: string; mimeType: string } | null {
+	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
+	if (!match) return null
+	const mimeType = match[1]
+	return {
+		bytes: Uint8Array.from(atob(match[2]), c => c.charCodeAt(0)),
+		ext: extensionForMime(mimeType, kind),
+		mimeType,
+	}
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function videoExtFromUrl(url: string): string {
+	const clean = url.split(/[?#]/)[0].toLowerCase()
+	if (clean.endsWith('.mov')) return 'mov'
+	if (clean.endsWith('.webm')) return 'webm'
+	return 'mp4'
+}
+
+function extractVideoTaskId(data: unknown): string | null {
+	return getStringAt(data, ['output', 'task_id']) || getStringAt(data, ['task_id'])
+}
+
+function extractVideoStatus(data: unknown): string {
+	return (
+		getStringAt(data, ['output', 'task_status'])
+		|| getStringAt(data, ['task_status'])
+		|| getStringAt(data, ['status'])
+		|| ''
+	).trim().toUpperCase()
+}
+
+function firstUrlInArray(value: unknown): string | null {
+	if (!Array.isArray(value)) return null
+	for (const item of value) {
+		if (typeof item === 'string' && isHttpUrl(item)) return item
+		if (isRecord(item)) {
+			const url = stringParam(item.url || item.video_url || item.file_url, '')
+			if (isHttpUrl(url)) return url
+		}
+	}
+	return null
+}
+
+function extractVideoUrl(json: unknown): string | null {
+	const paths = [
+		['output', 'video_url'],
+		['output', 'url'],
+		['output', 'video', 'url'],
+		['output', 'data', 'video_url'],
+		['output', 'data', 'url'],
+		['video_url'],
+		['url'],
+	]
+	for (const path of paths) {
+		const value = getStringAt(json, path)
+		if (value && isHttpUrl(value)) return value
+	}
+	return (
+		firstUrlInArray(getAt(json, ['output', 'results']))
+		|| firstUrlInArray(getAt(json, ['output', 'videos']))
+		|| firstUrlInArray(getAt(json, ['results']))
+		|| firstUrlInArray(getAt(json, ['videos']))
+	)
+}
+
+function videoFailureMessage(data: unknown): string {
+	return (
+		getStringAt(data, ['output', 'message'])
+		|| getStringAt(data, ['output', 'code'])
+		|| getStringAt(data, ['error', 'message'])
+		|| getStringAt(data, ['message'])
+		|| safePayloadSnippet(data)
+		|| 'Task failed'
+	)
+}
+
 function toVoiceOption(record: UnknownRecord, qwen: boolean, modelId: string): VoiceOption | null {
 	const id = qwen
 		? stringParam(record.voice, '')
@@ -262,6 +433,215 @@ function mergeVoices(voices: VoiceOption[]): VoiceOption[] {
 	return [...byId.values()]
 }
 
+type MediaKind = 'image' | 'audio' | 'video'
+
+interface Wan27Route {
+	model: string
+	input: UnknownRecord
+	parameters: UnknownRecord
+}
+
+export class DashScopeVideoProvider implements VideoProvider {
+	name = 'DashScope'
+
+	constructor(
+		private apiKey: string,
+		private app: App,
+		private outputDir: string,
+		private baseUrl = DEFAULT_DASHSCOPE_BASE_URL,
+	) {}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const route = await this.buildWan27Route(prompt, params || {})
+		const resp = await requestUrl({
+			url: dashScopeUrl(this.baseUrl, VIDEO_SYNTHESIS_PATH),
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+				'X-DashScope-Async': 'enable',
+			},
+			body: JSON.stringify({
+				model: route.model,
+				input: route.input,
+				parameters: route.parameters,
+			}),
+			throw: false,
+		})
+
+		if (isInvalidApiKeyResponse(resp)) throw new Error(`DashScope auth: ${parseErr(resp) || 'invalid API key.'}`)
+		if (resp.status >= 400) throw new Error(`DashScope video: ${parseErr(resp) || `HTTP ${resp.status}`}`)
+
+		const taskId = extractVideoTaskId(resp.json)
+		if (!taskId) throw new Error(`DashScope video: task_id was not returned - ${safePayloadSnippet(resp.json)}`)
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const resp = await requestUrl({
+			url: dashScopeUrl(this.baseUrl, `${TASK_PATH}/${encodeURIComponent(taskId)}`),
+			method: 'GET',
+			headers: { 'Authorization': `Bearer ${this.apiKey}` },
+			throw: false,
+		})
+
+		if (isInvalidApiKeyResponse(resp)) throw new Error(`DashScope auth: ${parseErr(resp) || 'invalid API key.'}`)
+		if (resp.status >= 400) throw new Error(`DashScope video: ${parseErr(resp) || `HTTP ${resp.status}`}`)
+
+		const payload: unknown = resp.json
+		const status = extractVideoStatus(payload)
+		const videoUrl = extractVideoUrl(payload)
+		if (VIDEO_DONE_STATUSES.has(status) || videoUrl) {
+			if (!videoUrl) throw new Error(`DashScope video: completed task has no video URL - ${safePayloadSnippet(payload)}`)
+			return { done: true, filePath: await this.downloadVideo(videoUrl) }
+		}
+		if (VIDEO_FAILED_STATUSES.has(status)) {
+			throw new Error(`DashScope video: ${videoFailureMessage(payload)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	private async buildWan27Route(prompt: string, params: Record<string, unknown>): Promise<Wan27Route> {
+		const genMode = stringParam(params.genMode, 'text-to-video')
+		const modelId = stringParam(params.modelId, 'wan-2.7')
+		const refImages = stringList(params.refImages)
+		const refAudios = stringList(params.refAudios)
+		const refVideos = stringList(params.refVideos)
+
+		if (modelId === WAN27_VIDEOEDIT || genMode === 'video-edit') {
+			return this.buildWan27VideoEdit(prompt, params, refImages, refVideos)
+		}
+		if (modelId === WAN27_R2V || genMode === 'image-ref' || genMode === 'multi-image-ref' || genMode === 'video-ref') {
+			return this.buildWan27R2v(prompt, params, refImages, refVideos, refAudios)
+		}
+		if (modelId === WAN27_I2V || genMode === 'first-frame' || genMode === 'first-last-frame' || genMode === 'video-extend') {
+			return this.buildWan27I2v(prompt, params, genMode, refImages, refVideos, refAudios)
+		}
+		return this.buildWan27T2v(prompt, params, refAudios)
+	}
+
+	private async buildWan27T2v(prompt: string, params: Record<string, unknown>, refAudios: string[]): Promise<Wan27Route> {
+		const input: UnknownRecord = { prompt }
+		if (refAudios[0]) input.audio_url = await this.ensureUrl(refAudios[0], 'audio')
+		return {
+			model: WAN27_T2V,
+			input,
+			parameters: this.commonParameters(params, 15),
+		}
+	}
+
+	private async buildWan27I2v(
+		prompt: string,
+		params: Record<string, unknown>,
+		genMode: string,
+		refImages: string[],
+		refVideos: string[],
+		refAudios: string[],
+	): Promise<Wan27Route> {
+		const media: UnknownRecord[] = []
+		if (genMode === 'video-extend') {
+			if (!refVideos[0]) throw new Error('Wan 2.7 video extend requires one upstream video.')
+			media.push({ type: 'first_clip', url: await this.ensureUrl(refVideos[0], 'video') })
+			if (refImages[0]) media.push({ type: 'last_frame', url: await this.ensureUrl(refImages[0], 'image') })
+		} else {
+			if (!refImages[0]) throw new Error('Wan 2.7 image-to-video requires one upstream image.')
+			media.push({ type: 'first_frame', url: await this.ensureUrl(refImages[0], 'image') })
+			if (genMode === 'first-last-frame') {
+				if (!refImages[1]) throw new Error('Wan 2.7 first-last-frame mode requires two upstream images.')
+				media.push({ type: 'last_frame', url: await this.ensureUrl(refImages[1], 'image') })
+			}
+		}
+		if (refAudios[0]) media.push({ type: 'driving_audio', url: await this.ensureUrl(refAudios[0], 'audio') })
+		return {
+			model: WAN27_I2V,
+			input: { prompt, media },
+			parameters: this.commonParameters(params, 15),
+		}
+	}
+
+	private async buildWan27R2v(
+		prompt: string,
+		params: Record<string, unknown>,
+		refImages: string[],
+		refVideos: string[],
+		refAudios: string[],
+	): Promise<Wan27Route> {
+		const media: UnknownRecord[] = []
+		const imageMedia = await Promise.all(refImages.map(async url => ({ type: 'reference_image', url: await this.ensureUrl(url, 'image') })))
+		const videoMedia = await Promise.all(refVideos.map(async url => ({ type: 'reference_video', url: await this.ensureUrl(url, 'video') })))
+		const refs: UnknownRecord[] = [...imageMedia, ...videoMedia]
+		if (refs.length === 0) throw new Error('Wan 2.7 reference mode requires at least one upstream image or video.')
+		if (media.length + refs.length > 5) throw new Error('Wan 2.7 reference mode supports at most 5 media inputs.')
+		for (let i = 0; i < refs.length; i++) {
+			if (refAudios[i]) refs[i].reference_voice = await this.ensureUrl(refAudios[i], 'audio')
+		}
+		media.push(...refs)
+		return {
+			model: WAN27_R2V,
+			input: { prompt, media },
+			parameters: this.commonParameters(params, 10),
+		}
+	}
+
+	private async buildWan27VideoEdit(
+		prompt: string,
+		params: Record<string, unknown>,
+		refImages: string[],
+		refVideos: string[],
+	): Promise<Wan27Route> {
+		if (!refVideos[0]) throw new Error('Wan 2.7 VideoEdit requires one upstream video.')
+		if (refImages.length > 3) throw new Error('Wan 2.7 VideoEdit supports at most 3 reference images.')
+		const media: UnknownRecord[] = [
+			{ type: 'video', url: await this.ensureUrl(refVideos[0], 'video') },
+		]
+		for (const ref of refImages) {
+			media.push({ type: 'reference_image', url: await this.ensureUrl(ref, 'image') })
+		}
+		const parameters = this.commonParameters(params, 10)
+		const audioSetting = stringParam(params.audio_setting, '')
+		if (audioSetting === 'auto' || audioSetting === 'origin') parameters.audio_setting = audioSetting
+		return {
+			model: WAN27_VIDEOEDIT,
+			input: { prompt, media },
+			parameters,
+		}
+	}
+
+	private commonParameters(params: Record<string, unknown>, maxDuration: number): UnknownRecord {
+		const parameters: UnknownRecord = {
+			resolution: normalizeResolution(params.resolution),
+			duration: boundedInt(params.duration, 5, 2, maxDuration),
+			prompt_extend: optionalBooleanParam(params.prompt_extend) ?? true,
+			watermark: false,
+		}
+		const ratio = normalizeRatio(params.ratio || params.aspectRatio || params.aspect_ratio)
+		if (ratio) parameters.ratio = ratio
+		const negativePrompt = optionalStringParam(params.negative_prompt)
+		if (negativePrompt) parameters.negative_prompt = negativePrompt
+		return parameters
+	}
+
+	private async ensureUrl(ref: string, kind: MediaKind): Promise<string> {
+		if (isHttpUrl(ref)) return ref
+		if (ref.startsWith('asset://')) {
+			throw new Error('DashScope video does not support provider asset:// references; use URL-uploaded media.')
+		}
+		const decoded = dataUriToBytes(ref, kind)
+		if (!decoded) throw new Error(`DashScope video: unsupported reference ${kind} format`)
+		return uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `dashscope-ref.${decoded.ext}`, decoded.mimeType)
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const resp = await requestUrl({ url })
+		const outputDir = outputDirectoryPath(this.outputDir)
+		const filePath = outputFilePath(this.outputDir, `dashscope_wan27_${Date.now()}.${videoExtFromUrl(url)}`)
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(outputDir)) await adapter.mkdir(outputDir)
+		await adapter.writeBinary(filePath, resp.arrayBuffer)
+		return filePath
+	}
+}
+
 export class DashScopeAudioProvider implements AudioProvider {
 	name = 'DashScope'
 
@@ -269,6 +649,7 @@ export class DashScopeAudioProvider implements AudioProvider {
 		private apiKey: string,
 		private app: App,
 		private outputDir: string,
+		private baseUrl = DEFAULT_DASHSCOPE_BASE_URL,
 	) {}
 
 	async generateAudio(prompt: string, options: { mode: 'tts' | 'music' | 'sound-effect'; modelId?: string; [k: string]: unknown }): Promise<GenerateAudioResult> {
@@ -295,7 +676,7 @@ export class DashScopeAudioProvider implements AudioProvider {
 		}
 
 		const resp = await requestUrl({
-			url: qwen ? QWEN_TTS_URL : COSY_TTS_URL,
+			url: dashScopeUrl(this.baseUrl, qwen ? QWEN_TTS_PATH : COSY_TTS_PATH),
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -362,7 +743,7 @@ export class DashScopeAudioProvider implements AudioProvider {
 			}
 
 		const resp = await requestUrl({
-			url: CUSTOMIZATION_URL,
+			url: dashScopeUrl(this.baseUrl, CUSTOMIZATION_PATH),
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -407,7 +788,7 @@ export class DashScopeAudioProvider implements AudioProvider {
 			}
 
 		const resp = await requestUrl({
-			url: CUSTOMIZATION_URL,
+			url: dashScopeUrl(this.baseUrl, CUSTOMIZATION_PATH),
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -445,7 +826,7 @@ export class DashScopeAudioProvider implements AudioProvider {
 			: { action: 'list_voice', page_size: 100, page_index: 0 }
 
 		const resp = await requestUrl({
-			url: CUSTOMIZATION_URL,
+			url: dashScopeUrl(this.baseUrl, CUSTOMIZATION_PATH),
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -22,7 +22,7 @@ import { MuleRouterImageProvider, MuleRouterVideoProvider, testMuleRouterConnect
 import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
 import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProvider } from './tokenrouter'
 import { Token360VideoProvider } from './token360'
-import { DashScopeAudioProvider } from './dashscope'
+import { DashScopeAudioProvider, DashScopeVideoProvider, dashScopeUrl } from './dashscope'
 
 const LUMA_ENDPOINT = 'https://luma.bragi.now'
 import { OpenAITextProvider, APIMartTextProvider, GeminiTextProvider, AnthropicTextProvider, BedrockClaudeTextProvider, XAITextProvider } from './text-gen'
@@ -347,18 +347,23 @@ export const PROVIDERS: ProviderSpec[] = [
 		id: 'dashscope',
 		name: 'DashScope',
 		docUrl: 'https://dashscope.console.aliyun.com/',
-		fields: [{ key: 'dashscope', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
+		fields: [
+			{ key: 'dashscope', label: 'API Key', placeholder: 'sk-...', type: 'password' },
+			{ key: 'dashscopeBaseUrl', label: 'Base URL', placeholder: 'https://dashscope.aliyuncs.com/api/v1', type: 'text' },
+		],
 		isConfigured: (s) => !!s.providers.dashscope,
+		makeVideo: ({ settings, app, outputDir }) =>
+			new DashScopeVideoProvider(settings.providers.dashscope, app, outputDir, settings.providers.dashscopeBaseUrl),
 		makeAudio: ({ settings, app, outputDir }) =>
-			new DashScopeAudioProvider(settings.providers.dashscope, app, outputDir),
+			new DashScopeAudioProvider(settings.providers.dashscope, app, outputDir, settings.providers.dashscopeBaseUrl),
 		makeText: ({ settings }) =>
-			new DashScopeTextProvider(settings.providers.dashscope),
+			new DashScopeTextProvider(settings.providers.dashscope, settings.providers.dashscopeBaseUrl),
 		testConnection: async (d) => {
 			const key = d.dashscope || ''
 			if (!key) return { ok: false, message: 'API key is empty.' }
 			try {
 				const resp = await requestUrl({
-					url: 'https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation',
+					url: dashScopeUrl(d.dashscopeBaseUrl, '/services/aigc/text-generation/generation'),
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 5
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 7
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {
@@ -501,6 +501,17 @@ function migrateProviderModelPrefs(settings: BragiSettings, previousVersion: num
 	pruneProviderModelPrefs(settings)
 }
 
+function migrateDashScopeWan27(settings: BragiSettings, previousVersion: number): void {
+	if (previousVersion >= 6) return
+	if (!settings.providers.dashscope?.trim()) return
+	const modelId = 'wan-2.7'
+	if (!connectProviderToModel(settings, 'dashscope', modelId)) return
+	settings.modelPrefs[modelId] = {
+		enabled: true,
+		selectedProvider: 'dashscope',
+	}
+}
+
 const RECOGNIZABLE_KEYS = [
 	'settingsSchemaVersion',
 	'outputDir',
@@ -550,6 +561,7 @@ export function migrateSettings(
 	migrateByteplusGroupId(settings, raw)
 	migrateProviderPrefs19(settings)
 	migrateProviderModelPrefs(settings, previousVersion)
+	migrateDashScopeWan27(settings, previousVersion)
 	settings.settingsSchemaVersion = CURRENT_SETTINGS_SCHEMA_VERSION
 
 	const valid = options.strict ? errors.length === 0 : true

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -113,6 +113,7 @@ export interface BragiSettings {
 		lumaToken: string
 		xai: string
 		dashscope: string
+		dashscopeBaseUrl: string
 	}
 
 	// Per-model preferences
@@ -181,6 +182,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 		lumaToken: '',
 		xai: '',
 		dashscope: '',
+		dashscopeBaseUrl: 'https://dashscope.aliyuncs.com/api/v1',
 	},
 	modelPrefs: {},
 	providerModelPrefs: {},

--- a/src/styles.css
+++ b/src/styles.css
@@ -1155,6 +1155,8 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 .bragi-bar-select {
 	-webkit-appearance: none;
 	appearance: none;
+	box-sizing: border-box;
+	height: 32px;
 	padding: 4px 20px 4px 6px;
 	border: 0;
 	border-radius: 4px;
@@ -1162,6 +1164,7 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	box-shadow: none;
 	color: var(--bragi-text);
 	font-size: 13px;
+	line-height: 24px;
 	cursor: pointer;
 	outline: 0;
 }
@@ -1251,10 +1254,19 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	position: relative;
 	display: inline-flex;
 	align-items: center;
+	box-sizing: border-box;
+	height: 32px;
+	margin: 0;
+	padding: 0;
 }
 
 .bragi-bar-range-menu > summary {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: border-box;
+	min-height: 32px;
 	list-style: none;
+	margin: 0;
 }
 
 .bragi-bar-range-menu > summary::-webkit-details-marker {
@@ -1262,8 +1274,10 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 }
 
 .bragi-bar-range-btn {
+	box-sizing: border-box;
 	display: inline-flex;
 	align-items: center;
+	height: 32px;
 	max-width: 150px;
 	padding: 4px 20px 4px 8px;
 	border: 0;
@@ -1271,7 +1285,7 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	background: transparent url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='rgba(0,0,0,0.4)' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat right 6px center;
 	color: var(--bragi-text);
 	font-size: 13px;
-	line-height: 1.2;
+	line-height: 24px;
 	box-shadow: none;
 	outline: 0;
 	cursor: pointer;

--- a/styles.css
+++ b/styles.css
@@ -1155,6 +1155,8 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 .bragi-bar-select {
 	-webkit-appearance: none;
 	appearance: none;
+	box-sizing: border-box;
+	height: 32px;
 	padding: 4px 20px 4px 6px;
 	border: 0;
 	border-radius: 4px;
@@ -1162,6 +1164,7 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	box-shadow: none;
 	color: var(--bragi-text);
 	font-size: 13px;
+	line-height: 24px;
 	cursor: pointer;
 	outline: 0;
 }
@@ -1251,10 +1254,19 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	position: relative;
 	display: inline-flex;
 	align-items: center;
+	box-sizing: border-box;
+	height: 32px;
+	margin: 0;
+	padding: 0;
 }
 
 .bragi-bar-range-menu > summary {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: border-box;
+	min-height: 32px;
 	list-style: none;
+	margin: 0;
 }
 
 .bragi-bar-range-menu > summary::-webkit-details-marker {
@@ -1262,8 +1274,10 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 }
 
 .bragi-bar-range-btn {
+	box-sizing: border-box;
 	display: inline-flex;
 	align-items: center;
+	height: 32px;
 	max-width: 150px;
 	padding: 4px 20px 4px 8px;
 	border: 0;
@@ -1271,7 +1285,7 @@ body.bragi-annotation-mode-active .canvas-wrapper.bragi-annotation-mode .canvas-
 	background: transparent url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='rgba(0,0,0,0.4)' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") no-repeat right 6px center;
 	color: var(--bragi-text);
 	font-size: 13px;
-	line-height: 1.2;
+	line-height: 24px;
 	box-shadow: none;
 	outline: 0;
 	cursor: pointer;


### PR DESCRIPTION
## Summary
- Add a unified DashScope-backed Wan 2.7 video model that routes T2V, I2V, R2V, video extend, and video edit modes.
- Add configurable DashScope native base URL support and southeast workspace compatibility.
- Simplify Wan 2.7 UI params and mode labels, including merging multi-image reference into Ref Image and fixing the Duration toolbar hover height.

## Validation
- npm run build
- npm run lint:obsidian
- git diff --check
- Live Obsidian Canvas QA was run during implementation for Wan 2.7 video modes and the southeast DashScope endpoint.