### PR TITLE
fix: render split/collage nodes and self-heal ref strip drag guard

### DIFF
--- a/src/audio-refs.ts
+++ b/src/audio-refs.ts
@@ -3,11 +3,10 @@ import type { App } from 'obsidian'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { clearIncomingRefAttachments, isGeneratingPlaceholderNode } from './generating-node'
 import { getUpstreamInputs } from './edge-parser'
+import { beginRefDrag, endRefDrag, isRefDragActive } from './ref-drag-guard'
 
 const STRIP_CLASS = 'bragi-audio-ref-strip'
 const NODE_HAS_AUDIO_REFS_CLASS = 'bragi-has-audio-refs'
-
-let isDragging = false
 
 export function getOrderedAudios(canvas: Canvas, node: CanvasNode): string[] {
 	const upstream = getUpstreamInputs(canvas, node)
@@ -55,7 +54,7 @@ async function getAudioDuration(app: App, filePath: string): Promise<number> {
 }
 
 export function updateAudioRefStrip(canvas: Canvas, node: CanvasNode, app: App): void {
-	if (isDragging) return
+	if (isRefDragActive()) return
 	if (isGeneratingPlaceholderNode(node)) {
 		clearIncomingRefAttachments(node)
 		return
@@ -128,12 +127,12 @@ export function updateAudioRefStrip(canvas: Canvas, node: CanvasNode, app: App):
 		})
 
 		wrapper.addEventListener('dragstart', (e) => {
-			isDragging = true
+			beginRefDrag()
 			e.dataTransfer!.setData('text/plain', `bragi-audio-ref:${audioPath}`)
 			wrapper.classList.add('is-dragging')
 		})
 		wrapper.addEventListener('dragend', () => {
-			isDragging = false
+			endRefDrag()
 			wrapper.classList.remove('is-dragging')
 		})
 		wrapper.addEventListener('dragover', (e) => {
@@ -161,7 +160,7 @@ export function updateAudioRefStrip(canvas: Canvas, node: CanvasNode, app: App):
 			const data = node.getData() as unknown
 			node.setData({ ...data, bragiAudioOrder: newOrder })
 
-			isDragging = false
+			endRefDrag()
 			updateAudioRefStrip(canvas, node, app)
 		})
 
@@ -182,7 +181,7 @@ export function updateAudioRefStrip(canvas: Canvas, node: CanvasNode, app: App):
 }
 
 export function refreshAllAudioRefs(canvas: Canvas, app: App): void {
-	if (isDragging) return
+	if (isRefDragActive()) return
 	if (!canvas.nodes) return
 	const nodes = canvas.nodes instanceof Map
 		? Array.from(canvas.nodes.values())

--- a/src/canvas-image-compose.ts
+++ b/src/canvas-image-compose.ts
@@ -276,11 +276,17 @@ export async function composeSelectedImageNodes(plugin: BragiCanvas, canvas: Can
 
 	const current = canvas.getData()
 	canvas.importData({
-		...current,
 		nodes: [...current.nodes, outputNode],
 		edges: [...current.edges, ...edges],
 	})
 	void canvas.requestSave()
+	// importData mutates the data model but does not repaint on its own; without
+	// a frame request the collage node is saved to disk yet never rendered.
+	try {
+		void canvas.requestFrame()
+	} catch (err) {
+		console.debug('Bragi collage: canvas frame refresh skipped', err)
+	}
 
 	const scaleNote = wasScaleLimited ? ` (${pixelScale.toFixed(2)}x)` : ''
 	new Notice(`Collage ready${scaleNote}`)

--- a/src/canvas-ops.ts
+++ b/src/canvas-ops.ts
@@ -604,6 +604,13 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 	}
 
 	void canvas.requestSave()
+	// importData mutates the data model but does not repaint on its own; without
+	// a frame request the duplicated node is saved to disk yet never rendered.
+	try {
+		void canvas.requestFrame()
+	} catch (frameErr) {
+		console.debug('Bragi duplicate: canvas frame refresh skipped', frameErr)
+	}
 	} catch (err) {
 		console.error('[Bragi] duplicateWithConnections failed', err)
 	}

--- a/src/grid-split-flow.ts
+++ b/src/grid-split-flow.ts
@@ -95,11 +95,17 @@ export async function splitImageNodeIntoTiles(plugin: BragiCanvas, canvas: Canva
 	}
 
 	canvas.importData({
-		...current,
 		nodes: [...current.nodes, ...newNodes],
 		edges: [...current.edges, ...newEdges],
 	})
 	void canvas.requestSave()
+	// importData mutates the data model but does not repaint on its own; without
+	// a frame request the new tile nodes are saved to disk yet never rendered.
+	try {
+		void canvas.requestFrame()
+	} catch (err) {
+		console.debug('Bragi split: canvas frame refresh skipped', err)
+	}
 
 	new Notice(`Split into ${tiles.length} tile${tiles.length === 1 ? '' : 's'}`)
 }

--- a/src/ref-drag-guard.ts
+++ b/src/ref-drag-guard.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared drag guard for reference strips (image / text / audio thumbnails).
+ *
+ * The ref strips are rebuilt by a 1s polling refresh. While the user is
+ * drag-reordering a thumbnail we must NOT rebuild the strip, or the element
+ * being dragged gets yanked out of the DOM and the drop breaks. The previous
+ * implementation used a per-module `isDragging` boolean flipped on `dragstart`
+ * / `dragend`. The problem: in Electron a drag's `dragend` can be lost (drop
+ * outside the window, a cancelled drag, or the source element removed
+ * mid-drag). A single lost `dragend` left the flag stuck `true` for the rest of
+ * the session, permanently wedging the refresh — newly connected upstream
+ * nodes would silently never render until the plugin reloaded.
+ *
+ * This guard is self-healing: the "dragging" state auto-expires after a short
+ * window, so a lost `dragend` can stall a refresh by at most DRAG_MAX_MS rather
+ * than forever. Only one ref drag can happen at a time, so a single shared
+ * guard is sufficient across all strip types.
+ */
+
+// Generous enough to cover a deliberate human reorder drag, short enough that a
+// lost dragend self-recovers quickly (the refresh interval is 1s anyway).
+const DRAG_MAX_MS = 3000
+
+let dragStartedAt = 0
+
+export function beginRefDrag(): void {
+	dragStartedAt = Date.now()
+}
+
+export function endRefDrag(): void {
+	dragStartedAt = 0
+}
+
+export function isRefDragActive(): boolean {
+	if (dragStartedAt === 0) return false
+	if (Date.now() - dragStartedAt > DRAG_MAX_MS) {
+		// Treat as a lost dragend and recover so refreshes don't stay wedged.
+		dragStartedAt = 0
+		return false
+	}
+	return true
+}

--- a/src/ref-thumbnails.ts
+++ b/src/ref-thumbnails.ts
@@ -3,14 +3,12 @@ import type { App } from 'obsidian'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { getUpstreamInputs } from './edge-parser'
 import { clearIncomingRefAttachments, isGeneratingPlaceholderNode } from './generating-node'
+import { beginRefDrag, endRefDrag, isRefDragActive } from './ref-drag-guard'
 
 const STRIP_CLASS = 'bragi-ref-strip'
 const NODE_HAS_REFS_CLASS = 'bragi-has-refs'
 
 const adjustedNodes = new Set<string>()
-
-// Block refresh during drag
-let isDragging = false
 
 /**
  * Get the ordered image list for a node.
@@ -45,7 +43,7 @@ export function getOrderedImages(canvas: Canvas, node: CanvasNode): string[] {
 }
 
 export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App): void {
-	if (isDragging) return // Don't rebuild during drag
+	if (isRefDragActive()) return // Don't rebuild during an active reorder drag
 	if (isGeneratingPlaceholderNode(node)) {
 		clearIncomingRefAttachments(node)
 		return
@@ -119,13 +117,13 @@ export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App):
 
 		// Drag events
 		wrapper.addEventListener('dragstart', (e) => {
-			isDragging = true
+			beginRefDrag()
 			e.dataTransfer!.setData('text/plain', imgPath)
 			wrapper.classList.add('is-dragging')
 		})
 
 		wrapper.addEventListener('dragend', () => {
-			isDragging = false
+			endRefDrag()
 			wrapper.classList.remove('is-dragging')
 		})
 
@@ -160,7 +158,7 @@ export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App):
 			node.setData({ ...rest, bragiImageOrder: newOrder })
 
 			// Force rebuild
-			isDragging = false
+			endRefDrag()
 			updateRefThumbnails(canvas, node, app)
 		})
 
@@ -224,7 +222,7 @@ export function getAssetIds(canvas: Canvas, node: CanvasNode, providerId?: strin
 }
 
 export function refreshAllThumbnails(canvas: Canvas, app: App): void {
-	if (isDragging) return
+	if (isRefDragActive()) return
 	if (!canvas.nodes) return
 
 	const nodes = canvas.nodes instanceof Map

--- a/src/text-refs.ts
+++ b/src/text-refs.ts
@@ -2,11 +2,10 @@
 import type { App } from 'obsidian'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { clearIncomingRefAttachments, isGeneratingPlaceholderNode } from './generating-node'
+import { beginRefDrag, endRefDrag, isRefDragActive } from './ref-drag-guard'
 
 const STRIP_CLASS = 'bragi-text-ref-strip'
 const NODE_HAS_TEXT_REFS_CLASS = 'bragi-has-text-refs'
-
-let isDragging = false
 
 export interface TextRef {
 	nodeId: string
@@ -118,7 +117,7 @@ export async function getOrderedPrompts(
 }
 
 export function updateTextRefStrip(canvas: Canvas, node: CanvasNode, app: App): void {
-	if (isDragging) return
+	if (isRefDragActive()) return
 	if (isGeneratingPlaceholderNode(node)) {
 		clearIncomingRefAttachments(node)
 		return
@@ -182,12 +181,12 @@ export function updateTextRefStrip(canvas: Canvas, node: CanvasNode, app: App): 
 		row.appendChild(preview)
 
 		row.addEventListener('dragstart', (e) => {
-			isDragging = true
+			beginRefDrag()
 			e.dataTransfer!.setData('text/plain', `bragi-text-ref:${ref.nodeId}`)
 			row.classList.add('is-dragging')
 		})
 		row.addEventListener('dragend', () => {
-			isDragging = false
+			endRefDrag()
 			row.classList.remove('is-dragging')
 		})
 		row.addEventListener('dragover', (e) => {
@@ -215,7 +214,7 @@ export function updateTextRefStrip(canvas: Canvas, node: CanvasNode, app: App): 
 			const d = node.getData() as unknown
 			node.setData({ ...d, bragiTextOrder: order })
 
-			isDragging = false
+			endRefDrag()
 			updateTextRefStrip(canvas, node, app)
 		})
 
@@ -233,7 +232,7 @@ export function updateTextRefStrip(canvas: Canvas, node: CanvasNode, app: App): 
 }
 
 export function refreshAllTextRefs(canvas: Canvas, app: App): void {
-	if (isDragging) return
+	if (isRefDragActive()) return
 	if (!canvas.nodes) return
 	const nodes = canvas.nodes instanceof Map
 		? Array.from(canvas.nodes.values())


### PR DESCRIPTION
## Summary
Fixes three related canvas bugs reported in testing:

1. **Grid Split shows a count but no nodes appear** — `splitImageNodeIntoTiles` wrote new tile nodes via `importData()` + `requestSave()` but never requested a frame, so nodes were persisted to disk yet never painted on the live canvas.
2. **Collage (multi-image compose) stopped working** — same root cause in `composeSelectedImageNodes`: the composed node was saved but not rendered.
3. **Upstream image refs intermittently don't show on the prompt node** — the image/text/audio reference strips are surfaced by a 1s polling refresh that early-returns during a reorder drag. The per-module `isDragging` boolean was only cleared on `dragend`/`drop`; a single lost `dragend` (drop outside the window, cancelled drag, source element removed mid-drag — common in Electron) left it stuck `true` for the whole session, silently preventing newly connected upstream nodes from rendering until reload.

## Changes
- `grid-split-flow.ts`, `canvas-image-compose.ts`: call `canvas.requestFrame()` after `importData()` (matching the proven annotation flow) and drop the stray `...current` spread.
- `canvas-ops.ts`: same `requestFrame()` hardening for `duplicateWithConnections` (same latent issue).
- New `ref-drag-guard.ts`: shared, timestamp-based drag guard that auto-expires, replacing the three sticky `isDragging` booleans in `ref-thumbnails.ts`, `text-refs.ts`, `audio-refs.ts`.

## Test plan
- [ ] Reload plugin; Split grid on a collage image → new tile nodes appear immediately on canvas.
- [ ] Multi-select images → Collage → composed node appears immediately.
- [ ] Connect an upstream image to a prompt node → thumbnail shows reliably; reorder a ref thumbnail then connect a new image → refs still refresh (no permanent wedge).