### PR TITLE
[codex] fix ElevenLabs SFX duration range

### DIFF
--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -8,7 +8,7 @@ import type { PanelResult } from './panel'
 import { getModelById, getActiveProvider, getEnabledModels } from './models/index'
 import { getTextInputCapability, listSupportedInputLabels, listUnsupportedInputLabels } from './models/text-input-capabilities'
 import { getConnectedConfiguredProviderIds, resolveApiModelId } from './provider-model-prefs'
-import type { GenerationType, Mode } from './models/types'
+import type { GenerationType, Mode, ModelParam } from './models/types'
 import { getUpstreamInputs } from './edge-parser'
 import { getOrderedTextRefs } from './text-refs'
 import { getOrderedImages } from './ref-thumbnails'
@@ -35,6 +35,37 @@ type BragiCanvasNodeData = AllCanvasNodeData & {
 type SerializableEdge = CanvasEdgeData | CanvasEdge
 type FileView = { file?: TFile }
 type EdgeStore = Map<string, CanvasEdge> | CanvasEdge[]
+
+function applyProviderOverride(param: ModelParam, provider: string | null): ModelParam {
+	const override = provider ? param.providerOverrides?.[provider] : undefined
+	return override ? { ...param, ...override } : param
+}
+
+function normalizeNumericParamValue(param: ModelParam, value: unknown): number {
+	const raw = typeof value === 'number'
+		? value
+		: typeof value === 'string'
+			? parseFloat(value)
+			: NaN
+	const fallback = typeof param.default === 'number' ? param.default : parseFloat(String(param.default))
+	let next = Number.isFinite(raw)
+		? raw
+		: Number.isFinite(fallback)
+			? fallback
+			: param.min ?? 0
+	const min = param.min
+	const max = param.max
+	const step = param.step
+	if (min !== undefined) next = Math.max(min, next)
+	if (max !== undefined) next = Math.min(max, next)
+	if (step !== undefined && step > 0 && Number.isFinite(step)) {
+		const base = min ?? 0
+		next = base + Math.round((next - base) / step) * step
+		if (min !== undefined) next = Math.max(min, next)
+		if (max !== undefined) next = Math.min(max, next)
+	}
+	return Number(next.toFixed(6))
+}
 
 export interface McpToolContext {
 	getCanvas: GetCanvas
@@ -450,16 +481,19 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 								supportedInputs: listSupportedInputLabels(capability),
 								unsupportedInputs: listUnsupportedInputLabels(capability),
 							} : {}),
-							params: m.params.map(p => ({
-								id: p.id,
-								label: p.label,
-								type: p.type,
-								default: p.default,
-								...(p.modes ? { modes: p.modes } : {}),
-								...(p.options ? { options: p.options } : {}),
-								...(p.optionsByMode ? { optionsByMode: p.optionsByMode } : {}),
-								...(p.min !== undefined ? { min: p.min, max: p.max, step: p.step, unit: p.unit } : {}),
-							})),
+							params: m.params.map(param => {
+								const p = applyProviderOverride(param, provider)
+								return {
+									id: p.id,
+									label: p.label,
+									type: p.type,
+									default: p.default,
+									...(p.modes ? { modes: p.modes } : {}),
+									...(p.options ? { options: p.options } : {}),
+									...(p.optionsByMode ? { optionsByMode: p.optionsByMode } : {}),
+									...(p.min !== undefined ? { min: p.min, max: p.max, step: p.step, unit: p.unit } : {}),
+								}
+							}),
 						})
 					}
 				}
@@ -533,9 +567,13 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 
 				// Resolve params with defaults, but only for params visible in this mode.
 				const resolvedParams: Record<string, string | number> = { ...(params || {}) }
-				for (const p of model.params) {
-					if (p.modes && (!selectedMode || !p.modes.includes(selectedMode))) continue
-					resolvedParams[p.id] = resolvedParams[p.id] ?? p.default
+				for (const baseParam of model.params) {
+					if (baseParam.modes && (!selectedMode || !baseParam.modes.includes(selectedMode))) continue
+					const p = applyProviderOverride(baseParam, provider)
+					const value = resolvedParams[p.id] ?? p.default
+					resolvedParams[p.id] = (p.type === 'range' || p.type === 'number')
+						? normalizeNumericParamValue(p, value)
+						: value
 				}
 
 				const panelResult: PanelResult = {

--- a/src/models/audio.ts
+++ b/src/models/audio.ts
@@ -383,16 +383,15 @@ export const elevenLabsSFX: ModelConfig = {
 		{
 			id: 'duration',
 			label: 'Duration',
-			type: 'select',
-			options: [
-				{ label: '1s', value: '1' },
-				{ label: '3s', value: '3' },
-				{ label: '5s', value: '5' },
-				{ label: '10s', value: '10' },
-				{ label: '20s', value: '20' },
-				{ label: '30s', value: '30' },
-			],
-			default: '5',
+			type: 'range',
+			default: 5,
+			min: 0.5,
+			max: 30,
+			step: 0.5,
+			unit: 's',
+			providerOverrides: {
+				fal: { max: 22 },
+			},
 		},
 	],
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -13,6 +13,15 @@ export interface ParamOption {
 	value: string
 }
 
+export interface ModelParamProviderOverride {
+	options?: ParamOption[]
+	default?: string | number
+	min?: number
+	max?: number
+	step?: number
+	unit?: string
+}
+
 export interface ModelParam {
 	id: string
 	label: string
@@ -30,6 +39,11 @@ export interface ModelParam {
 	 * Used e.g. for xAI video where image-ref caps duration at 10s while others go to 15s.
 	 */
 	optionsByMode?: Record<string, ParamOption[]>
+	/**
+	 * Provider-specific parameter overrides for cases where wrappers expose a
+	 * narrower schema than the native upstream model.
+	 */
+	providerOverrides?: Record<string, ModelParamProviderOverride>
 	default: string | number
 	min?: number
 	max?: number

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -73,6 +73,37 @@ function rangeParamValueLabel(param: ModelParam, value: string | number): string
 	return `${value}${param.unit || ''}`
 }
 
+function applyProviderOverride(param: ModelParam, provider: string | null): ModelParam {
+	const override = provider ? param.providerOverrides?.[provider] : undefined
+	return override ? { ...param, ...override } : param
+}
+
+function normalizeNumericParamValue(param: ModelParam, value: unknown): number {
+	const raw = typeof value === 'number'
+		? value
+		: typeof value === 'string'
+			? parseFloat(value)
+			: NaN
+	const fallback = typeof param.default === 'number' ? param.default : parseFloat(String(param.default))
+	let next = Number.isFinite(raw)
+		? raw
+		: Number.isFinite(fallback)
+			? fallback
+			: param.min ?? 0
+	const min = param.min
+	const max = param.max
+	const step = param.step
+	if (min !== undefined) next = Math.max(min, next)
+	if (max !== undefined) next = Math.min(max, next)
+	if (step !== undefined && step > 0 && Number.isFinite(step)) {
+		const base = min ?? 0
+		next = base + Math.round((next - base) / step) * step
+		if (min !== undefined) next = Math.max(min, next)
+		if (max !== undefined) next = Math.min(max, next)
+	}
+	return Number(next.toFixed(6))
+}
+
 function paramVisibleForMode(param: ModelParam, mode: Mode | null): boolean {
 	return !param.modes || (!!mode && param.modes.includes(mode))
 }
@@ -104,7 +135,9 @@ function renderRangeParamDropdown(
 	range.min = String(param.min ?? 0)
 	range.max = String(param.max ?? 100)
 	range.step = String(param.step ?? 1)
-	range.value = String(paramValues[param.id] ?? param.default)
+	const initialValue = normalizeNumericParamValue(param, paramValues[param.id] ?? param.default)
+	range.value = String(initialValue)
+	paramValues[param.id] = initialValue
 	range.title = param.label
 
 	const valueLabel = createSpan()
@@ -117,7 +150,7 @@ function renderRangeParamDropdown(
 	}
 
 	range.addEventListener('input', () => {
-		paramValues[param.id] = parseFloat(range.value)
+		paramValues[param.id] = normalizeNumericParamValue(param, range.value)
 		updateLabel()
 	})
 
@@ -515,11 +548,15 @@ export function showGenerateBar(
 		const prev = { ...paramValues }
 		paramValues = {}
 		if (!selectedModel) return
-		for (const p of selectedModel.params) {
+		const { provider } = resolveProvider(selectedModel, settings)
+		for (const baseParam of selectedModel.params) {
+			const p = applyProviderOverride(baseParam, provider)
 			// Keep current value if same param exists and value is valid in new model
 			const canKeepDynamicVoice = preserveDynamicVoice && p.id === 'voice' && (p.options?.length || 0) === 0
 			if (prev[p.id] !== undefined && (canKeepDynamicVoice || p.options?.some(o => o.value === String(prev[p.id])))) {
 				paramValues[p.id] = prev[p.id]
+			} else if (prev[p.id] !== undefined && (p.type === 'range' || p.type === 'number')) {
+				paramValues[p.id] = normalizeNumericParamValue(p, prev[p.id])
 			} else {
 				paramValues[p.id] = p.default
 			}
@@ -654,7 +691,9 @@ export function showGenerateBar(
 	function rebuildParams() {
 		paramsEl.innerHTML = ''
 		if (!selectedModel) return
-		for (const param of paramsVisibleForMode(selectedModel, selectedMode)) {
+		const { provider } = resolveProvider(selectedModel, settings)
+		for (const baseParam of paramsVisibleForMode(selectedModel, selectedMode)) {
+			const param = applyProviderOverride(baseParam, provider)
 			if (param.type === 'select' && param.options) {
 				// Pick mode-specific options if declared; otherwise the base list.
 				const effectiveOptions = (selectedMode && param.optionsByMode?.[selectedMode]) || param.options
@@ -763,10 +802,15 @@ export function showGenerateBar(
 	function currentVisibleParamValues(): Record<string, string | number> {
 		if (!selectedModel) return {}
 		const visibleIds = new Set(paramsVisibleForMode(selectedModel, selectedMode).map(param => param.id))
+		const { provider } = resolveProvider(selectedModel, settings)
 		const result: Record<string, string | number> = {}
 		for (const [key, value] of Object.entries(paramValues)) {
 			if (visibleIds.has(key) || key === 'voiceLabel' || key === 'voiceMode' || key === 'voiceRefAudioIndex' || key === 'voiceDesignTextIndex') {
-				result[key] = value
+				const baseParam = selectedModel.params.find(param => param.id === key)
+				const param = baseParam ? applyProviderOverride(baseParam, provider) : null
+				result[key] = param && (param.type === 'range' || param.type === 'number')
+					? normalizeNumericParamValue(param, value)
+					: value
 			}
 		}
 		return result
@@ -1219,10 +1263,14 @@ export function showBatchGenerateBar(
 		const prev = { ...paramValues }
 		paramValues = {}
 		if (!selectedModel) return
-		for (const p of selectedModel.params) {
+		const { provider } = resolveProvider(selectedModel, settings)
+		for (const baseParam of selectedModel.params) {
+			const p = applyProviderOverride(baseParam, provider)
 			const canKeepDynamicVoice = preserveDynamicVoice && p.id === 'voice' && (p.options?.length || 0) === 0
 			if (prev[p.id] !== undefined && (canKeepDynamicVoice || p.options?.some(o => o.value === String(prev[p.id])))) {
 				paramValues[p.id] = prev[p.id]
+			} else if (prev[p.id] !== undefined && (p.type === 'range' || p.type === 'number')) {
+				paramValues[p.id] = normalizeNumericParamValue(p, prev[p.id])
 			} else {
 				paramValues[p.id] = p.default
 			}
@@ -1233,7 +1281,9 @@ export function showBatchGenerateBar(
 	function rebuildParams() {
 		paramsEl.innerHTML = ''
 		if (!selectedModel) return
-		for (const param of paramsVisibleForMode(selectedModel, selectedMode)) {
+		const { provider } = resolveProvider(selectedModel, settings)
+		for (const baseParam of paramsVisibleForMode(selectedModel, selectedMode)) {
+			const param = applyProviderOverride(baseParam, provider)
 			if (param.type === 'select' && param.options) {
 				const effectiveOptions = (selectedMode && param.optionsByMode?.[selectedMode]) || param.options
 				const currentValue = String(paramValues[param.id] ?? param.default)
@@ -1313,9 +1363,16 @@ export function showBatchGenerateBar(
 	function currentVisibleParamValues(): Record<string, string | number> {
 		if (!selectedModel) return {}
 		const visibleIds = new Set(paramsVisibleForMode(selectedModel, selectedMode).map(param => param.id))
+		const { provider } = resolveProvider(selectedModel, settings)
 		const result: Record<string, string | number> = {}
 		for (const [key, value] of Object.entries(paramValues)) {
-			if (visibleIds.has(key) || key === 'voiceLabel') result[key] = value
+			if (visibleIds.has(key) || key === 'voiceLabel') {
+				const baseParam = selectedModel.params.find(param => param.id === key)
+				const param = baseParam ? applyProviderOverride(baseParam, provider) : null
+				result[key] = param && (param.type === 'range' || param.type === 'number')
+					? normalizeNumericParamValue(param, value)
+					: value
+			}
 		}
 		return result
 	}

--- a/src/providers/elevenlabs.ts
+++ b/src/providers/elevenlabs.ts
@@ -297,7 +297,8 @@ export class ElevenLabsProvider implements AudioProvider {
 
 		const duration = optionalStringParam(params?.duration)
 		if (duration) {
-			body.duration_seconds = parseFloat(duration)
+			const parsed = parseFloat(duration)
+			if (Number.isFinite(parsed)) body.duration_seconds = clamp(parsed, 0.5, 30)
 		}
 
 		const response = await requestUrl({
@@ -326,4 +327,8 @@ export class ElevenLabsProvider implements AudioProvider {
 		await adapter.writeBinary(filePath, data)
 		return { filePath }
 	}
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max)
 }

--- a/src/providers/fal-audio.ts
+++ b/src/providers/fal-audio.ts
@@ -94,11 +94,19 @@ function buildAudioInput(prompt: string, params: Record<string, unknown>, apiMod
 		}
 	} else if (mode === 'sound-effect') {
 		input.text = prompt
-		if (params.duration) input.duration_seconds = parseFloat(params.duration)
+		const duration = numericParam(params.duration)
+		if (duration !== null) {
+			const maxDuration = apiModelId.includes('/elevenlabs/sound-effects/v2') ? 22 : 30
+			input.duration_seconds = clamp(duration, 0.5, maxDuration)
+		}
 	} else {
 		input.prompt = prompt
 	}
 	return input
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max)
 }
 
 function numericParam(value: unknown): number | null {


### PR DESCRIPTION
## What changed

- Changed ElevenLabs Sound Effects duration from fixed select options to the existing range dropdown control.
- Added provider-specific parameter overrides so native ElevenLabs exposes 0.5-30s while fal.ai exposes 0.5-22s.
- Clamped SFX duration in both native ElevenLabs and fal.ai providers to protect old saved node metadata and MCP-triggered runs.
- Updated MCP model listing and generation defaults to report and normalize provider-specific ranges.

## Why

ElevenLabs native Sound Effects and the fal.ai ElevenLabs wrapper expose different accepted duration ranges. The UI previously used coarse fixed choices and could send values unsupported by the active provider.

## Validation

- `npm run build`
- `npm run lint:obsidian`
- `git diff --check`