### PR TITLE
feat(svnewapi): expand reference media support and add gateway asset flow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { startAttachmentRedirect } from './attachment-redirect'
 import { openImageAnnotationTool } from './image-annotations'
 import { openVideoEditTool } from './video-edit'
 import { ensureBytePlusAsset, getBytePlusAssetCreds } from './byteplus-asset-flow'
+import { ensureSvNewApiAsset, getSvNewApiAssetCreds, SvNewApiAssetUnsupportedError } from './svnewapi-asset-flow'
 import { ensureTokenRouterModelArkAsset, getTokenRouterModelArkCreds } from './tokenrouter-asset-flow'
 import { ensureToken360Asset, getToken360AssetCreds } from './token360-asset-flow'
 import { splitImageNodeIntoTiles } from './grid-split-flow'
@@ -607,9 +608,18 @@ export default class BragiCanvas extends Plugin {
 			const supportsSeedanceUrlRefs = supportsSeedanceAssetRefs
 				|| (activeProvider === 'tokenrouter' && isSeedanceModel)
 				|| (activeProvider === 'token360' && isSeedanceModel)
+				// svnewapi seedance (byteplus-seedance-2 / Ark) accepts public ref URLs for
+				// image/audio/video, which the gateway turns into Ark content[] roles.
+				|| (activeProvider === 'svnewapi' && isSeedanceModel)
 			const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}
 			const token360AssetCreds = (activeProvider === 'token360' && isSeedanceModel && uniqueImages.length > 0)
 				? getToken360AssetCreds(this)
+				: null
+			// svnewapi seedance: register face-bearing refs (image/video) through the
+			// gateway asset library so real-person/live-action refs are reviewed at
+			// registration and referenced as asset:// during generation.
+			const svNewApiAssetCreds = (activeProvider === 'svnewapi' && isSeedanceModel && hasSeedanceMediaRefs)
+				? getSvNewApiAssetCreds(this)
 				: null
 			for (const imgPath of uniqueImages) {
 				if (bytePlusCreds) {
@@ -621,6 +631,16 @@ export default class BragiCanvas extends Plugin {
 					refImages.push(await ensureToken360Asset(this, canvas, imgPath, token360AssetCreds))
 				} else if (assetIdMap[imgPath]) {
 					refImages.push(`asset://${assetIdMap[imgPath]}`)
+				} else if (svNewApiAssetCreds) {
+					try {
+						refImages.push(await ensureSvNewApiAsset(this, canvas, imgPath, apiModelId, svNewApiAssetCreds))
+					} catch (e) {
+						if (e instanceof SvNewApiAssetUnsupportedError) {
+							refImages.push(await this.prepareReferenceMedia(activeProvider, model, 'image', imgPath))
+						} else {
+							throw e
+						}
+					}
 				} else {
 					// Delivery (relay vs inline/passthrough) is declared per provider×model in the catalog.
 					refImages.push(await this.prepareReferenceMedia(activeProvider, model, 'image', imgPath))
@@ -667,6 +687,16 @@ export default class BragiCanvas extends Plugin {
 							refVideos.push(await ensureBytePlusAsset(this, canvas, videoPath, bytePlusCreds))
 						} else if (tokenRouterModelArkCreds) {
 							refVideos.push(await ensureTokenRouterModelArkAsset(this, canvas, videoPath, tokenRouterModelArkCreds))
+						} else if (svNewApiAssetCreds) {
+							try {
+								refVideos.push(await ensureSvNewApiAsset(this, canvas, videoPath, apiModelId, svNewApiAssetCreds))
+							} catch (e) {
+								if (e instanceof SvNewApiAssetUnsupportedError) {
+									refVideos.push(await this.prepareReferenceMedia(activeProvider, model, 'video', videoPath))
+								} else {
+									throw e
+								}
+							}
 						} else {
 							refVideos.push(await this.prepareReferenceMedia(activeProvider, model, 'video', videoPath))
 						}

--- a/src/models/grok.ts
+++ b/src/models/grok.ts
@@ -50,8 +50,9 @@ export const grokVideo: ModelConfig = {
 	supportedProviders: {
 		xai: { apiModelId: 'grok-imagine-video' },
 		fal: { apiModelId: 'xai/grok-imagine-video' },
-		// Gateway routes to fal grok image-to-video — requires a source image.
-		svnewapi: { apiModelId: 'sv-video-grok-fal', modes: ['first-frame'] },
+		// Gateway maps sv-video-grok-fal to the fal grok base id and picks the sub-endpoint
+		// by input shape: 1 image -> image-to-video, 2+ -> reference-to-video, video -> extend.
+		svnewapi: { apiModelId: 'sv-video-grok-fal', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'] },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'],
 	params: [

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -10,8 +10,9 @@ export const seedance2: ModelConfig = {
 		fal: { apiModelId: 'bytedance/seedance-2.0' },
 		tokenrouter: { apiModelId: 'dreamina-seedance-2-0-260128', refDelivery: { image: 'native_asset', video: 'native_asset', audio: 'native_asset', nativeAssetProvider: 'tokenrouter' } },
 		token360: { apiModelId: 'seedance-2.0', refDelivery: { image: 'native_asset', nativeAssetProvider: 'token360' } },
-		// Gateway /v1/videos verified for text-to-video only; ref-image routing through `metadata` is unconfirmed.
-		svnewapi: { apiModelId: 'sv-video-seedance', modes: ['text-to-video'] },
+		// Gateway (byteplus-seedance-2 / Ark) builds content[] with reference roles from
+		// top-level images/audios/videos — full ref support including audio-driven + video-ref.
+		svnewapi: { apiModelId: 'sv-video-seedance', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'] },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'],
 	params: [

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -306,6 +306,10 @@ function buildVideoBody(modelId: string, prompt: string, params: Record<string, 
 		if (resolution) metadata.resolution = resolution
 		if (params.generate_audio !== undefined) metadata.generate_audio = params.generate_audio !== 'false'
 		body.metadata = metadata
+		// Reference-to-video: the gateway reads the top-level `images` array (plural) and
+		// converts each entry to an Ark `content[].image_url`. Without this, reference
+		// images are silently dropped and seedance runs as pure text-to-video.
+		if (imageUrls.length) body.images = imageUrls
 	} else {
 		if (imageUrls[0]) body.image = imageUrls[0]
 		if (ratio) body.aspect_ratio = ratio

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -152,10 +152,14 @@ function extractFailure(data: unknown, fallback: string): string {
 	return fallback
 }
 
-async function uploadRefImage(label: string, ref: string): Promise<string> {
-	if (isHttpUrl(ref)) return ref
+// Reference media is delivered to the gateway as public URLs or provider asset:// ids.
+// http(s) inputs and asset:// refs pass through unchanged (asset:// is produced by the
+// gateway asset-registration flow, see svnewapi-asset-flow.ts); data URIs (any modality
+// — image/audio/video) are uploaded to the relay.
+async function uploadRefMedia(label: string, ref: string): Promise<string> {
+	if (isHttpUrl(ref) || ref.startsWith('asset://')) return ref
 	const decoded = dataUriToBytes(ref)
-	if (!decoded) throw new Error(`${label}: unsupported reference image format`)
+	if (!decoded) throw new Error(`${label}: unsupported reference media format`)
 	return uploadRef(undefined, copyToArrayBuffer(decoded.bytes), `ref.${decoded.ext}`, decoded.mimeType)
 }
 
@@ -240,8 +244,12 @@ export class SvNewApiVideoProvider implements VideoProvider {
 		if (!modelId) throw new Error('SV NewAPI video: modelId required')
 
 		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages as string[] : []
-		const imageUrls = await Promise.all(refImages.map(ref => uploadRefImage('SV NewAPI video', ref)))
-		const body = buildVideoBody(modelId, prompt, params || {}, imageUrls)
+		const refAudios: string[] = Array.isArray(params?.refAudios) ? params.refAudios as string[] : []
+		const refVideos: string[] = Array.isArray(params?.refVideos) ? params.refVideos as string[] : []
+		const imageUrls = await Promise.all(refImages.map(ref => uploadRefMedia('SV NewAPI video', ref)))
+		const audioUrls = await Promise.all(refAudios.map(ref => uploadRefMedia('SV NewAPI video', ref)))
+		const videoUrls = await Promise.all(refVideos.map(ref => uploadRefMedia('SV NewAPI video', ref)))
+		const body = buildVideoBody(modelId, prompt, params || {}, imageUrls, audioUrls, videoUrls)
 
 		const resp = await requestUrl({
 			url: `${this.baseUrl}/v1/videos`,
@@ -290,10 +298,20 @@ export class SvNewApiVideoProvider implements VideoProvider {
 
 /**
  * The gateway forwards to different upstreams that disagree on where params live:
- * Seedance (byteplus) reads ratio/duration/watermark from a `metadata` object; the
- * fal-routed models (kling/grok/veo) take a top-level `image` plus top-level params.
+ * Seedance (byteplus, Ark) reads ratio/duration/watermark from a `metadata` object and
+ * builds an Ark `content[]` from the top-level `images`/`audios`/`videos` arrays (each
+ * tagged with a reference role). The fal-routed models (kling/grok/veo/sora) take the
+ * top-level `images` array plus top-level params; the gateway picks the fal sub-endpoint
+ * by input shape (e.g. grok: 2+ images -> reference-to-video, a video -> extend-video).
  */
-function buildVideoBody(modelId: string, prompt: string, params: Record<string, unknown>, imageUrls: string[]): JsonRecord {
+function buildVideoBody(
+	modelId: string,
+	prompt: string,
+	params: Record<string, unknown>,
+	imageUrls: string[],
+	audioUrls: string[],
+	videoUrls: string[],
+): JsonRecord {
 	const body: JsonRecord = { model: modelId, prompt }
 	const ratio = optionalString(params.ratio || params.aspect_ratio || params.aspectRatio)
 	const duration = optionalString(params.duration || params.durationSeconds)
@@ -306,12 +324,17 @@ function buildVideoBody(modelId: string, prompt: string, params: Record<string, 
 		if (resolution) metadata.resolution = resolution
 		if (params.generate_audio !== undefined) metadata.generate_audio = params.generate_audio !== 'false'
 		body.metadata = metadata
-		// Reference-to-video: the gateway reads the top-level `images` array (plural) and
-		// converts each entry to an Ark `content[].image_url`. Without this, reference
-		// images are silently dropped and seedance runs as pure text-to-video.
+		// The gateway converts each entry to an Ark content[] reference part
+		// (image_url/reference_image, audio_url/reference_audio, video_url/reference_video).
+		// Without these, refs are dropped and seedance runs as pure text-to-video.
 		if (imageUrls.length) body.images = imageUrls
+		if (audioUrls.length) body.audios = audioUrls
+		if (videoUrls.length) body.videos = videoUrls
 	} else {
-		if (imageUrls[0]) body.image = imageUrls[0]
+		// Send the full ordered images array (plural) so the gateway can do first-frame,
+		// first-last-frame, or multi-image reference modes; `videos` enables video-extend.
+		if (imageUrls.length) body.images = imageUrls
+		if (videoUrls.length) body.videos = videoUrls
 		if (ratio) body.aspect_ratio = ratio
 		if (duration && duration !== '-1') body.duration = duration
 		if (resolution) body.resolution = resolution

--- a/src/svnewapi-asset-flow.ts
+++ b/src/svnewapi-asset-flow.ts
@@ -1,0 +1,185 @@
+import type BragiCanvas from './main'
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+import { requestUrl } from 'obsidian'
+import { uploadRef } from './providers/upload'
+
+// SV NewAPI (new-api gateway) asset-library flow. Unlike the direct byteplus /
+// tokenrouter / token360 flows which call the provider's asset API themselves, this
+// registers reference media through the gateway's POST /v1/assets endpoint, so the
+// BytePlus AK/SK stay in the gateway and the asset is created in the same account that
+// will serve generation. The asset_id is cached on the canvas node (keyed by
+// 'svnewapi'). See new-api: relay/channel/task/SEEDANCE_ASSET_PROXY_WIP.md.
+
+const PROVIDER_KEY = 'svnewapi'
+const POLL_INTERVAL_MS = 4000
+const POLL_TIMEOUT_MS = 300000 // 5 minutes
+
+const IMAGE_EXTS = /\.(png|jpe?g|webp|gif)$/i
+const AUDIO_EXTS = /\.(mp3|wav|flac)$/i
+const VIDEO_EXTS = /\.(mp4|mov)$/i
+
+type AssetType = 'Image' | 'Audio' | 'Video'
+
+export interface SvNewApiAssetCreds {
+	baseUrl: string
+	apiKey: string
+}
+
+// Thrown when the gateway/channel does not support asset registration (HTTP 501).
+// The caller may fall back to sending the public reference URL.
+export class SvNewApiAssetUnsupportedError extends Error {}
+
+function normalizeBaseUrl(value: string | undefined): string {
+	const s = (value || '').trim()
+	return s.endsWith('/') ? s.slice(0, -1) : s
+}
+
+export function getSvNewApiAssetCreds(plugin: BragiCanvas): SvNewApiAssetCreds | null {
+	const p = plugin.settings.providers
+	const apiKey = (p.svnewapi || '').trim()
+	const baseUrl = normalizeBaseUrl(p.svnewapiBaseUrl)
+	if (!apiKey || !baseUrl) return null
+	return { baseUrl, apiKey }
+}
+
+function assetFileInfo(filePath: string): { assetType: AssetType; ext: string; mime: string } {
+	const ext = (filePath.split('.').pop() || '').toLowerCase()
+	if (IMAGE_EXTS.test(filePath)) {
+		return { assetType: 'Image', ext: ext || 'png', mime: ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg' : `image/${ext || 'png'}` }
+	}
+	if (AUDIO_EXTS.test(filePath)) {
+		return { assetType: 'Audio', ext: ext || 'mp3', mime: ext === 'wav' ? 'audio/wav' : ext === 'flac' ? 'audio/flac' : 'audio/mpeg' }
+	}
+	if (VIDEO_EXTS.test(filePath)) {
+		return { assetType: 'Video', ext: ext || 'mp4', mime: ext === 'mov' ? 'video/quicktime' : 'video/mp4' }
+	}
+	throw new Error(`SV NewAPI assets support image, audio, MP4, or MOV files only: ${filePath.split('/').pop() || filePath}`)
+}
+
+function findNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
+	for (const node of canvas.nodes.values()) {
+		const d = node.getData() as { type?: string; file?: string }
+		if (d.type === 'file' && d.file === filePath) return node
+	}
+	return null
+}
+
+function getCachedAssetId(node: CanvasNode): string | null {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	return d.bragiAssetIds?.[PROVIDER_KEY] || null
+}
+
+function setCachedAssetId(node: CanvasNode, assetId: string): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	const map = { ...(d.bragiAssetIds || {}), [PROVIDER_KEY]: assetId }
+	node.setData({ ...d, bragiAssetIds: map })
+}
+
+function clearCachedAssetId(node: CanvasNode): void {
+	const d = node.getData() as { bragiAssetIds?: Record<string, string> }
+	if (!d.bragiAssetIds) return
+	const rest = { ...d.bragiAssetIds }
+	delete rest[PROVIDER_KEY]
+	node.setData({ ...d, bragiAssetIds: rest })
+}
+
+interface GatewayResp {
+	status: number
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	json: any
+	text: string
+}
+
+async function postJson(creds: SvNewApiAssetCreds, path: string, body: unknown): Promise<GatewayResp> {
+	const resp = await requestUrl({
+		url: `${creds.baseUrl}${path}`,
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${creds.apiKey}`,
+		},
+		body: JSON.stringify(body),
+		throw: false,
+	})
+	return { status: resp.status, json: resp.json, text: resp.text }
+}
+
+async function createGatewayAsset(creds: SvNewApiAssetCreds, model: string, url: string, assetType: AssetType): Promise<{ id: string; status: string }> {
+	const r = await postJson(creds, '/v1/assets', { model, url, asset_type: assetType })
+	if (r.status === 501) {
+		throw new SvNewApiAssetUnsupportedError('gateway/channel does not support asset registration')
+	}
+	if (r.status < 200 || r.status >= 300) {
+		throw new Error(`SV NewAPI asset register failed: ${r.json?.error || r.text?.substring(0, 200) || `HTTP ${r.status}`}`)
+	}
+	const id = r.json?.id
+	if (!id) throw new Error('SV NewAPI asset register: no id in response')
+	return { id, status: r.json?.status || 'Processing' }
+}
+
+async function getGatewayAssetStatus(creds: SvNewApiAssetCreds, model: string, id: string): Promise<{ status: string; failedReason?: string }> {
+	const r = await postJson(creds, '/v1/assets/status', { model, id })
+	if (r.status < 200 || r.status >= 300) {
+		throw new Error(`SV NewAPI asset status failed: ${r.json?.error || `HTTP ${r.status}`}`)
+	}
+	return { status: r.json?.status || 'Unknown', failedReason: r.json?.failed_reason }
+}
+
+async function waitForActive(creds: SvNewApiAssetCreds, model: string, id: string): Promise<void> {
+	const deadline = Date.now() + POLL_TIMEOUT_MS
+	while (Date.now() < deadline) {
+		const { status, failedReason } = await getGatewayAssetStatus(creds, model, id)
+		if (status === 'Active') return
+		if (status === 'Rejected') throw new Error(`Reference rejected by content review${failedReason ? ': ' + failedReason : ''}`)
+		if (status === 'Failed') throw new Error(`Reference asset failed${failedReason ? ': ' + failedReason : ''}`)
+		await new Promise(r => window.setTimeout(r, POLL_INTERVAL_MS))
+	}
+	throw new Error(`SV NewAPI asset timed out after ${POLL_TIMEOUT_MS / 1000}s`)
+}
+
+/**
+ * Ensure the given local media file is registered in the gateway's asset library and
+ * return an `asset://<id>` URI. Uses a per-node cache (validated via the status
+ * endpoint). Throws SvNewApiAssetUnsupportedError if the gateway can't register assets
+ * (so the caller can fall back to a plain URL); throws on Rejected/Failed/timeout.
+ */
+export async function ensureSvNewApiAsset(
+	plugin: BragiCanvas,
+	canvas: Canvas,
+	filePath: string,
+	model: string,
+	creds: SvNewApiAssetCreds,
+): Promise<string> {
+	const { assetType, ext, mime } = assetFileInfo(filePath)
+	const node = findNodeByPath(canvas, filePath)
+
+	// 1. Cache + validate
+	if (node) {
+		const cached = getCachedAssetId(node)
+		if (cached) {
+			try {
+				const { status } = await getGatewayAssetStatus(creds, model, cached)
+				if (status === 'Active') return `asset://${cached}`
+				if (status === 'Processing') {
+					await waitForActive(creds, model, cached)
+					return `asset://${cached}`
+				}
+				clearCachedAssetId(node) // Rejected / Failed / Unknown → re-register
+			} catch {
+				clearCachedAssetId(node) // not found / transient → re-register
+			}
+		}
+	}
+
+	// 2. Upload to Bragi temp storage so the gateway (and upstream) can fetch it
+	const binary = await plugin.app.vault.adapter.readBinary(filePath)
+	const publicUrl = await uploadRef(undefined, binary, `ref.${ext}`, mime)
+
+	// 3. Register via the gateway and poll to Active
+	const { id, status } = await createGatewayAsset(creds, model, publicUrl, assetType)
+	if (status !== 'Active') {
+		await waitForActive(creds, model, id)
+	}
+	if (node) setCachedAssetId(node, id)
+	return `asset://${id}`
+}


### PR DESCRIPTION
## Summary

Broadens svnewapi reference-media handling beyond seedance images, and adds a gateway-side asset-registration flow.

- **seedance**: support image / audio / video refs (`text-to-video`, `first-frame`, `image-ref`, `video-ref`) via top-level `images`/`audios`/`videos` arrays, which the gateway turns into Ark `content[]` reference roles.
- **grok**: enable `text-to-video`, `image-ref`, and `video-extend` modes; the gateway picks the fal sub-endpoint by input shape (1 image → image-to-video, 2+ → reference-to-video, video → extend).
- **provider**: generalize `uploadRefImage` → `uploadRefMedia` (image/audio/video), pass through `http(s)` and `asset://` refs unchanged, send the ordered `images`/`videos` arrays.
- **new** `svnewapi-asset-flow.ts`: register face-bearing refs through the gateway's `/v1/assets` endpoint so they're content-reviewed at registration and referenced as `asset://` during generation. Per-node cache (validated via status endpoint), with fallback to public URLs when the gateway returns 501 (registration unsupported).

## Test plan

- [ ] seedance: image-ref, video-ref, and audio-driven generation route refs correctly through the gateway
- [ ] grok: first-frame, multi-image reference, and video-extend each hit the expected fal sub-endpoint
- [ ] asset flow: face-bearing ref registers, polls to `Active`, and is reused from the node cache; 501 falls back to public URL; Rejected/Failed surface a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)