### PR TITLE
Add Kling V3 Motion Control mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -680,7 +680,7 @@ export default class BragiCanvas extends Plugin {
 				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
 					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')
 				}
-				const shouldUseVideos = supportsSeedanceUrlRefs || isDashScopeWan || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref'
+				const shouldUseVideos = supportsSeedanceUrlRefs || isDashScopeWan || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref' || mode === 'motion-control'
 				if (shouldUseVideos) {
 					for (const videoPath of uniqueVideos) {
 						if (isNativeSeedance && bytePlusCreds) {

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -68,8 +68,9 @@ export const kling3: ModelConfig = {
 	name: 'Kling 3.0',
 	type: 'video',
 	supportedProviders: {
-		// Motion Control is implemented only against the native Kling API.
 		kling: { apiModelId: 'kling-v3' },
+		// APIMart exposes Kling only via its Motion Control endpoint.
+		apimart: { apiModelId: 'kling-v3-motion-control', modes: ['motion-control'] },
 		fal: { apiModelId: 'fal-ai/kling-video/v3/pro', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
 		tokenrouter: { apiModelId: 'kling-v3', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
 		// Gateway routes to fal kling reference-to-video — requires a reference image.

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -1,10 +1,16 @@
-import type { ModelConfig } from './types'
+import type { ModelConfig, ModelParam } from './types'
 
-const KLING_PARAMS = [
+// Modes where duration / aspect ratio are user-selectable. Motion Control is
+// excluded: its output length is dictated by character_orientation (image = 5s,
+// video = matches the reference clip) and its framing comes from the inputs.
+const KLING_FRAMED_MODES = ['text-to-video', 'first-frame', 'first-last-frame'] as const
+
+const KLING_PARAMS: ModelParam[] = [
 	{
 		id: 'duration',
 		label: 'Duration',
-		type: 'select' as const,
+		type: 'select',
+		modes: [...KLING_FRAMED_MODES],
 		options: [
 			{ label: '5s', value: '5' },
 			{ label: '10s', value: '10' },
@@ -14,7 +20,8 @@ const KLING_PARAMS = [
 	{
 		id: 'aspect_ratio',
 		label: 'Ratio',
-		type: 'select' as const,
+		type: 'select',
+		modes: [...KLING_FRAMED_MODES],
 		options: [
 			{ label: '16:9', value: '16:9' },
 			{ label: '9:16', value: '9:16' },
@@ -23,9 +30,31 @@ const KLING_PARAMS = [
 		default: '16:9',
 	},
 	{
+		id: 'character_orientation',
+		label: 'Orientation',
+		type: 'select',
+		modes: ['motion-control'],
+		options: [
+			{ label: 'Follow Video', value: 'video' },
+			{ label: 'Follow Image', value: 'image' },
+		],
+		default: 'video',
+	},
+	{
+		id: 'keep_original_sound',
+		label: 'Audio',
+		type: 'select',
+		modes: ['motion-control'],
+		options: [
+			{ label: 'Keep Sound', value: 'yes' },
+			{ label: 'Mute', value: 'no' },
+		],
+		default: 'yes',
+	},
+	{
 		id: 'mode',
 		label: 'Quality',
-		type: 'select' as const,
+		type: 'select',
 		options: [
 			{ label: 'Standard', value: 'std' },
 			{ label: 'Pro', value: 'pro' },
@@ -39,14 +68,16 @@ export const kling3: ModelConfig = {
 	name: 'Kling 3.0',
 	type: 'video',
 	supportedProviders: {
+		// Motion Control is implemented only against the native Kling API.
 		kling: { apiModelId: 'kling-v3' },
-		fal: { apiModelId: 'fal-ai/kling-video/v3/pro' },
-		tokenrouter: { apiModelId: 'kling-v3' },
+		fal: { apiModelId: 'fal-ai/kling-video/v3/pro', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
+		tokenrouter: { apiModelId: 'kling-v3', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
 		// Gateway routes to fal kling reference-to-video — requires a reference image.
 		svnewapi: { apiModelId: 'sv-video-kling-fal', modes: ['first-frame'] },
 	},
 	// T2V + first-frame (image→video) + first-last-frame (start+end keyframe)
-	modes: ['text-to-video', 'first-frame', 'first-last-frame'],
+	// + motion-control (character image + reference motion video, V3.0 only)
+	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'motion-control'],
 	params: KLING_PARAMS,
 }
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,7 +1,7 @@
 export type GenerationType = 'image' | 'video' | 'text' | 'audio'
 
 export type ImageMode = 'text-to-image' | 'image-ref-to-image'
-export type VideoMode = 'text-to-video' | 'first-frame' | 'image-ref' | 'first-last-frame' | 'multi-image-ref' | 'video-ref' | 'video-extend' | 'video-edit'
+export type VideoMode = 'text-to-video' | 'first-frame' | 'image-ref' | 'first-last-frame' | 'multi-image-ref' | 'video-ref' | 'video-extend' | 'video-edit' | 'motion-control'
 export type TextMode = 'text-to-text'
 export type AudioMode = 'tts' | 'music' | 'sound-effect'
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -33,6 +33,7 @@ const MODE_LABELS: Record<string, string> = {
 	'video-ref': 'Ref Video',
 	'video-extend': 'Extend Video',
 	'video-edit': 'Edit Video',
+	'motion-control': 'Motion Control',
 	'text-to-text': 'Text → Text',
 	'tts': 'Text to Speech',
 	'music': 'Music',
@@ -233,6 +234,9 @@ function supportsVoiceSource(model: ModelConfig, source: VoiceMode): boolean {
  * Falls through priorities — if the model doesn't support a mode, skip it.
  */
 function inferMode(modes: Mode[], imageCount: number, videoCount: number): Mode {
+	// Image + video upstream → Kling Motion Control (character image + motion clip)
+	if (imageCount > 0 && videoCount > 0 && modes.includes('motion-control')) return 'motion-control'
+
 	// Video upstream → reference or extend
 	if (videoCount > 0 && modes.includes('video-ref')) return 'video-ref'
 	if (videoCount > 0 && modes.includes('video-extend')) return 'video-extend'
@@ -851,8 +855,10 @@ export function showGenerateBar(
 		if (m.type !== 'video') return true
 		// No special inputs — only text-to-video models can run without refs.
 		if (upstreamImageCount === 0 && upstreamVideoCount === 0) return m.modes.includes('text-to-video')
-		// Has video input — needs a video-input mode
+		// Has video input — needs a video-input mode. Motion Control also qualifies,
+		// but only when an image is present too (it needs both a character + a clip).
 		if (upstreamVideoCount > 0) {
+			if (upstreamImageCount > 0 && m.modes.includes('motion-control')) return true
 			return m.modes.includes('video-ref') || m.modes.includes('video-extend') || m.modes.includes('video-edit')
 		}
 		// Has 2+ images — needs first-last-frame, multi-image-ref, or image-ref

--- a/src/providers/apimart.ts
+++ b/src/providers/apimart.ts
@@ -178,6 +178,12 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 
 	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
 		const modelId = stringParam(params?.modelId, DEFAULT_VIDEO_MODEL)
+
+		const genMode = stringParam(params?.genMode, '')
+		if (genMode === 'motion-control' || modelId.includes('motion-control')) {
+			return this.generateMotionControl(prompt, modelId, params)
+		}
+
 		const resolution = stringParam(params?.resolution, '720p').toLowerCase()
 		const aspectRatio = stringParam(params?.aspect_ratio || params?.aspectRatio || params?.ratio, '16:9')
 		const refImages = arrayParam(params?.refImages)
@@ -230,6 +236,52 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 		const taskId = first?.task_id || first?.id
 		if (!taskId) {
 			throw new Error(`APIMart: no task_id in video submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	/**
+	 * Kling Motion Control (kling-v3-motion-control / kling-v2-6-motion-control):
+	 * one character image + one reference motion video. Same async submit/poll flow
+	 * as Omni-Flash-Ext, but a different request schema (singular image_url/video_url).
+	 */
+	private async generateMotionControl(prompt: string, modelId: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const refImages = arrayParam(params?.refImages)
+		const refVideos = arrayParam(params?.refVideos)
+		if (refImages.length < 1 || refVideos.length < 1) {
+			throw new Error('APIMart Kling Motion Control needs one reference image and one reference video.')
+		}
+
+		const body: Record<string, unknown> = {
+			model: modelId,
+			prompt,
+			image_url: await this.ensureRelayUrl(refImages[0], 'image'),
+			video_url: await this.ensureRelayUrl(refVideos[0], 'video'),
+			character_orientation: stringParam(params?.character_orientation, 'video'),
+			keep_original_sound: stringParam(params?.keep_original_sound, 'yes'),
+			mode: stringParam(params?.mode, 'std'),
+			watermark_info: { enabled: false },
+		}
+
+		const resp = await requestUrl({
+			url: `${API_BASE}/videos/generations`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status === 401 || resp.status === 403) throw new Error('APIMart: invalid API key')
+		if (resp.status >= 400) throw new Error(`APIMart: ${parseApimartError(resp)}`)
+
+		const submitData = resp.json
+		const first = submitData?.data?.[0]
+		const taskId = first?.task_id || first?.id
+		if (!taskId) {
+			throw new Error(`APIMart: no task_id in motion control submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
 		}
 		return { done: false, taskId }
 	}

--- a/src/providers/kling.ts
+++ b/src/providers/kling.ts
@@ -26,12 +26,28 @@ export class KlingProvider implements VideoProvider {
 		const quality = params?.mode || 'std'
 		const genMode = params?.genMode || null  // user-selected mode from panel
 		const refImages: string[] = params?.refImages || []
+		const refVideos: string[] = params?.refVideos || []
+		const characterOrientation = params?.character_orientation || 'video'
+		const keepOriginalSound = params?.keep_original_sound || 'yes'
 
 		const token = await this.getToken()
 
 		let taskId: string
 
-		if (genMode === 'first-last-frame' && refImages.length >= 2) {
+		if (genMode === 'motion-control' && refImages.length >= 1 && refVideos.length >= 1) {
+			// Motion Control: transfer the reference video's motion onto the character image.
+			// image_url/video_url accept a public URL or base64; refs are relay https URLs
+			// here, and stripDataUriPrefix passes a URL through unchanged.
+			taskId = await this.createMotionControlTask(token, {
+				model_name: modelId,
+				prompt,
+				image_url: stripDataUriPrefix(refImages[0]),
+				video_url: refVideos[0],
+				character_orientation: characterOrientation,
+				keep_original_sound: keepOriginalSound,
+				mode: quality,
+			})
+		} else if (genMode === 'first-last-frame' && refImages.length >= 2) {
 			taskId = await this.createImageToVideoTask(token, {
 				model_name: modelId,
 				prompt,
@@ -67,18 +83,22 @@ export class KlingProvider implements VideoProvider {
 	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
 		const token = await this.getToken()
 
-		// Try text2video endpoint first, then image2video
+		// The task type isn't tracked, so probe each video endpoint until one resolves.
+		const paths = [
+			`/v1/videos/text2video/${taskId}`,
+			`/v1/videos/image2video/${taskId}`,
+			`/v1/videos/motion-control/${taskId}`,
+		]
 		let data: unknown
-		const t2vResult = await this.pollTask(token, `/v1/videos/text2video/${taskId}`)
-		if (t2vResult?.code === 0) {
-			data = t2vResult
-		} else {
-			const i2vResult = await this.pollTask(token, `/v1/videos/image2video/${taskId}`)
-			if (i2vResult?.code === 0) {
-				data = i2vResult
-			} else {
-				throw new Error(`Kling: Cannot find task ${taskId}`)
+		for (const path of paths) {
+			const result = await this.pollTask(token, path)
+			if (result?.code === 0) {
+				data = result
+				break
 			}
+		}
+		if (!data) {
+			throw new Error(`Kling: Cannot find task ${taskId}`)
 		}
 
 		const status = data?.data?.task_status
@@ -128,6 +148,27 @@ export class KlingProvider implements VideoProvider {
 		const data = response.json
 		if (data.code !== 0) {
 			throw new Error(`Kling: ${data.message || 'Failed to create task'}`)
+		}
+		return data.data.task_id
+	}
+
+	private async createMotionControlTask(token: string, body: unknown): Promise<string> {
+		// throw:false so a 4xx still returns the body — Kling puts the real reason
+		// (e.g. "image orientation requires reference video <= 10s") in `message`.
+		const response = await requestUrl({
+			url: `${BASE_URL}/v1/videos/motion-control`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${token}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		const data = response.json
+		if (response.status >= 400 || data?.code !== 0) {
+			throw new Error(`Kling: ${data?.message || `Motion Control failed (HTTP ${response.status})`}`)
 		}
 		return data.data.task_id
 	}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -266,7 +266,8 @@ export const PROVIDERS: ProviderSpec[] = [
 		isConfigured: (s) => !!(s.providers.klingAk && s.providers.klingSk),
 		// Kling image2video accepts a public image URL (verified live) — relay avoids
 		// bloating the JSON body with base64. stripDataUriPrefix passes a URL through unchanged.
-		defaultRefDelivery: { image: 'relay' },
+		// Motion Control's reference video also goes through relay so Kling can fetch it by URL.
+		defaultRefDelivery: { image: 'relay', video: 'relay' },
 		makeVideo: ({ settings, app, outputDir }) =>
 			new KlingProvider(settings.providers.klingAk, settings.providers.klingSk, app, outputDir),
 		// Kling uses JWT with HMAC-SHA256; auth is complex. Skip network test for now — Save will fail fast at first use.


### PR DESCRIPTION
## Summary
Adds the native Kling **Motion Control** generation mode (character image + reference motion video -> animated video), available through two providers.

### Native Kling provider
- New `motion-control` `VideoMode` on Kling V3.0, exposed on the native `kling` provider (`POST /v1/videos/motion-control`). `fal` / `tokenrouter` / `svnewapi` are restricted to their existing modes.
- Request uses official field names `image_url` / `video_url` (verified against the Kling platform API docs); reference video routed through the relay so Kling can fetch it by URL.
- `checkStatus` also polls the motion-control endpoint; task creation surfaces Kling's real error body on 4xx.

### APIMart provider
- `kling-3.0` also lists **APIMart**, restricted to the motion-control mode (`POST /v1/videos/generations`, model `kling-v3-motion-control`).
- `APIMartProvider.generateVideo` branches to a motion-control schema (singular `image_url`/`video_url`, `character_orientation`, `keep_original_sound`, `mode`, `watermark_info`); reuses the existing async submit/poll flow (`result.videos[0].url`).

### Shared UI
- Panel auto-selects Motion Control when one image + one video are attached; `modelSupportsInputs` treats that combo as valid.
- Motion-control-only params: **Orientation** (`character_orientation`: follow video / follow image) and **Audio** (`keep_original_sound`). `duration` / `aspect_ratio` are hidden since output length is dictated by orientation (image <= 10s, video <= 30s).

## Test plan
- [ ] Attach 1 character image + 1 motion video to a Kling 3.0 video node; confirm the mode auto-selects **Motion Control** and Orientation / Audio dropdowns appear.
- [ ] Native Kling provider: generate with Follow Video (<=30s) and Follow Image (<=10s); confirm mp4 lands in the vault and a too-long clip surfaces Kling's real error.
- [ ] APIMart provider: connect APIMart to Kling 3.0, generate, confirm mp4 lands.
- [ ] Confirm `fal` / `tokenrouter` Kling 3.0 do not show Motion Control.

🤖 Generated with [Cursor](https://cursor.com)