### PR TITLE
Fix TokenRouter GPT Image edits

### DIFF
--- a/scripts/verify-reference-image-upload.mjs
+++ b/scripts/verify-reference-image-upload.mjs
@@ -6,6 +6,7 @@ const uploadSource = readFileSync('src/providers/upload.ts', 'utf8')
 const token360FlowSource = readFileSync('src/token360-asset-flow.ts', 'utf8')
 const openaiSource = readFileSync('src/providers/openai.ts', 'utf8')
 const tokenrouterSource = readFileSync('src/providers/tokenrouter.ts', 'utf8')
+const gptImageSource = readFileSync('src/models/gpt-image.ts', 'utf8')
 const agentSource = readFileSync('AGENT.md', 'utf8')
 
 function assertOrder(source, first, second, message) {
@@ -73,8 +74,20 @@ assert.match(
 
 assert.match(
 	tokenrouterSource,
-	/prepareReferenceUpload\([\s\S]*'TokenRouter image edit upload'[\s\S]*appendMultipartFile\(parts, boundary, 'image\[\]', prepared\.fileName, prepared\.contentType/,
+	/private async prepareImageEditUpload\(ref: string, index: number\)[\s\S]*prepareReferenceUpload\([\s\S]*'TokenRouter image edit upload'/,
 	'TokenRouter image edit multipart uploads must use the shared image normalization helper',
+)
+
+assert.match(
+	tokenrouterSource,
+	/appendMultipartFile\(parts, boundary, imageFieldName, prepared\.fileName, prepared\.contentType/,
+	'TokenRouter image edit multipart uploads must append the prepared bytes with the resolved image field name',
+)
+
+assert.match(
+	gptImageSource,
+	/tokenrouter: \{ apiModelId: 'openai\/gpt-5\.4-image-2', refDelivery: \{ image: 'inline' \} \}/,
+	'TokenRouter GPT Image edits must keep reference images inline so /images/edits can upload file bytes',
 )
 
 assert.match(

--- a/src/models/gpt-image.ts
+++ b/src/models/gpt-image.ts
@@ -26,7 +26,7 @@ export const gptImage: ModelConfig = {
 	supportedProviders: {
 		openai: { apiModelId: 'gpt-image-2' },
 		fal: { apiModelId: 'fal-ai/gpt-image-2' },
-		tokenrouter: { apiModelId: 'openai/gpt-5.4-image-2' },
+		tokenrouter: { apiModelId: 'openai/gpt-5.4-image-2', refDelivery: { image: 'inline' } },
 		apimart: { apiModelId: 'gpt-image-2' },
 		svnewapi: { apiModelId: 'sv-image-gpt' },
 	},

--- a/src/providers/tokenrouter.ts
+++ b/src/providers/tokenrouter.ts
@@ -101,6 +101,20 @@ function fileExtFromUrl(url: string): string {
 	return match?.[1] || 'bin'
 }
 
+function headerValue(headers: Record<string, string> | undefined, name: string): string {
+	if (!headers) return ''
+	const target = name.toLowerCase()
+	const key = Object.keys(headers).find(k => k.toLowerCase() === target)
+	return key ? headers[key] : ''
+}
+
+function imageMimeFromUrl(url: string, contentType = ''): string {
+	const normalized = contentType.split(';')[0]?.trim().toLowerCase() || ''
+	if (normalized.startsWith('image/')) return normalized === 'image/jpg' ? 'image/jpeg' : normalized
+	const ext = imageExtFromUrl(url)
+	return ext === 'jpg' ? 'image/jpeg' : `image/${ext}`
+}
+
 function pushUnique(target: string[], value: string): void {
 	const text = value.trim()
 	if (text && !target.includes(text)) target.push(text)
@@ -414,15 +428,14 @@ export class TokenRouterImageProvider implements ImageProvider {
 		appendMultipartField(parts, boundary, 'quality', stringParam(params.quality, 'auto'))
 		appendMultipartField(parts, boundary, 'n', '1')
 
+		let uploadCount = 0
+		const imageFieldName = refImages.length === 1 ? 'image' : 'image[]'
 		for (let i = 0; i < refImages.length; i++) {
-			const match = refImages[i].match(/^data:([^;]+);base64,(.+)$/)
-			if (!match) continue
-			const mime = match[1]
-			const bytes = Uint8Array.from(atob(match[2]), c => c.charCodeAt(0))
-			const ext = mime.includes('webp') ? 'webp' : mime.includes('png') ? 'png' : 'jpg'
-			const prepared = await prepareReferenceUpload(copyToArrayBuffer(bytes), `ref${i}.${ext}`, mime, 'TokenRouter image edit upload')
-			appendMultipartFile(parts, boundary, 'image[]', prepared.fileName, prepared.contentType, new Uint8Array(prepared.bytes))
+			const prepared = await this.prepareImageEditUpload(refImages[i], i)
+			appendMultipartFile(parts, boundary, imageFieldName, prepared.fileName, prepared.contentType, new Uint8Array(prepared.bytes))
+			uploadCount++
 		}
+		if (uploadCount === 0) throw new Error('TokenRouter image edit: No uploadable reference image was prepared.')
 		parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
 
 		const resp = await requestUrl({
@@ -438,6 +451,32 @@ export class TokenRouterImageProvider implements ImageProvider {
 
 		if (resp.status >= 400) throw new Error(parseProviderError('TokenRouter image edit', resp))
 		return extractImageSources(resp.json)
+	}
+
+	private async prepareImageEditUpload(ref: string, index: number) {
+		const decoded = dataUriToBytes(ref)
+		if (decoded) {
+			return prepareReferenceUpload(
+				copyToArrayBuffer(decoded.bytes),
+				`ref${index}.${decoded.ext}`,
+				decoded.mimeType,
+				'TokenRouter image edit upload',
+			)
+		}
+
+		if (isHttpUrl(ref)) {
+			const resp = await requestUrl({ url: ref, throw: false })
+			if (resp.status >= 400) throw new Error(parseProviderError('TokenRouter image edit reference download', resp))
+			const contentType = imageMimeFromUrl(ref, headerValue(resp.headers, 'content-type'))
+			return prepareReferenceUpload(
+				resp.arrayBuffer,
+				`ref${index}.${extensionForMime(contentType)}`,
+				contentType,
+				'TokenRouter image edit upload',
+			)
+		}
+
+		throw new Error('TokenRouter image edit: Reference image must be an inline data URI or a fetchable URL.')
 	}
 
 	private async generateViaChat(modelId: string, prompt: string, refImages: string[]): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Fix TokenRouter GPT Image 2 image-edit requests so upstream reference images are delivered as multipart file uploads.
- Keep GPT Image 2 TokenRouter refs inline instead of routing them through the relay before /images/edits.
- Add regression checks for TokenRouter image-edit upload behavior.

## Root cause

TokenRouter defaults image references to relay URLs, but GPT Image 2 image editing uses /v1/images/edits and needs actual multipart image files. The provider previously skipped non-data-URI refs, sending no image part and triggering convert_request_failed: image is required.

## Validation

- npm run test:reference-image-upload
- npm run check:catalog
- npm run lint:obsidian
- npm run build
- git diff --check
- Live TokenRouter probe: no image part reproduced image is required; single image multipart field returned 200 with b64_json.
