### PR TITLE
SV NewAPI model integration: gateway-aligned image/video params + GPT Image 2 (Official)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
+    "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
+    "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },

--- a/scripts/verify-svnewapi-audio-params.mjs
+++ b/scripts/verify-svnewapi-audio-params.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const source = readFileSync('src/providers/svnewapi.ts', 'utf8')
+
+assert.match(
+	source,
+	/function numericParam\(value: unknown\): number \| undefined/,
+	'SV NewAPI audio generation must parse numeric params before sending JSON.',
+)
+
+assert.match(
+	source,
+	/const speed = numericParam\(options\.speed\)[\s\S]*if \(speed !== undefined\) body\.speed = speed/,
+	'SV NewAPI audio generation must send speed as a top-level audio request field.',
+)
+
+assert.match(
+	source,
+	/const metadata: JsonRecord = \{\}/,
+	'SV NewAPI audio generation must build request metadata for provider-specific audio params.',
+)
+
+assert.match(
+	source,
+	/if \(options\.mode === 'sound-effect'\)[\s\S]*metadata\.duration_seconds = duration/,
+	'SV NewAPI sound effects must send duration as metadata.duration_seconds.',
+)
+
+assert.match(
+	source,
+	/const voiceSettings: JsonRecord = \{\}[\s\S]*voiceSettings\.stability = stability[\s\S]*voiceSettings\.similarity_boost = similarityBoost[\s\S]*voiceSettings\.style = style[\s\S]*metadata\.voice_settings = voiceSettings/,
+	'SV NewAPI ElevenLabs TTS must send voice settings in metadata.voice_settings.',
+)
+
+assert.match(
+	source,
+	/if \(Object\.keys\(metadata\)\.length > 0\) body\.metadata = metadata/,
+	'SV NewAPI audio generation must attach metadata only when it has provider-specific fields.',
+)
+
+console.log('SV NewAPI audio parameter checks passed.')

--- a/scripts/verify-svnewapi-image-refs.mjs
+++ b/scripts/verify-svnewapi-image-refs.mjs
@@ -27,4 +27,46 @@ assert.match(
 	'SV NewAPI image generation must send reference images as image_urls for seeded APIMart.',
 )
 
+// Seedream's Ark upstream rejects the smaller generic OpenAI sizes ("image size must be at
+// least 3686400 pixels"). The gateway path must route Seedream through the Seedream size map.
+assert.match(
+	source,
+	/resolveSeedreamImageSize\(/,
+	'SV NewAPI image generation must size Seedream models via resolveSeedreamImageSize, not the generic OpenAI table.',
+)
+
+// `quality` may be forwarded ONLY for sv-gpt-image-2-official (its upstream honors it).
+// Plain sv-gpt-image-2's upstream rejects the model UI's OpenAI enum ("invalid quality:
+// medium"), so quality must be gated behind the official check, never set unconditionally.
+assert.match(
+	source,
+	/modelId === SV_IMAGE_GPT_OFFICIAL\)\s*\{\s*\n\s*const quality = optionalString\(params\?\.quality\)\s*\n\s*if \(quality\) body\.quality = quality/,
+	'SV NewAPI must forward quality only inside the sv-gpt-image-2-official branch.',
+)
+
+// The gpt-image-2 family on APIMart (sv-gpt-image-2 and -official) is billed per quality ×
+// resolution, so it must send an aspect-ratio `size` plus a 1k/2k/4k `resolution` tier — NOT a
+// derived pixel size. Lock that shape, and that the regex covers both ids.
+assert.match(
+	source,
+	/SV_IMAGE_GPT_RE = \/\^sv-gpt-image-2\(-official\)\?\$\//,
+	'SV NewAPI must match both sv-gpt-image-2 and sv-gpt-image-2-official for the APIMart size shape.',
+)
+assert.match(
+	source,
+	/SV_IMAGE_GPT_RE\.test\(modelId\)\)\s*\{[\s\S]*?body\.size = stringParam\(params\?\.aspectRatio[\s\S]*?body\.resolution =/,
+	'SV NewAPI image generation must send the gpt-image-2 family as aspect-ratio size + resolution tier.',
+)
+
+const seedreamSource = readFileSync('src/providers/seedream.ts', 'utf8')
+const twoKLine = seedreamSource.match(/'2K':\s*\{([^}]*)\}/)
+assert.ok(twoKLine, 'Seedream SIZE map must define a 2K tier.')
+const sixteenNine = twoKLine[1].match(/'16:9':\s*'(\d+)x(\d+)'/)
+assert.ok(sixteenNine, 'Seedream 2K tier must define a 16:9 size.')
+const pixels = Number(sixteenNine[1]) * Number(sixteenNine[2])
+assert.ok(
+	pixels >= 3686400,
+	`Seedream 2K 16:9 must be >= 3,686,400 px to satisfy the Ark upstream minimum (got ${pixels}).`,
+)
+
 console.log('SV NewAPI image reference checks passed.')

--- a/scripts/verify-svnewapi-image-refs.mjs
+++ b/scripts/verify-svnewapi-image-refs.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const source = readFileSync('src/providers/svnewapi.ts', 'utf8')
+
+assert.match(
+	source,
+	/const refImages: string\[\] = Array\.isArray\(params\?\.refImages\)/,
+	'SV NewAPI image generation must read params.refImages.',
+)
+
+assert.match(
+	source,
+	/const imageUrls = await Promise\.all\(refImages\.map\(ref => uploadRefMedia\('SV NewAPI image', ref\)\)\)/,
+	'SV NewAPI image generation must prepare reference images once.',
+)
+
+assert.match(
+	source,
+	/body\.image = imageUrls/,
+	'SV NewAPI image generation must send reference images as image for seeded BytePlus Seedream.',
+)
+
+assert.match(
+	source,
+	/body\.image_urls = imageUrls/,
+	'SV NewAPI image generation must send reference images as image_urls for seeded APIMart.',
+)
+
+console.log('SV NewAPI image reference checks passed.')

--- a/src/models/audio.ts
+++ b/src/models/audio.ts
@@ -115,7 +115,7 @@ export const elevenLabsTTS: ModelConfig = {
 	supportedProviders: {
 		elevenlabs: { apiModelId: 'eleven_v3' },
 		fal: { apiModelId: 'fal-ai/elevenlabs/tts/eleven-v3' },
-		svnewapi: { apiModelId: 'sv-voice-elevenlabs-fal' },
+		svnewapi: { apiModelId: 'sv-elevenlabs-tts-v3' },
 	},
 	modes: ['tts'],
 	params: [
@@ -182,7 +182,7 @@ export const minimaxTTS: ModelConfig = {
 	supportedProviders: {
 		fal: { apiModelId: 'fal-ai/minimax/speech-2.8-hd' },
 		minimax: { apiModelId: 'speech-2.8-hd' },
-		svnewapi: { apiModelId: 'sv-voice-minimax-fal' },
+		svnewapi: { apiModelId: 'sv-minimax-tts' },
 	},
 	modes: ['tts'],
 	params: [
@@ -379,7 +379,7 @@ export const elevenLabsSFX: ModelConfig = {
 	supportedProviders: {
 		elevenlabs: { apiModelId: 'eleven_text_to_sound_v2' },
 		fal: { apiModelId: 'fal-ai/elevenlabs/sound-effects/v2' },
-		svnewapi: { apiModelId: 'sv-sfx-elevenlabs-fal' },
+		svnewapi: { apiModelId: 'sv-elevenlabs-sfx' },
 	},
 	modes: ['sound-effect'],
 	params: [

--- a/src/models/gpt-image.ts
+++ b/src/models/gpt-image.ts
@@ -28,7 +28,7 @@ export const gptImage: ModelConfig = {
 		fal: { apiModelId: 'fal-ai/gpt-image-2' },
 		tokenrouter: { apiModelId: 'openai/gpt-5.4-image-2' },
 		apimart: { apiModelId: 'gpt-image-2' },
-		svnewapi: { apiModelId: 'sv-image-gpt' },
+		svnewapi: { apiModelId: 'sv-gpt-image-2' },
 	},
 	modes: ['text-to-image'],
 	params: [

--- a/src/models/gpt-image.ts
+++ b/src/models/gpt-image.ts
@@ -65,3 +65,22 @@ export const gptImage: ModelConfig = {
 		},
 	],
 }
+
+/**
+ * GPT Image 2 (Official) — OpenAI's official gpt-image-2 channel via APIMart.
+ * Distinct from `gpt-image-2` because the official channel honors `quality` and
+ * is billed per a quality × resolution matrix on the SV gateway. Only the APIMart
+ * and SV gateway routes expose it; the same `aspectRatio`/`imageSize`/`quality`
+ * controls as GPT Image 2 apply.
+ */
+export const gptImageOfficial: ModelConfig = {
+	id: 'gpt-image-2-official',
+	name: 'GPT Image 2 (Official)',
+	type: 'image',
+	supportedProviders: {
+		apimart: { apiModelId: 'gpt-image-2-official' },
+		svnewapi: { apiModelId: 'sv-gpt-image-2-official' },
+	},
+	modes: gptImage.modes,
+	params: gptImage.params,
+}

--- a/src/models/grok.ts
+++ b/src/models/grok.ts
@@ -50,9 +50,9 @@ export const grokVideo: ModelConfig = {
 	supportedProviders: {
 		xai: { apiModelId: 'grok-imagine-video' },
 		fal: { apiModelId: 'xai/grok-imagine-video' },
-		// Gateway maps sv-video-grok-fal to the fal grok base id and picks the sub-endpoint
+		// Gateway maps sv-grok-video to the fal grok base id and picks the sub-endpoint
 		// by input shape: 1 image -> image-to-video, 2+ -> reference-to-video, video -> extend.
-		svnewapi: { apiModelId: 'sv-video-grok-fal', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'] },
+		svnewapi: { apiModelId: 'sv-grok-video', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'] },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'],
 	params: [

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,5 @@
 import type { ModelConfig, GenerationType, Mode } from './types'
-import { gptImage } from './gpt-image'
+import { gptImage, gptImageOfficial } from './gpt-image'
 import { nanoBananaPro, nanoBanana2 } from './nano-banana'
 import { seedream5, seedream5Lite, seedream45 } from './seedream'
 import { seedance2, seedance2Fast } from './seedance'
@@ -30,6 +30,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	nanoBananaPro,
 	nanoBanana2,
 	gptImage,
+	gptImageOfficial,
 	grokImagine,
 	midjourneyV8,
 	midjourneyNiji7,

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -73,8 +73,8 @@ export const kling3: ModelConfig = {
 		apimart: { apiModelId: 'kling-v3-motion-control', modes: ['motion-control'] },
 		fal: { apiModelId: 'fal-ai/kling-video/v3/pro', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
 		tokenrouter: { apiModelId: 'kling-v3', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
-		// Gateway routes to fal kling reference-to-video — requires a reference image.
-		svnewapi: { apiModelId: 'sv-video-kling-fal', modes: ['first-frame'] },
+		// Gateway routes to fal Kling v3 Pro for regular Kling 3.0 modes.
+		svnewapi: { apiModelId: 'sv-kling-3.0', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
 	},
 	// T2V + first-frame (image→video) + first-last-frame (start+end keyframe)
 	// + motion-control (character image + reference motion video, V3.0 only)

--- a/src/models/nano-banana.ts
+++ b/src/models/nano-banana.ts
@@ -30,7 +30,7 @@ export const nanoBananaPro: ModelConfig = {
 		fal: { apiModelId: 'fal-ai/nano-banana-pro' },
 		tokenrouter: { apiModelId: 'google/gemini-3-pro-image-preview' },
 		apimart: { apiModelId: 'gemini-3-pro-image-preview' },
-		svnewapi: { apiModelId: 'sv-image-banana-pro' },
+		svnewapi: { apiModelId: 'sv-nano-banana-pro' },
 	},
 	modes: ['text-to-image'],
 	params: [

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -12,7 +12,7 @@ export const seedance2: ModelConfig = {
 		token360: { apiModelId: 'seedance-2.0', refDelivery: { image: 'native_asset', nativeAssetProvider: 'token360' } },
 		// Gateway (byteplus-seedance-2 / Ark) builds content[] with reference roles from
 		// top-level images/audios/videos — full ref support including audio-driven + video-ref.
-		svnewapi: { apiModelId: 'sv-video-seedance', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'] },
+		svnewapi: { apiModelId: 'sv-seedance-2.0', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'] },
 	},
 	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-ref'],
 	params: [

--- a/src/models/seedream.ts
+++ b/src/models/seedream.ts
@@ -47,7 +47,7 @@ export const seedream5Lite: ModelConfig = {
 	supportedProviders: {
 		bytedance: { apiModelId: 'doubao-seedream-5-0-lite-260128' },
 		byteplus: { apiModelId: 'seedream-5-0-lite-260128' },
-		svnewapi: { apiModelId: 'sv-image-seedream-lite' },
+		svnewapi: { apiModelId: 'sv-seedream-5.0-lite' },
 	},
 	modes: ['text-to-image'],
 	params: [

--- a/src/models/text-gen.ts
+++ b/src/models/text-gen.ts
@@ -8,7 +8,7 @@ export const gpt55: ModelConfig = {
 		openai: { apiModelId: 'gpt-5.5' },
 		tokenrouter: { apiModelId: 'openai/gpt-5.5' },
 		apimart: { apiModelId: 'gpt-5.5' },
-		svnewapi: { apiModelId: 'sv-text-pro' },
+		svnewapi: { apiModelId: 'sv-gpt-5.5' },
 	},
 	modes: ['text-to-text'],
 	params: [],

--- a/src/models/veo.ts
+++ b/src/models/veo.ts
@@ -41,7 +41,7 @@ export const veo31: ModelConfig = {
 	supportedProviders: {
 		gemini: { apiModelId: 'veo-3.1-generate-preview' },
 		fal: { apiModelId: 'fal-ai/veo3.1' },
-		svnewapi: { apiModelId: 'sv-video-veo-fal', modes: ['text-to-video', 'first-frame'] },
+		svnewapi: { apiModelId: 'sv-veo-3.1', modes: ['text-to-video', 'first-frame'] },
 	},
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref'],
 	params: VEO_PARAMS,

--- a/src/providers/seedream.ts
+++ b/src/providers/seedream.ts
@@ -3,12 +3,18 @@ import type { ImageProvider, GenerateImageResult } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
 
-// Resolution + aspect ratio → pixel size mapping
-const SIZE_MAP: Record<string, Record<string, string>> = {
+// Resolution + aspect ratio → pixel size mapping. Seedream's Ark upstream enforces a
+// per-tier minimum pixel count (e.g. 2K must be ≥ 3,686,400 px), so these are larger than
+// the generic OpenAI size table — exported so the SV NewAPI gateway path stays consistent.
+export const SEEDREAM_SIZE_MAP: Record<string, Record<string, string>> = {
 	'1K': { '1:1': '1024x1024', '4:3': '1152x864', '3:4': '864x1152', '16:9': '1280x720', '9:16': '720x1280', '3:2': '1248x832', '2:3': '832x1248', '21:9': '1512x648' },
 	'2K': { '1:1': '2048x2048', '4:3': '2304x1728', '3:4': '1728x2304', '16:9': '2848x1600', '9:16': '1600x2848', '3:2': '2496x1664', '2:3': '1664x2496', '21:9': '3136x1344' },
 	'3K': { '1:1': '3072x3072', '4:3': '3456x2592', '3:4': '2592x3456', '16:9': '4096x2304', '9:16': '2304x4096', '3:2': '3744x2496', '2:3': '2496x3744', '21:9': '4704x2016' },
 	'4K': { '1:1': '4096x4096', '4:3': '4704x3520', '3:4': '3520x4704', '16:9': '5504x3040', '9:16': '3040x5504', '3:2': '4992x3328', '2:3': '3328x4992', '21:9': '6240x2656' },
+}
+
+export function resolveSeedreamImageSize(resolution: string, aspectRatio: string): string {
+	return SEEDREAM_SIZE_MAP[resolution.toUpperCase()]?.[aspectRatio] || '2048x2048'
 }
 
 const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3/images/generations'
@@ -34,7 +40,7 @@ export class SeedreamProvider implements ImageProvider {
 		const refImages: string[] = params?.refImages || []
 
 		// Look up pixel size
-		const size = SIZE_MAP[resolution]?.[aspectRatio] || '2048x2048'
+		const size = resolveSeedreamImageSize(resolution as string, aspectRatio as string)
 
 		// Build request body
 		const body: unknown = {

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -7,6 +7,7 @@ import type {
 } from './types'
 import { uploadRef } from './upload'
 import { resolveOpenAIImageSize } from './openai-image-size'
+import { resolveSeedreamImageSize } from './seedream'
 
 /**
  * SV NewAPI — our self-hosted new-api / One-API gateway. It exposes stable `sv-*`
@@ -22,7 +23,15 @@ import { resolveOpenAIImageSize } from './openai-image-size'
 
 // Model ids that need special-casing (these are the gateway `sv-*` virtual names).
 const SV_IMAGE_BANANA_PRO = 'sv-nano-banana-pro'    // APIMart gemini-3-pro-image-preview rejects `size`
+// gpt-image-2 family on the APIMart channel (sv-gpt-image-2 and sv-gpt-image-2-official):
+// aspect-ratio `size` + 1k/2k/4k `resolution` tier — same shape as the direct APIMart provider.
+const SV_IMAGE_GPT_RE = /^sv-gpt-image-2(-official)?$/
+const SV_IMAGE_GPT_OFFICIAL = 'sv-gpt-image-2-official' // only this one honors `quality`
 const SV_VIDEO_SEEDANCE = 'sv-seedance-2.0'         // byteplus seedance: params go in `metadata`, not top-level
+// Seedream's Ark upstream enforces a per-tier minimum pixel count, so its `size` must come
+// from the Seedream-specific map, not the smaller generic OpenAI table (kept as a fallback for
+// other OpenAI-compatible image models).
+const SV_IMAGE_SEEDREAM_RE = /seedream/i
 
 const DONE_STATUSES = new Set(['SUCCESS', 'SUCCEEDED', 'COMPLETED'])
 const FAILED_STATUSES = new Set(['FAILURE', 'FAILED', 'ERROR', 'CANCELLED', 'CANCELED'])
@@ -198,12 +207,36 @@ export class SvNewApiImageProvider implements ImageProvider {
 		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages as string[] : []
 		const body: JsonRecord = { model: modelId, prompt, n: 1 }
 		// Banana Pro (gemini-3-pro-image-preview) maps `size` to its own aspect_ratio and
-		// rejects arbitrary pixel sizes — omit it. Everything else takes an OpenAI `size`.
-		if (modelId !== SV_IMAGE_BANANA_PRO) {
+		// rejects arbitrary pixel sizes — omit it. Seedream needs its own larger size map
+		// (the Ark upstream rejects the smaller generic sizes). Everything else takes an OpenAI `size`.
+		if (modelId === SV_IMAGE_BANANA_PRO) {
+			// size intentionally omitted
+		} else if (SV_IMAGE_GPT_RE.test(modelId)) {
+			// Both sv-gpt-image-2 and sv-gpt-image-2-official route to the APIMart channel,
+			// which takes an aspect-ratio `size` plus a 1k/2k/4k `resolution` clarity tier
+			// (same shape as the direct APIMart provider) and bills per quality × resolution —
+			// so send the tier explicitly rather than a derived pixel size.
+			body.size = stringParam(params?.aspectRatio, '1:1')
+			const tier = stringParam(params?.imageSize ?? params?.resolution, '2K').toLowerCase()
+			body.resolution = tier === 'auto' ? '2k' : tier
+		} else if (SV_IMAGE_SEEDREAM_RE.test(modelId)) {
+			body.size = resolveSeedreamImageSize(
+				stringParam(params?.resolution ?? params?.imageSize, '2K'),
+				stringParam(params?.aspectRatio, '1:1'),
+			)
+		} else {
 			body.size = resolveOpenAIImageSize({
 				...params,
 				imageSize: params?.imageSize ?? params?.resolution,
 			})
+		}
+		// `quality` is forwarded ONLY for sv-gpt-image-2-official, whose upstream honors it.
+		// Plain sv-gpt-image-2's upstream rejects the model UI's OpenAI-style enum
+		// ("invalid quality: medium, allowed: standard/hd/4k/ultra/high"), so omit it there
+		// and let that upstream default the quality.
+		if (modelId === SV_IMAGE_GPT_OFFICIAL) {
+			const quality = optionalString(params?.quality)
+			if (quality) body.quality = quality
 		}
 		if (refImages.length > 0) {
 			const imageUrls = await Promise.all(refImages.map(ref => uploadRefMedia('SV NewAPI image', ref)))

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -21,8 +21,8 @@ import { resolveOpenAIImageSize } from './openai-image-size'
  */
 
 // Model ids that need special-casing (these are the gateway `sv-*` virtual names).
-const SV_IMAGE_BANANA_PRO = 'sv-image-banana-pro'   // APIMart gemini-3-pro-image-preview rejects `size`
-const SV_VIDEO_SEEDANCE = 'sv-video-seedance'       // byteplus seedance: params go in `metadata`, not top-level
+const SV_IMAGE_BANANA_PRO = 'sv-nano-banana-pro'    // APIMart gemini-3-pro-image-preview rejects `size`
+const SV_VIDEO_SEEDANCE = 'sv-seedance-2.0'         // byteplus seedance: params go in `metadata`, not top-level
 
 const DONE_STATUSES = new Set(['SUCCESS', 'SUCCEEDED', 'COMPLETED'])
 const FAILED_STATUSES = new Set(['FAILURE', 'FAILED', 'ERROR', 'CANCELLED', 'CANCELED'])

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -48,6 +48,20 @@ function optionalString(value: unknown): string | undefined {
 	return text || undefined
 }
 
+function numericParam(value: unknown): number | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value !== 'string' || !value.trim()) return undefined
+	const parsed = parseFloat(value)
+	return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function booleanParam(value: unknown): boolean | undefined {
+	if (typeof value === 'boolean') return value
+	if (value === 'true') return true
+	if (value === 'false') return false
+	return undefined
+}
+
 function isHttpUrl(value: string): boolean {
 	return /^https?:\/\//i.test(value)
 }
@@ -181,6 +195,7 @@ export class SvNewApiImageProvider implements ImageProvider {
 		const modelId = stringParam(params?.modelId)
 		if (!modelId) throw new Error('SV NewAPI image: modelId required')
 
+		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages as string[] : []
 		const body: JsonRecord = { model: modelId, prompt, n: 1 }
 		// Banana Pro (gemini-3-pro-image-preview) maps `size` to its own aspect_ratio and
 		// rejects arbitrary pixel sizes — omit it. Everything else takes an OpenAI `size`.
@@ -189,6 +204,11 @@ export class SvNewApiImageProvider implements ImageProvider {
 				...params,
 				imageSize: params?.imageSize ?? params?.resolution,
 			})
+		}
+		if (refImages.length > 0) {
+			const imageUrls = await Promise.all(refImages.map(ref => uploadRefMedia('SV NewAPI image', ref)))
+			body.image = imageUrls
+			body.image_urls = imageUrls
 		}
 
 		const resp = await requestUrl({
@@ -361,11 +381,31 @@ export class SvNewApiAudioProvider implements AudioProvider {
 		if (!modelId) throw new Error('SV NewAPI audio: modelId required')
 
 		const body: JsonRecord = { model: modelId, input: prompt }
+		const metadata: JsonRecord = {}
 		// Sound-effect models take no voice; TTS forwards the selected voice id/name.
 		if (options.mode !== 'sound-effect') {
 			const voice = optionalString(options.voice)
 			if (voice) body.voice = voice
 		}
+		const speed = numericParam(options.speed)
+		if (speed !== undefined) body.speed = speed
+
+		if (options.mode === 'sound-effect') {
+			const duration = numericParam(options.duration)
+			if (duration !== undefined) metadata.duration_seconds = duration
+		}
+
+		const voiceSettings: JsonRecord = {}
+		const stability = numericParam(options.stability)
+		const similarityBoost = numericParam(options.similarity_boost)
+		const style = numericParam(options.style)
+		const useSpeakerBoost = booleanParam(options.use_speaker_boost)
+		if (stability !== undefined) voiceSettings.stability = stability
+		if (similarityBoost !== undefined) voiceSettings.similarity_boost = similarityBoost
+		if (style !== undefined) voiceSettings.style = style
+		if (useSpeakerBoost !== undefined) voiceSettings.use_speaker_boost = useSpeakerBoost
+		if (Object.keys(voiceSettings).length > 0) metadata.voice_settings = voiceSettings
+		if (Object.keys(metadata).length > 0) body.metadata = metadata
 
 		const resp = await requestUrl({
 			url: `${this.baseUrl}/v1/audio/speech`,


### PR DESCRIPTION
## What

Wires the SV NewAPI (self-hosted new-api / One-API) gateway models up so each upstream gets the request shape it actually expects, and adds the official GPT Image 2 channel. Builds on the earlier branch work (model-id alignment + media-param forwarding) and adds this session's image sizing/quality fixes.

## Changes

**Models**
- Add `gpt-image-2-official` (`sv-gpt-image-2-official`) — the APIMart official channel that honors `quality` and is billed per quality × resolution; registered in `ALL_MODELS`.
- Align `sv-*` model ids / modes with the gateway contract across grok / kling / veo / seedance / nano-banana / seedream / audio / text.

**SV NewAPI image provider**
- Route the gpt-image-2 family (`sv-gpt-image-2` and `-official`) through the APIMart shape — aspect-ratio `size` + 1k/2k/4k `resolution` tier — instead of a derived pixel size.
- Forward `quality` **only** for `sv-gpt-image-2-official`; the non-official upstream rejects the OpenAI quality enum (`invalid quality: medium, allowed: standard/hd/4k/ultra/high`).
- Size Seedream models via the Seedream size map: its Ark upstream enforces a per-tier minimum pixel count, and the generic OpenAI table's 2K was too small (`image size must be at least 3686400 pixels`).
- `seedream`: export `SEEDREAM_SIZE_MAP` + `resolveSeedreamImageSize` so the gateway path matches the direct provider.

**SV NewAPI video provider**
- Forward media params (ratio/duration/resolution/generate_audio) per upstream: Seedance reads them from `metadata` + top-level `images`/`audios`/`videos` (→ Ark `reference_image`/`reference_audio`); the fal-routed models (kling/grok/veo) take top-level `images` + params.

**Tests**
- `verify-svnewapi-image-refs`: lock the Seedream 2K minimum, the gpt-image-2 family size shape, and that `quality` is forwarded only for the official id.
- `verify-svnewapi-audio-params`, `verify-reference-image-upload`: param/upload coverage.

## Verified end-to-end (manual, against the live gateway)
- ✅ Nano Banana Pro (refs), Seedream 5.0 Lite (size fix), GPT Image 2 (Official), Seedance 2.0 (first-frame + character refs + audio + metadata), Kling 3.0, GPT-5.5 text.
- Reference-media delivery uses Bragi relay URLs in `image_urls`, consistent with the direct APIMart provider.

## Notes
- `gpt-image-2-official` model registration was the missing piece that made it selectable in the UI; the provider branch already referenced the id.
- A residual APIMart upstream `proxy CONNECT → 500` on the gpt-image-2 reference create-file step is an upstream/infra intermittent issue (not this code) — same relay URLs succeed for other models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)