### PR TITLE
Fix canvas-scoped duplicate and ref refresh

### DIFF
--- a/src/canvas-ops.ts
+++ b/src/canvas-ops.ts
@@ -23,6 +23,11 @@ export function getCanvasFromNode(node: CanvasNode): Canvas {
 	return node.canvas
 }
 
+export type DuplicateWithConnectionsResult = {
+	canvas: Canvas
+	newNodeId: string
+}
+
 const PLACEMENT_GAP = 20
 const PLACEMENT_RADIUS = 20  // up to (2*R+1)² = 1681 candidate cells
 
@@ -531,8 +536,9 @@ export function markNodeInterrupted(node: CanvasNode): void {
  * Duplicate a node and recreate all its incoming (upstream) edges on the copy.
  * The new node is placed to the right of the original.
  */
-export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void {
+export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): DuplicateWithConnectionsResult | null {
 	try {
+	const targetCanvas = node.canvas || canvas
 	const data = node.getData() as unknown
 	const gap = 50
 
@@ -540,7 +546,7 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 		const width = data.width || 300
 		const height = data.height || 100
 		const nodeId = generateId()
-		const currentData = canvas.getData()
+		const currentData = targetCanvas.getData()
 		const newNodeData: unknown = {
 			id: nodeId,
 			type: 'text',
@@ -556,7 +562,7 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 		const lastGen = data.bragiLastGen || data.ovidLastGen
 		if (lastGen) newNodeData.bragiLastGen = { ...lastGen }
 
-		const incomingEdges = getIncomingEdgeData(canvas, node)
+		const incomingEdges = getIncomingEdgeData(targetCanvas, node)
 		const newEdges = incomingEdges.map(e => ({
 			id: generateId(),
 			fromNode: e.fromNode,
@@ -567,13 +573,22 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 			toEnd: e.toEnd,
 		}))
 
-		canvas.importData({
+		targetCanvas.importData({
 			nodes: [...currentData.nodes, newNodeData],
 			edges: [...currentData.edges, ...newEdges],
 		})
+		void targetCanvas.requestSave()
+		// importData mutates the data model but does not repaint on its own; without
+		// a frame request the duplicated node is saved to disk yet never rendered.
+		try {
+			void targetCanvas.requestFrame()
+		} catch (frameErr) {
+			console.debug('Bragi duplicate: canvas frame refresh skipped', frameErr)
+		}
+		return { canvas: targetCanvas, newNodeId: nodeId }
 	} else if (data.type === 'file') {
 		const nodeId = generateId()
-		const currentData = canvas.getData()
+		const currentData = targetCanvas.getData()
 		const newNodeData = {
 			id: nodeId,
 			type: 'file' as const,
@@ -586,7 +601,7 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 			subpath: data.subpath,
 		}
 
-		const incomingEdges = getIncomingEdgeData(canvas, node)
+		const incomingEdges = getIncomingEdgeData(targetCanvas, node)
 		const newEdges = incomingEdges.map(e => ({
 			id: generateId(),
 			fromNode: e.fromNode,
@@ -597,23 +612,24 @@ export function duplicateWithConnections(canvas: Canvas, node: CanvasNode): void
 			toEnd: e.toEnd,
 		}))
 
-		canvas.importData({
+		targetCanvas.importData({
 			nodes: [...currentData.nodes, newNodeData],
 			edges: [...currentData.edges, ...newEdges],
 		})
-	}
-
-	void canvas.requestSave()
-	// importData mutates the data model but does not repaint on its own; without
-	// a frame request the duplicated node is saved to disk yet never rendered.
-	try {
-		void canvas.requestFrame()
-	} catch (frameErr) {
-		console.debug('Bragi duplicate: canvas frame refresh skipped', frameErr)
+		void targetCanvas.requestSave()
+		// importData mutates the data model but does not repaint on its own; without
+		// a frame request the duplicated node is saved to disk yet never rendered.
+		try {
+			void targetCanvas.requestFrame()
+		} catch (frameErr) {
+			console.debug('Bragi duplicate: canvas frame refresh skipped', frameErr)
+		}
+		return { canvas: targetCanvas, newNodeId: nodeId }
 	}
 	} catch (err) {
 		console.error('[Bragi] duplicateWithConnections failed', err)
 	}
+	return null
 }
 
 function getIncomingEdgeData(canvas: Canvas, node: CanvasNode): Array<{

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,12 +122,16 @@ export default class BragiCanvas extends Plugin {
 		)
 		this.registerEvent(
 			this.app.workspace.on('active-leaf-change', () => {
+				this.refreshActiveCanvasSoon()
 				this.maybeCheckForUpdatesFromActiveCanvas()
 			})
 		)
 		this.registerEvent(
 			this.app.workspace.on('file-open', (file) => {
-				if (file?.path.endsWith('.canvas')) this.maybeCheckForUpdatesFromActiveCanvas()
+				if (file?.path.endsWith('.canvas')) {
+					this.refreshActiveCanvasSoon()
+					this.maybeCheckForUpdatesFromActiveCanvas()
+				}
 			})
 		)
 
@@ -321,6 +325,25 @@ export default class BragiCanvas extends Plugin {
 		void this.saveSettings()
 	}
 
+	private refreshCanvasRefsAfterMutation(canvas: Canvas): void {
+		const refresh = () => {
+			refreshAllThumbnails(canvas, this.app)
+			refreshAllTextRefs(canvas, this.app)
+			refreshAllAudioRefs(canvas, this.app)
+		}
+		window.requestAnimationFrame(() => {
+			refresh()
+			window.requestAnimationFrame(refresh)
+			window.setTimeout(refresh, 150)
+		})
+	}
+
+	private refreshActiveCanvasSoon(): void {
+		this.tryPatchCanvas()
+		window.requestAnimationFrame(() => this.tryPatchCanvas())
+		window.setTimeout(() => this.tryPatchCanvas(), 150)
+	}
+
 	tryPatchCanvas() {
 		const leaf = this.app.workspace.getLeaf(false)
 		if (!leaf) return
@@ -366,14 +389,17 @@ export default class BragiCanvas extends Plugin {
 				(node) => this.openPanel('audio', node),
 				(node) => { void this.handleSTT(node) },
 				(node) => { void this.handleAudioIsolation(node) },
-			(node) => duplicateWithConnections(canvas, node),
+			(node) => {
+				const result = duplicateWithConnections(getCanvasFromNode(node), node)
+				if (result) this.refreshCanvasRefsAfterMutation(result.canvas)
+			},
 			(type, nodes) => this.openBatchPanel(type, nodes),
-			(node) => openPanoramaViewer(this.app, canvas, node, this.getOutputDir(), path => this.rememberGeneratedAsset(path)),
-			(node) => void splitImageNodeIntoTiles(this, canvas, node).catch(err => {
+			(node) => openPanoramaViewer(this.app, getCanvasFromNode(node), node, this.getOutputDir(), path => this.rememberGeneratedAsset(path)),
+			(node) => void splitImageNodeIntoTiles(this, getCanvasFromNode(node), node).catch(err => {
 				console.error('Bragi split grid error:', err)
 				new Notice(`Split failed: ${err.message || err}`)
 			}),
-			(nodes) => void composeSelectedImageNodes(this, canvas, nodes).catch(err => {
+			(nodes) => void composeSelectedImageNodes(this, getCanvasFromNode(nodes[0]), nodes).catch(err => {
 				console.error('Bragi compose images error:', err)
 				new Notice(`Collage failed: ${err.message || err}`)
 			}),


### PR DESCRIPTION
## Summary

- Use the selected node owning canvas when duplicating prompt/file nodes so duplicate operations do not write into the first opened canvas.
- Refresh reference image/text/audio strips after duplicate mutations.
- Re-run canvas patching and delayed reference refresh on active canvas changes and canvas file opens so prompt-node thumbnails survive tab switches.

## Root Cause

The canvas menu patch is installed once globally, but some callbacks captured the canvas instance from the first patched view. In multi-canvas sessions this let actions on later canvases mutate the first canvas. Separately, thumbnail strips could be missed after tab switches because refresh was tied to layout changes rather than active canvas remounts.

## Validation

- `npm run build`
- `npm run lint:obsidian`
- `git diff --check`
