### PR TITLE
Switch APIMart GPT Image 2 to official model ID

### DIFF
--- a/src/models/gpt-image.ts
+++ b/src/models/gpt-image.ts
@@ -27,7 +27,7 @@ export const gptImage: ModelConfig = {
 		openai: { apiModelId: 'gpt-image-2' },
 		fal: { apiModelId: 'fal-ai/gpt-image-2' },
 		tokenrouter: { apiModelId: 'openai/gpt-5.4-image-2', refDelivery: { image: 'inline' } },
-		apimart: { apiModelId: 'gpt-image-2' },
+		apimart: { apiModelId: 'gpt-image-2-official' },
 		svnewapi: { apiModelId: 'sv-gpt-image-2' },
 	},
 	modes: ['text-to-image'],


### PR DESCRIPTION
## Summary

- Route the existing `gpt-image-2` catalog entry through APIMart's official upstream ID, `gpt-image-2-official`.
- Keep the Bragi model ID stable as `gpt-image-2`, so existing enabled-model settings and MCP usage continue to work.
- Leave the APIMart provider implementation unchanged; it already forwards `quality` when the resolved upstream model ID is official.

## Validation

- `npm run check:catalog`
- `npm run audit:catalog`
- `npm run build`
- `npm run lint:obsidian`
- `git diff --check`
