### PR TITLE
Fix SV NewAPI Banana Pro sizing params

### DIFF
--- a/scripts/verify-svnewapi-image-refs.mjs
+++ b/scripts/verify-svnewapi-image-refs.mjs
@@ -27,6 +27,21 @@ assert.match(
 	'SV NewAPI image generation must send reference images as image_urls for seeded APIMart.',
 )
 
+// Banana Pro uses the APIMart image shape: aspect-ratio `size` plus the selected
+// 1k/2k/4k resolution tier.
+assert.match(
+	source,
+	/modelId === SV_IMAGE_BANANA_PRO\)\s*\{\s*\n\s*body\.size = stringParam\(params\?\.aspectRatio, '1:1'\)\s*\n\s*const tier = stringParam\(params\?\.imageSize \?\? params\?\.resolution, '1K'\)\.toLowerCase\(\)\s*\n\s*body\.resolution = tier === 'auto' \? '1k' : tier/,
+	'SV NewAPI Banana Pro must forward aspectRatio as size and imageSize/resolution as body.resolution.',
+)
+const bananaBranch = source.match(/modelId === SV_IMAGE_BANANA_PRO\)\s*\{([\s\S]*?)\}\s*else if \(SV_IMAGE_GPT_RE\.test\(modelId\)\)/)
+assert.ok(bananaBranch, 'SV NewAPI Banana Pro branch must be present.')
+assert.match(
+	bananaBranch[1],
+	/body\.size =/,
+	'SV NewAPI Banana Pro must forward aspect-ratio size.',
+)
+
 // Seedream's Ark upstream rejects the smaller generic OpenAI sizes ("image size must be at
 // least 3686400 pixels"). The gateway path must route Seedream through the Seedream size map.
 assert.match(

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -206,11 +206,14 @@ export class SvNewApiImageProvider implements ImageProvider {
 
 		const refImages: string[] = Array.isArray(params?.refImages) ? params.refImages as string[] : []
 		const body: JsonRecord = { model: modelId, prompt, n: 1 }
-		// Banana Pro (gemini-3-pro-image-preview) maps `size` to its own aspect_ratio and
-		// rejects arbitrary pixel sizes — omit it. Seedream needs its own larger size map
-		// (the Ark upstream rejects the smaller generic sizes). Everything else takes an OpenAI `size`.
+		// Banana Pro (gemini-3-pro-image-preview) expects APIMart's shape:
+		// aspect-ratio `size` plus a 1k/2k/4k `resolution` tier. Seedream needs
+		// its own larger size map (the Ark upstream rejects the smaller generic
+		// sizes). Everything else takes an OpenAI pixel `size`.
 		if (modelId === SV_IMAGE_BANANA_PRO) {
-			// size intentionally omitted
+			body.size = stringParam(params?.aspectRatio, '1:1')
+			const tier = stringParam(params?.imageSize ?? params?.resolution, '1K').toLowerCase()
+			body.resolution = tier === 'auto' ? '1k' : tier
 		} else if (SV_IMAGE_GPT_RE.test(modelId)) {
 			// Both sv-gpt-image-2 and sv-gpt-image-2-official route to the APIMart channel,
 			// which takes an aspect-ratio `size` plus a 1k/2k/4k `resolution` clarity tier


### PR DESCRIPTION
## Summary
- forward Nano Banana Pro aspect ratio as APIMart-style size through SV NewAPI
- forward selected imageSize/resolution as the resolution tier
- add a static verification check for the Banana Pro SV NewAPI payload shape

## Tests
- npm run test:svnewapi-image-refs
- npm run build