### PR TITLE
fix(svnewapi): forward Seedance auto duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
+    "test:svnewapi-video-params": "node scripts/verify-svnewapi-video-params.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
   },

--- a/scripts/verify-svnewapi-video-params.mjs
+++ b/scripts/verify-svnewapi-video-params.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import assert from 'node:assert/strict'
+
+const source = readFileSync('src/providers/svnewapi.ts', 'utf8')
+const directSeedanceSource = readFileSync('src/providers/seedance.ts', 'utf8')
+
+assert.match(
+	source,
+	/const duration = optionalString\(params\.duration \|\| params\.durationSeconds\)/,
+	'SV NewAPI video generation must read duration and durationSeconds.',
+)
+
+assert.match(
+	source,
+	/if \(modelId === SV_VIDEO_SEEDANCE\) \{[\s\S]*?if \(duration\) metadata\.duration = duration === '-1' \? -1 : parseInt\(duration, 10\)/,
+	'SV NewAPI Seedance must forward Auto duration as metadata.duration = -1 to match direct Ark Seedance.',
+)
+
+assert.match(
+	source,
+	/\} else \{[\s\S]*?if \(duration && duration !== '-1'\) body\.duration = duration/,
+	'SV NewAPI non-Seedance video models should continue omitting duration = -1.',
+)
+
+assert.match(
+	directSeedanceSource,
+	/const duration = parseInt\(params\?\.duration \|\| '5'\)[\s\S]*?duration,/,
+	'Direct BytePlus/Volcengine Seedance must continue forwarding Auto duration as numeric -1.',
+)
+
+console.log('SV NewAPI video parameter checks passed.')

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -376,7 +376,7 @@ function buildVideoBody(
 	if (modelId === SV_VIDEO_SEEDANCE) {
 		const metadata: JsonRecord = { watermark: false }
 		if (ratio) metadata.ratio = ratio
-		if (duration && duration !== '-1') metadata.duration = parseInt(duration, 10)
+		if (duration) metadata.duration = duration === '-1' ? -1 : parseInt(duration, 10)
 		if (resolution) metadata.resolution = resolution
 		if (params.generate_audio !== undefined) metadata.generate_audio = params.generate_audio !== 'false'
 		body.metadata = metadata


### PR DESCRIPTION
## Summary
- Forward SV NewAPI Seedance Auto duration as metadata.duration = -1, matching direct BytePlus/Volcengine Ark Seedance behavior.
- Add a static SV NewAPI video parameter check covering Seedance Auto duration and non-Seedance duration=-1 behavior.

## Tests
- npm run test:svnewapi-video-params
- npm run test:svnewapi-image-refs
- npm run test:svnewapi-audio-params
- npm run check:catalog
- npm run build

## Manual verification
- Installed the build into dev-bragi-canvas and generated VID-01 with duration:-1; output node/file was created successfully.