### PR TITLE
feat(svnewapi): rename provider to SVRouter with fixed gateway URL

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -23,14 +23,9 @@ import { XAIImageProvider, XAIVideoProvider, XAIAudioProvider } from './xai'
 import { TokenRouterImageProvider, TokenRouterTextProvider, TokenRouterVideoProvider } from './tokenrouter'
 import { Token360VideoProvider } from './token360'
 import { DashScopeAudioProvider, DashScopeVideoProvider, dashScopeUrl } from './dashscope'
-import { SvNewApiImageProvider, SvNewApiVideoProvider, SvNewApiAudioProvider } from './svnewapi'
+import { SvNewApiImageProvider, SvNewApiVideoProvider, SvNewApiAudioProvider, SVROUTER_BASE_URL } from './svnewapi'
 
 const LUMA_ENDPOINT = 'https://luma.bragi.now'
-
-/** Normalize a user-entered gateway base URL: trim and drop any trailing slash. */
-function normalizeBaseUrl(value: string | undefined): string {
-	return (value || '').trim().replace(/\/+$/, '')
-}
 import { OpenAITextProvider, APIMartTextProvider, GeminiTextProvider, AnthropicTextProvider, BedrockClaudeTextProvider, XAITextProvider } from './text-gen'
 import { DashScopeTextProvider } from './dashscope-text'
 import { requestUrl } from 'obsidian'
@@ -557,30 +552,26 @@ export const PROVIDERS: ProviderSpec[] = [
 	},
 	{
 		id: 'svnewapi',
-		name: 'SV NewAPI',
-		// Self-hosted new-api / One-API gateway. The base URL is deployment-specific, so it is
-		// a configurable field (no domain is hardcoded); the gateway root has no `/v1` suffix.
+		name: 'SVRouter',
+		// Self-hosted new-api / One-API gateway behind a fixed domain; the gateway root has no `/v1` suffix.
 		fields: [
-			{ key: 'svnewapiBaseUrl', label: 'Base URL', placeholder: 'https://your-newapi-host', type: 'text' },
 			{ key: 'svnewapi', label: 'API Key', placeholder: 'sk-...', type: 'password' },
 		],
 		// The gateway forwards reference media as public relay URLs (fal/byteplus upstreams accept URLs).
 		defaultRefDelivery: { image: 'relay', video: 'relay' },
-		isConfigured: (s) => !!(s.providers.svnewapi && s.providers.svnewapiBaseUrl),
+		isConfigured: (s) => !!s.providers.svnewapi,
 		makeImage: ({ settings, app, outputDir }) =>
-			new SvNewApiImageProvider(settings.providers.svnewapi, app, outputDir, normalizeBaseUrl(settings.providers.svnewapiBaseUrl)),
+			new SvNewApiImageProvider(settings.providers.svnewapi, app, outputDir, SVROUTER_BASE_URL),
 		makeVideo: ({ settings, app, outputDir }) =>
-			new SvNewApiVideoProvider(settings.providers.svnewapi, app, outputDir, normalizeBaseUrl(settings.providers.svnewapiBaseUrl)),
+			new SvNewApiVideoProvider(settings.providers.svnewapi, app, outputDir, SVROUTER_BASE_URL),
 		makeAudio: ({ settings, app, outputDir }) =>
-			new SvNewApiAudioProvider(settings.providers.svnewapi, app, outputDir, normalizeBaseUrl(settings.providers.svnewapiBaseUrl)),
+			new SvNewApiAudioProvider(settings.providers.svnewapi, app, outputDir, SVROUTER_BASE_URL),
 		// Text is plain OpenAI /v1/chat/completions — reuse the shared OpenAI text client.
 		makeText: ({ settings }) =>
-			new OpenAITextProvider(settings.providers.svnewapi, `${normalizeBaseUrl(settings.providers.svnewapiBaseUrl)}/v1`),
+			new OpenAITextProvider(settings.providers.svnewapi, `${SVROUTER_BASE_URL}/v1`),
 		testConnection: (d) => {
-			const baseUrl = normalizeBaseUrl(d.svnewapiBaseUrl)
-			if (!baseUrl) return Promise.resolve({ ok: false, message: 'Base URL is empty.' })
 			if (!d.svnewapi) return Promise.resolve({ ok: false, message: 'API key is empty.' })
-			return testListModels(`${baseUrl}/v1/models`, d.svnewapi)
+			return testListModels(`${SVROUTER_BASE_URL}/v1/models`, d.svnewapi)
 		},
 	},
 ]

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -9,8 +9,11 @@ import { uploadRef } from './upload'
 import { resolveOpenAIImageSize } from './openai-image-size'
 import { resolveSeedreamImageSize } from './seedream'
 
+// Fixed SVRouter gateway root (OpenAI-compatible; requests append `/v1/...`).
+export const SVROUTER_BASE_URL = 'https://gateway.storyverseai.art'
+
 /**
- * SV NewAPI — our self-hosted new-api / One-API gateway. It exposes stable `sv-*`
+ * SVRouter — our self-hosted new-api / One-API gateway. It exposes stable `sv-*`
  * virtual model names (mapped to real upstreams via the channel `model_mapping`)
  * over an OpenAI-compatible surface:
  *   - text   → POST /v1/chat/completions   (handled by OpenAITextProvider in the registry)
@@ -187,7 +190,7 @@ async function uploadRefMedia(label: string, ref: string): Promise<string> {
 }
 
 export class SvNewApiImageProvider implements ImageProvider {
-	name = 'SV NewAPI'
+	name = 'SVRouter'
 	private apiKey: string
 	private app: App
 	private outputDir: string
@@ -282,7 +285,7 @@ export class SvNewApiImageProvider implements ImageProvider {
 }
 
 export class SvNewApiVideoProvider implements VideoProvider {
-	name = 'SV NewAPI'
+	name = 'SVRouter'
 	private apiKey: string
 	private app: App
 	private outputDir: string
@@ -399,7 +402,7 @@ function buildVideoBody(
 }
 
 export class SvNewApiAudioProvider implements AudioProvider {
-	name = 'SV NewAPI'
+	name = 'SVRouter'
 	private apiKey: string
 	private app: App
 	private outputDir: string

--- a/src/svnewapi-asset-flow.ts
+++ b/src/svnewapi-asset-flow.ts
@@ -2,6 +2,7 @@ import type BragiCanvas from './main'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { requestUrl } from 'obsidian'
 import { uploadRef } from './providers/upload'
+import { SVROUTER_BASE_URL } from './providers/svnewapi'
 
 // SV NewAPI (new-api gateway) asset-library flow. Unlike the direct byteplus /
 // tokenrouter / token360 flows which call the provider's asset API themselves, this
@@ -46,17 +47,10 @@ function gatewayErrorMessage(json: unknown, text: string, fallback: string): str
 	return stringValue(error?.message || body?.error || body?.message || text.substring(0, 200), fallback)
 }
 
-function normalizeBaseUrl(value: string | undefined): string {
-	const s = (value || '').trim()
-	return s.endsWith('/') ? s.slice(0, -1) : s
-}
-
 export function getSvNewApiAssetCreds(plugin: BragiCanvas): SvNewApiAssetCreds | null {
-	const p = plugin.settings.providers
-	const apiKey = (p.svnewapi || '').trim()
-	const baseUrl = normalizeBaseUrl(p.svnewapiBaseUrl)
-	if (!apiKey || !baseUrl) return null
-	return { baseUrl, apiKey }
+	const apiKey = (plugin.settings.providers.svnewapi || '').trim()
+	if (!apiKey) return null
+	return { baseUrl: SVROUTER_BASE_URL, apiKey }
 }
 
 function assetFileInfo(filePath: string): { assetType: AssetType; ext: string; mime: string } {


### PR DESCRIPTION
## Summary
- Renames the provider display name from **SV NewAPI** to **SVRouter** (provider instances + settings entry).
- Hardcodes the gateway base URL to `https://gateway.storyverseai.art` and removes the user-editable **Base URL** field; only the API Key is required now.
- Keeps the internal provider id `svnewapi` unchanged so existing settings and model mappings keep working. The legacy `svnewapiBaseUrl` setting field is retained for data compatibility but no longer used.

## Test plan
- [x] `npm run build` (production esbuild) passes
- [x] `npm run test:svnewapi-audio-params` passes
- [x] `npm run test:svnewapi-image-refs` passes
- [x] `npm run test:svnewapi-video-params` passes
- [ ] Manually confirm the provider shows as "SVRouter" in settings with only an API Key field, and generation/connection test hit the fixed gateway