### PR TITLE
feat: add Kling 3.0 Omni providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added Kling 3.0 Omni through the native Kling and APIMart providers, including text-to-video, first/last-frame, multi-image reference, feature-video reference, and video-edit flows.
 - Added 3–15 second duration, Standard/Pro/4K quality, optional generated audio, source-audio retention, and advanced multi-shot/subject payload support while keeping the generator bar mode-specific and compact.
+- Exposed intelligent multi-shot generation as the default `Multi shots` control, with `Single shot` as the alternative, and clarified generated-audio choices as `Audio On` / `Audio Off`.
 - Added payload contract verification for both provider request shapes and native Omni task polling.
 
 ## 1.27.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added Kling 3.0 Omni through the native Kling and APIMart providers, including text-to-video, first/last-frame, multi-image reference, feature-video reference, and video-edit flows.
+- Added 3–15 second duration, Standard/Pro/4K quality, optional generated audio, source-audio retention, and advanced multi-shot/subject payload support while keeping the generator bar mode-specific and compact.
+- Added payload contract verification for both provider request shapes and native Omni task polling.
+
 ## 1.27.3
 
 - Fixed SV NewAPI Seedance Auto duration by forwarding it as `metadata.duration = -1`, matching the direct BytePlus/Volcengine Ark Seedance behavior.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -56,7 +56,7 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Reference-image mode adds missing `<<<image_N>>>` tokens so every ordered canvas image participates. Native Kling accepts up to 7 images without a video and 4 with a feature video; APIMart feature-video mode accepts at most one first-frame image.
 - Video reference maps to `video_list.refer_type = feature`; video edit maps to `base`, omits duration/aspect ratio, disables generated audio, and follows the source clip duration.
 - Duration is an integer from 3 through 15. Quality values are `std`, `pro`, and `4k`. Generated audio is unavailable when `video_list` is present.
-- Keep the generator bar compact: expose only duration, ratio, quality, and the audio control relevant to the selected mode. Advanced callers may pass `multi_shot`, `shot_type`, `multi_prompt`, and `element_list` directly.
+- Keep the generator bar compact: expose duration, ratio, quality, the mode-relevant audio control, and a `Multi shots` / `Single shot` toggle. `Multi shots` is the default and maps to intelligent splitting (`multi_shot = true`, `shot_type = intelligence`). Advanced callers may still pass custom `multi_prompt` shot lists and `element_list` directly.
 
 ## SuChuang Gemini Omni
 

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -46,6 +46,18 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Supported duration values are 4, 6, 8, and 10 seconds.
 - Supported resolution values are `720p`, `1080p`, and `4k`.
 
+## Kling 3.0 Omni
+
+- Bragi model ID: `kling-3.0-omni`; upstream model ID on both providers: `kling-v3-omni`.
+- Native Kling endpoint: `POST /v1/videos/omni-video`; Bragi tries the existing global `https://api.klingai.com` region first and falls back to the documented Beijing host when the AK is not registered globally. Task polling probes both regional hosts.
+- APIMart endpoint: `POST https://api.apimart.ai/v1/videos/generations`; task status uses `GET /v1/tasks/{task_id}`.
+- Supported modes are text-to-video, first-frame, first-last-frame, image reference, feature-video reference, and base-video edit.
+- Native Kling uses `image_list` entries with `first_frame` / `end_frame`; APIMart uses `image_with_roles` with `first_frame` / `last_frame`.
+- Reference-image mode adds missing `<<<image_N>>>` tokens so every ordered canvas image participates. Native Kling accepts up to 7 images without a video and 4 with a feature video; APIMart feature-video mode accepts at most one first-frame image.
+- Video reference maps to `video_list.refer_type = feature`; video edit maps to `base`, omits duration/aspect ratio, disables generated audio, and follows the source clip duration.
+- Duration is an integer from 3 through 15. Quality values are `std`, `pro`, and `4k`. Generated audio is unavailable when `video_list` is present.
+- Keep the generator bar compact: expose only duration, ratio, quality, and the audio control relevant to the selected mode. Advanced callers may pass `multi_shot`, `shot_type`, `multi_prompt`, and `element_list` directly.
+
 ## SuChuang Gemini Omni
 
 - Endpoint: `POST https://api.wuyinkeji.com/api/async/video_google_omni`.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
+    "test:kling-omni": "node scripts/verify-kling-omni.mjs",
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",

--- a/scripts/verify-kling-omni.mjs
+++ b/scripts/verify-kling-omni.mjs
@@ -162,6 +162,9 @@ try {
 	assert.match(modelCatalog, /id: 'kling-3\.0-omni'/)
 	assert.match(modelCatalog, /kling: \{ apiModelId: 'kling-v3-omni' \}/)
 	assert.match(modelCatalog, /apimart: \{ apiModelId: 'kling-v3-omni' \}/)
+	assert.match(modelCatalog, /id: 'multi_shot'[\s\S]*?label: 'Shots'[\s\S]*?label: 'Multi shots', value: 'true'[\s\S]*?default: 'true'/)
+	assert.match(modelCatalog, /label: 'Audio Off', value: 'off'/)
+	assert.match(modelCatalog, /label: 'Audio On', value: 'on'/)
 	assert.match(mainSource, /supportsKlingOmniVideoRef/)
 
 	console.log('Kling 3.0 Omni payload and provider wiring checks passed.')

--- a/scripts/verify-kling-omni.mjs
+++ b/scripts/verify-kling-omni.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-kling-omni-'))
+const bundlePath = join(tempDir, 'payload.mjs')
+
+try {
+	await build({
+		entryPoints: ['src/providers/kling-omni-payload.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: bundlePath,
+		logLevel: 'silent',
+	})
+	const { buildOfficialKlingOmniRequest, buildApimartKlingOmniRequest } = await import(`${pathToFileURL(bundlePath).href}?t=${Date.now()}`)
+
+	const officialFrames = buildOfficialKlingOmniRequest('A slow camera push', {
+		genMode: 'first-last-frame',
+		refImages: ['https://refs/first.png', 'https://refs/last.png'],
+		duration: 6,
+		mode: 'pro',
+		sound: 'on',
+	})
+	assert.equal(officialFrames.model_name, 'kling-v3-omni')
+	assert.equal(officialFrames.duration, '6')
+	assert.equal(officialFrames.aspect_ratio, undefined)
+	assert.deepEqual(officialFrames.image_list, [
+		{ image_url: 'https://refs/first.png', type: 'first_frame' },
+		{ image_url: 'https://refs/last.png', type: 'end_frame' },
+	])
+	const officialFirstFrame = buildOfficialKlingOmniRequest('Begin from this frame', {
+		genMode: 'first-frame',
+		refImages: ['https://refs/first.png'],
+	})
+	assert.deepEqual(officialFirstFrame.image_list, [{ image_url: 'https://refs/first.png', type: 'first_frame' }])
+	assert.equal(officialFirstFrame.aspect_ratio, undefined)
+
+	const officialRefs = buildOfficialKlingOmniRequest('Let them meet', {
+		genMode: 'image-ref',
+		refImages: ['https://refs/1.png', 'https://refs/2.png', 'https://refs/3.png'],
+		duration: 15,
+		aspect_ratio: '9:16',
+		mode: '4k',
+		sound: 'on',
+		multi_shot: true,
+	})
+	assert.match(officialRefs.prompt, /<<<image_1>>> <<<image_2>>> <<<image_3>>>/)
+	assert.equal(officialRefs.mode, '4k')
+	assert.equal(officialRefs.sound, 'on')
+	assert.equal(officialRefs.multi_shot, true)
+	assert.equal(officialRefs.shot_type, 'intelligence')
+
+	const officialFeature = buildOfficialKlingOmniRequest('Continue the move', {
+		genMode: 'video-ref',
+		refImages: ['https://refs/look.png'],
+		refVideos: ['https://refs/motion.mp4'],
+		keep_original_sound: 'yes',
+	})
+	assert.match(officialFeature.prompt, /<<<image_1>>>/)
+	assert.match(officialFeature.prompt, /<<<video_1>>>/)
+	assert.equal(officialFeature.sound, 'off')
+	assert.deepEqual(officialFeature.video_list, [{
+		video_url: 'https://refs/motion.mp4',
+		refer_type: 'feature',
+		keep_original_sound: 'yes',
+	}])
+
+	const officialEdit = buildOfficialKlingOmniRequest('Replace the sky', {
+		genMode: 'video-edit',
+		refVideos: ['https://refs/base.mp4'],
+		keep_original_sound: 'yes',
+		duration: 12,
+	})
+	assert.equal(officialEdit.duration, undefined)
+	assert.equal(officialEdit.aspect_ratio, undefined)
+	assert.equal(officialEdit.sound, 'off')
+	assert.equal(officialEdit.multi_shot, false)
+
+	const apimartRefs = buildApimartKlingOmniRequest('Use both locations', {
+		genMode: 'image-ref',
+		refImages: ['https://refs/1.png', 'https://refs/2.png'],
+		duration: 7,
+		aspect_ratio: '1:1',
+		mode: 'pro',
+		sound: 'on',
+		negative_prompt: 'blur',
+	})
+	assert.equal(apimartRefs.model, 'kling-v3-omni')
+	assert.equal(apimartRefs.duration, 7)
+	assert.equal(typeof apimartRefs.duration, 'number')
+	assert.equal(apimartRefs.audio, true)
+	assert.equal(apimartRefs.negative_prompt, 'blur')
+	assert.deepEqual(apimartRefs.image_urls, ['https://refs/1.png', 'https://refs/2.png'])
+	assert.match(apimartRefs.prompt, /<<<image_1>>> <<<image_2>>>/)
+
+	const apimartFrames = buildApimartKlingOmniRequest('Move between frames', {
+		genMode: 'first-last-frame',
+		refImages: ['https://refs/first.png', 'https://refs/last.png'],
+	})
+	assert.deepEqual(apimartFrames.image_with_roles, [
+		{ url: 'https://refs/first.png', role: 'first_frame' },
+		{ url: 'https://refs/last.png', role: 'last_frame' },
+	])
+	assert.equal(apimartFrames.aspect_ratio, undefined)
+	const apimartFirstFrame = buildApimartKlingOmniRequest('Begin from this frame', {
+		genMode: 'first-frame',
+		refImages: ['https://refs/first.png'],
+	})
+	assert.deepEqual(apimartFirstFrame.image_with_roles, [{ url: 'https://refs/first.png', role: 'first_frame' }])
+
+	const apimartAdvanced = buildApimartKlingOmniRequest('Custom sequence', {
+		genMode: 'text-to-video',
+		duration: 6,
+		multi_shot: true,
+		shot_type: 'customize',
+		multi_prompt: [
+			{ index: 1, prompt: 'Wide shot', duration: 3 },
+			{ index: 2, prompt: 'Close shot', duration: 3 },
+		],
+		element_list: [{ name: 'element_crane', description: 'paper crane', element_input_urls: ['https://refs/1.png', 'https://refs/2.png'] }],
+	})
+	assert.equal(apimartAdvanced.multi_shot, true)
+	assert.equal(apimartAdvanced.shot_type, 'customize')
+	assert.equal(apimartAdvanced.multi_prompt.length, 2)
+	assert.equal(apimartAdvanced.element_list.length, 1)
+
+	const apimartEdit = buildApimartKlingOmniRequest('Remove the sign', {
+		genMode: 'video-edit',
+		refVideos: ['https://refs/base.mp4'],
+	})
+	assert.equal(apimartEdit.duration, undefined)
+	assert.equal(apimartEdit.audio, undefined)
+	assert.deepEqual(apimartEdit.video_list, [{
+		video_url: 'https://refs/base.mp4',
+		refer_type: 'base',
+		keep_original_sound: 'no',
+	}])
+
+	assert.throws(
+		() => buildApimartKlingOmniRequest('Bad duration', { genMode: 'text-to-video', duration: 16 }),
+		/duration must be a whole number from 3 to 15/,
+	)
+	assert.throws(
+		() => buildOfficialKlingOmniRequest('Missing frame', { genMode: 'first-last-frame', refImages: ['https://refs/first.png'] }),
+		/requires exactly two images/,
+	)
+
+	const [klingProvider, apimartProvider, modelCatalog, mainSource] = await Promise.all([
+		readFile('src/providers/kling.ts', 'utf8'),
+		readFile('src/providers/apimart.ts', 'utf8'),
+		readFile('src/models/kling.ts', 'utf8'),
+		readFile('src/main.ts', 'utf8'),
+	])
+	assert.match(klingProvider, /OMNI_BASE_URLS = \[BASE_URL, 'https:\/\/api-beijing\.klingai\.com'\]/)
+	assert.match(klingProvider, /OMNI_BASE_URLS\.map\(baseUrl => `\$\{baseUrl\}\/v1\/videos\/omni-video\/\$\{taskId\}`\)/)
+	assert.match(apimartProvider, /modelId === KLING_OMNI_MODEL_ID/)
+	assert.match(modelCatalog, /id: 'kling-3\.0-omni'/)
+	assert.match(modelCatalog, /kling: \{ apiModelId: 'kling-v3-omni' \}/)
+	assert.match(modelCatalog, /apimart: \{ apiModelId: 'kling-v3-omni' \}/)
+	assert.match(mainSource, /supportsKlingOmniVideoRef/)
+
+	console.log('Kling 3.0 Omni payload and provider wiring checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -621,6 +621,7 @@ export default class BragiCanvas extends Plugin {
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7'
 			const isDashScopeWan = activeProvider === 'dashscope' && model.id === 'wan-2.7'
 			const supportsApimartVideoRef = activeProvider === 'apimart' && model.id === 'omni-flash-ext'
+			const supportsKlingOmniVideoRef = model.id === 'kling-3.0-omni' && (activeProvider === 'kling' || activeProvider === 'apimart')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
@@ -694,14 +695,17 @@ export default class BragiCanvas extends Plugin {
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
 			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
-				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !isDashScopeWan) {
-					throw new Error('Reference video is only available with Volcengine, BytePlus, TokenRouter, or Token360 Seedance, APIMart Omni-Flash-Ext, or DashScope Wan 2.7.')
+				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !supportsKlingOmniVideoRef && !isDashScopeWan) {
+					throw new Error('Reference video is not available for the active model and provider.')
 				}
 				if (supportsSeedanceUrlRefs && uniqueVideos.length > 3) {
 					throw new Error('Seedance supports up to 3 reference videos.')
 				}
 				if (supportsApimartVideoRef && uniqueVideos.length > 1) {
 					throw new Error('APIMart Omni-Flash-Ext supports at most 1 reference video.')
+				}
+				if (supportsKlingOmniVideoRef && uniqueVideos.length > 1) {
+					throw new Error('Kling 3.0 Omni supports at most 1 reference video.')
 				}
 				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
 					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,7 @@ import { gptImage, gptImageOfficial } from './gpt-image'
 import { nanoBananaPro, nanoBanana2 } from './nano-banana'
 import { seedream5, seedream5Lite, seedream45 } from './seedream'
 import { seedance2, seedance2Fast } from './seedance'
-import { kling3, kling26 } from './kling'
+import { kling3, klingOmni3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
 import { zImageSpicy, qwenImageEditSpicy, wan27 } from './wan'
@@ -44,6 +44,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	seedance2,
 	seedance2Fast,
 	kling3,
+	klingOmni3,
 	kling26,
 	happyHorseT2V,
 	happyHorseI2V,

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -107,10 +107,21 @@ const KLING_OMNI_PARAMS: ModelParam[] = [
 		type: 'select',
 		modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref'],
 		options: [
-			{ label: 'Off', value: 'off' },
-			{ label: 'On', value: 'on' },
+			{ label: 'Audio Off', value: 'off' },
+			{ label: 'Audio On', value: 'on' },
 		],
 		default: 'off',
+	},
+	{
+		id: 'multi_shot',
+		label: 'Shots',
+		type: 'select',
+		modes: [...KLING_OMNI_TIMED_MODES],
+		options: [
+			{ label: 'Multi shots', value: 'true' },
+			{ label: 'Single shot', value: 'false' },
+		],
+		default: 'true',
 	},
 	{
 		id: 'keep_original_sound',

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -63,6 +63,68 @@ const KLING_PARAMS: ModelParam[] = [
 	},
 ]
 
+const KLING_OMNI_TIMED_MODES = ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref'] as const
+const KLING_OMNI_RATIO_MODES = ['text-to-video', 'image-ref', 'video-ref'] as const
+
+const KLING_OMNI_PARAMS: ModelParam[] = [
+	{
+		id: 'duration',
+		label: 'Duration',
+		type: 'range',
+		modes: [...KLING_OMNI_TIMED_MODES],
+		default: 5,
+		min: 3,
+		max: 15,
+		step: 1,
+		unit: 's',
+	},
+	{
+		id: 'aspect_ratio',
+		label: 'Ratio',
+		type: 'select',
+		modes: [...KLING_OMNI_RATIO_MODES],
+		options: [
+			{ label: '16:9', value: '16:9' },
+			{ label: '9:16', value: '9:16' },
+			{ label: '1:1', value: '1:1' },
+		],
+		default: '16:9',
+	},
+	{
+		id: 'mode',
+		label: 'Quality',
+		type: 'select',
+		options: [
+			{ label: 'Standard', value: 'std' },
+			{ label: 'Pro', value: 'pro' },
+			{ label: '4K', value: '4k' },
+		],
+		default: 'std',
+	},
+	{
+		id: 'sound',
+		label: 'Audio',
+		type: 'select',
+		modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref'],
+		options: [
+			{ label: 'Off', value: 'off' },
+			{ label: 'On', value: 'on' },
+		],
+		default: 'off',
+	},
+	{
+		id: 'keep_original_sound',
+		label: 'Source Audio',
+		type: 'select',
+		modes: ['video-ref', 'video-edit'],
+		options: [
+			{ label: 'Mute', value: 'no' },
+			{ label: 'Keep', value: 'yes' },
+		],
+		default: 'no',
+	},
+]
+
 export const kling3: ModelConfig = {
 	id: 'kling-3.0',
 	name: 'Kling 3.0',
@@ -80,6 +142,18 @@ export const kling3: ModelConfig = {
 	// + motion-control (character image + reference motion video, V3.0 only)
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'motion-control'],
 	params: KLING_PARAMS,
+}
+
+export const klingOmni3: ModelConfig = {
+	id: 'kling-3.0-omni',
+	name: 'Kling 3.0 Omni',
+	type: 'video',
+	supportedProviders: {
+		kling: { apiModelId: 'kling-v3-omni' },
+		apimart: { apiModelId: 'kling-v3-omni' },
+	},
+	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-edit'],
+	params: KLING_OMNI_PARAMS,
 }
 
 export const kling26: ModelConfig = {

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -242,7 +242,13 @@ function inferMode(modes: Mode[], imageCount: number, videoCount: number): Mode 
 	if (videoCount > 0 && modes.includes('video-extend')) return 'video-extend'
 	if (videoCount > 0 && modes.includes('video-edit')) return 'video-edit'
 
-	// 2+ images → prefer first-last-frame, then multi-ref, then image-ref
+	// 3+ images cannot be a first/last-frame pair; prefer a reference mode.
+	if (imageCount > 2) {
+		if (modes.includes('multi-image-ref')) return 'multi-image-ref'
+		if (modes.includes('image-ref')) return 'image-ref'
+	}
+
+	// 2 images → prefer first-last-frame, then multi-ref, then image-ref
 	if (imageCount >= 2) {
 		if (modes.includes('first-last-frame')) return 'first-last-frame'
 		if (modes.includes('multi-image-ref')) return 'multi-image-ref'

--- a/src/providers/apimart.ts
+++ b/src/providers/apimart.ts
@@ -5,6 +5,7 @@ import { requestUrl } from 'obsidian'
 import { stringParam } from './params'
 import { BUILTIN_BRAGI_RELAY } from './bragi-relay'
 import { uploadRef } from './upload'
+import { buildApimartKlingOmniRequest, KLING_OMNI_MODEL_ID } from './kling-omni-payload'
 
 /**
  * APIMart provider.
@@ -183,6 +184,9 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 		if (genMode === 'motion-control' || modelId.includes('motion-control')) {
 			return this.generateMotionControl(prompt, modelId, params)
 		}
+		if (modelId === KLING_OMNI_MODEL_ID) {
+			return this.generateKlingOmni(prompt, params)
+		}
 
 		const resolution = stringParam(params?.resolution, '720p').toLowerCase()
 		const aspectRatio = stringParam(params?.aspect_ratio || params?.aspectRatio || params?.ratio, '16:9')
@@ -236,6 +240,34 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 		const taskId = first?.task_id || first?.id
 		if (!taskId) {
 			throw new Error(`APIMart: no task_id in video submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	private async generateKlingOmni(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const refImages = await Promise.all(arrayParam(params?.refImages).map(ref => this.ensureRelayUrl(ref, 'image')))
+		const refVideos = await Promise.all(arrayParam(params?.refVideos).map(ref => this.ensureRelayUrl(ref, 'video')))
+		const body = buildApimartKlingOmniRequest(prompt, { ...(params || {}), refImages, refVideos })
+
+		const resp = await requestUrl({
+			url: `${API_BASE}/videos/generations`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status === 401 || resp.status === 403) throw new Error('APIMart: invalid API key')
+		if (resp.status >= 400) throw new Error(`APIMart Kling Omni: ${parseApimartError(resp)}`)
+
+		const submitData = resp.json
+		const first = submitData?.data?.[0]
+		const taskId = first?.task_id || first?.id
+		if (!taskId) {
+			throw new Error(`APIMart Kling Omni: no task_id in submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
 		}
 		return { done: false, taskId }
 	}

--- a/src/providers/kling-omni-payload.ts
+++ b/src/providers/kling-omni-payload.ts
@@ -1,0 +1,214 @@
+export const KLING_OMNI_MODEL_ID = 'kling-v3-omni'
+
+type JsonObject = Record<string, unknown>
+
+const VALID_MODES = new Set(['std', 'pro', '4k'])
+const VALID_RATIOS = new Set(['16:9', '9:16', '1:1'])
+
+function stringValue(value: unknown, fallback = ''): string {
+	return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function stringList(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+		: []
+}
+
+function booleanValue(value: unknown, fallback = false): boolean {
+	if (typeof value === 'boolean') return value
+	if (value === 'true' || value === 'on' || value === 'yes') return true
+	if (value === 'false' || value === 'off' || value === 'no') return false
+	return fallback
+}
+
+function generationMode(params: JsonObject): string {
+	return stringValue(params.genMode, 'text-to-video')
+}
+
+function qualityMode(params: JsonObject): string {
+	const value = stringValue(params.mode, 'std').toLowerCase()
+	if (!VALID_MODES.has(value)) throw new Error('Kling Omni quality must be Standard, Pro, or 4K.')
+	return value
+}
+
+function durationSeconds(params: JsonObject): number {
+	const value = Number(params.duration ?? 5)
+	if (!Number.isInteger(value) || value < 3 || value > 15) {
+		throw new Error('Kling Omni duration must be a whole number from 3 to 15 seconds.')
+	}
+	return value
+}
+
+function aspectRatio(params: JsonObject): string {
+	const value = stringValue(params.aspect_ratio ?? params.aspectRatio ?? params.ratio, '16:9')
+	if (!VALID_RATIOS.has(value)) throw new Error('Kling Omni ratio must be 16:9, 9:16, or 1:1.')
+	return value
+}
+
+function withMissingReferences(prompt: string, kind: 'image' | 'video', count: number): string {
+	const missing: string[] = []
+	for (let index = 1; index <= count; index++) {
+		const token = `<<<${kind}_${index}>>>`
+		if (!prompt.includes(token)) missing.push(token)
+	}
+	return missing.length > 0 ? `${missing.join(' ')} ${prompt}`.trim() : prompt
+}
+
+function validateInputs(genMode: string, refImages: string[], refVideos: string[], provider: 'Kling' | 'APIMart'): void {
+	if (refVideos.length > 1) throw new Error(`${provider} Kling Omni supports at most one reference video.`)
+
+	if (genMode === 'text-to-video' && (refImages.length > 0 || refVideos.length > 0)) {
+		throw new Error(`${provider} Kling Omni text-to-video does not accept upstream media; choose a reference mode.`)
+	}
+	if (genMode === 'first-frame' && (refImages.length !== 1 || refVideos.length > 0)) {
+		throw new Error(`${provider} Kling Omni first-frame mode requires exactly one image and no video.`)
+	}
+	if (genMode === 'first-last-frame' && (refImages.length !== 2 || refVideos.length > 0)) {
+		throw new Error(`${provider} Kling Omni first-last-frame mode requires exactly two images and no video.`)
+	}
+	if ((genMode === 'image-ref' || genMode === 'multi-image-ref') && (refImages.length < 1 || refVideos.length > 0)) {
+		throw new Error(`${provider} Kling Omni image reference mode requires images and no video.`)
+	}
+	if ((genMode === 'video-ref' || genMode === 'video-edit') && refVideos.length !== 1) {
+		throw new Error(`${provider} Kling Omni ${genMode} mode requires exactly one reference video.`)
+	}
+	if (genMode === 'video-edit' && refImages.length > 0) {
+		throw new Error(`${provider} Kling Omni video edit cannot be combined with image references.`)
+	}
+	if (!['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'multi-image-ref', 'video-ref', 'video-edit'].includes(genMode)) {
+		throw new Error(`${provider} Kling Omni does not support ${genMode} mode.`)
+	}
+}
+
+function applyAdvancedOptions(body: JsonObject, params: JsonObject, allowMultiShot: boolean): void {
+	const multiShot = allowMultiShot && booleanValue(params.multi_shot)
+	body.multi_shot = multiShot
+	if (multiShot) {
+		const shotType = stringValue(params.shot_type, 'intelligence')
+		if (shotType !== 'intelligence' && shotType !== 'customize') {
+			throw new Error('Kling Omni shot type must be intelligence or customize.')
+		}
+		body.shot_type = shotType
+		if (shotType === 'customize') {
+			if (!Array.isArray(params.multi_prompt) || params.multi_prompt.length < 1 || params.multi_prompt.length > 6) {
+				throw new Error('Kling Omni custom multi-shot requires 1 to 6 shot prompts.')
+			}
+			body.multi_prompt = params.multi_prompt
+		}
+	}
+	if (Array.isArray(params.element_list) && params.element_list.length > 0) {
+		body.element_list = params.element_list
+	}
+}
+
+export function buildOfficialKlingOmniRequest(prompt: string, params: JsonObject = {}): JsonObject {
+	const genMode = generationMode(params)
+	const refImages = stringList(params.refImages)
+	const refVideos = stringList(params.refVideos)
+	validateInputs(genMode, refImages, refVideos, 'Kling')
+
+	if (refImages.length > (refVideos.length > 0 ? 4 : 7)) {
+		throw new Error(`Kling Omni supports at most ${refVideos.length > 0 ? 4 : 7} reference images for this input.`)
+	}
+
+	let finalPrompt = prompt
+	const body: JsonObject = {
+		model_name: KLING_OMNI_MODEL_ID,
+		mode: qualityMode(params),
+		watermark_info: { enabled: booleanValue(params.watermark) },
+	}
+
+	if (genMode === 'first-frame') {
+		body.image_list = [{ image_url: refImages[0], type: 'first_frame' }]
+	} else if (genMode === 'first-last-frame') {
+		body.image_list = [
+			{ image_url: refImages[0], type: 'first_frame' },
+			{ image_url: refImages[1], type: 'end_frame' },
+		]
+	} else if (genMode === 'image-ref' || genMode === 'multi-image-ref') {
+		body.image_list = refImages.map(imageUrl => ({ image_url: imageUrl }))
+		finalPrompt = withMissingReferences(finalPrompt, 'image', refImages.length)
+	} else if (genMode === 'video-ref') {
+		body.video_list = [{
+			video_url: refVideos[0],
+			refer_type: 'feature',
+			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
+		}]
+		if (refImages.length > 0) {
+			body.image_list = refImages.map(imageUrl => ({ image_url: imageUrl }))
+			finalPrompt = withMissingReferences(finalPrompt, 'image', refImages.length)
+		}
+		finalPrompt = withMissingReferences(finalPrompt, 'video', 1)
+	} else if (genMode === 'video-edit') {
+		body.video_list = [{
+			video_url: refVideos[0],
+			refer_type: 'base',
+			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
+		}]
+	}
+
+	body.prompt = finalPrompt
+	const hasFirstFrame = genMode === 'first-frame' || genMode === 'first-last-frame'
+	if (genMode !== 'video-edit') body.duration = String(durationSeconds(params))
+	if (!hasFirstFrame && genMode !== 'video-edit') body.aspect_ratio = aspectRatio(params)
+	body.sound = refVideos.length > 0 ? 'off' : stringValue(params.sound, 'off')
+	applyAdvancedOptions(body, params, genMode !== 'video-edit')
+	return body
+}
+
+export function buildApimartKlingOmniRequest(prompt: string, params: JsonObject = {}): JsonObject {
+	const genMode = generationMode(params)
+	const refImages = stringList(params.refImages)
+	const refVideos = stringList(params.refVideos)
+	validateInputs(genMode, refImages, refVideos, 'APIMart')
+
+	if (refImages.length > 7) throw new Error('APIMart Kling Omni supports at most 7 reference images.')
+	if (genMode === 'video-ref' && refImages.length > 1) {
+		throw new Error('APIMart Kling Omni feature-video mode supports at most one first-frame image.')
+	}
+
+	let finalPrompt = prompt
+	const body: JsonObject = {
+		model: KLING_OMNI_MODEL_ID,
+		mode: qualityMode(params),
+		watermark: booleanValue(params.watermark),
+	}
+
+	const negativePrompt = stringValue(params.negative_prompt)
+	if (negativePrompt) body.negative_prompt = negativePrompt
+
+	if (genMode === 'first-frame') {
+		body.image_with_roles = [{ url: refImages[0], role: 'first_frame' }]
+	} else if (genMode === 'first-last-frame') {
+		body.image_with_roles = [
+			{ url: refImages[0], role: 'first_frame' },
+			{ url: refImages[1], role: 'last_frame' },
+		]
+	} else if (genMode === 'image-ref' || genMode === 'multi-image-ref') {
+		body.image_urls = refImages
+		finalPrompt = withMissingReferences(finalPrompt, 'image', refImages.length)
+	} else if (genMode === 'video-ref') {
+		body.video_list = [{
+			video_url: refVideos[0],
+			refer_type: 'feature',
+			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
+		}]
+		if (refImages.length === 1) body.image_with_roles = [{ url: refImages[0], role: 'first_frame' }]
+		finalPrompt = withMissingReferences(finalPrompt, 'video', 1)
+	} else if (genMode === 'video-edit') {
+		body.video_list = [{
+			video_url: refVideos[0],
+			refer_type: 'base',
+			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
+		}]
+	}
+
+	body.prompt = finalPrompt
+	const hasFirstFrame = genMode === 'first-frame' || genMode === 'first-last-frame' || (genMode === 'video-ref' && refImages.length === 1)
+	if (genMode !== 'video-edit') body.duration = durationSeconds(params)
+	if (!hasFirstFrame && genMode !== 'video-edit') body.aspect_ratio = aspectRatio(params)
+	if (refVideos.length === 0) body.audio = stringValue(params.sound, 'off') === 'on'
+	applyAdvancedOptions(body, params, genMode !== 'video-edit')
+	return body
+}

--- a/src/providers/kling.ts
+++ b/src/providers/kling.ts
@@ -2,8 +2,10 @@
 import type { VideoProvider, GenerateVideoResult } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
+import { buildOfficialKlingOmniRequest, KLING_OMNI_MODEL_ID } from './kling-omni-payload'
 
 const BASE_URL = 'https://api.klingai.com'
+const OMNI_BASE_URLS = [BASE_URL, 'https://api-beijing.klingai.com'] as const
 
 export class KlingProvider implements VideoProvider {
 	name = 'Kling'
@@ -34,7 +36,9 @@ export class KlingProvider implements VideoProvider {
 
 		let taskId: string
 
-		if (genMode === 'motion-control' && refImages.length >= 1 && refVideos.length >= 1) {
+		if (modelId === KLING_OMNI_MODEL_ID) {
+			taskId = await this.createOmniVideoTask(token, buildOfficialKlingOmniRequest(prompt, params || {}))
+		} else if (genMode === 'motion-control' && refImages.length >= 1 && refVideos.length >= 1) {
 			// Motion Control: transfer the reference video's motion onto the character image.
 			// image_url/video_url accept a public URL or base64; refs are relay https URLs
 			// here, and stripDataUriPrefix passes a URL through unchanged.
@@ -84,14 +88,15 @@ export class KlingProvider implements VideoProvider {
 		const token = await this.getToken()
 
 		// The task type isn't tracked, so probe each video endpoint until one resolves.
-		const paths = [
-			`/v1/videos/text2video/${taskId}`,
-			`/v1/videos/image2video/${taskId}`,
-			`/v1/videos/motion-control/${taskId}`,
+		const urls = [
+			...OMNI_BASE_URLS.map(baseUrl => `${baseUrl}/v1/videos/omni-video/${taskId}`),
+			`${BASE_URL}/v1/videos/text2video/${taskId}`,
+			`${BASE_URL}/v1/videos/image2video/${taskId}`,
+			`${BASE_URL}/v1/videos/motion-control/${taskId}`,
 		]
 		let data: unknown
-		for (const path of paths) {
-			const result = await this.pollTask(token, path)
+		for (const url of urls) {
+			const result = await this.pollTask(token, url)
 			if (result?.code === 0) {
 				data = result
 				break
@@ -173,11 +178,41 @@ export class KlingProvider implements VideoProvider {
 		return data.data.task_id
 	}
 
-	private async pollTask(token: string, path: string): Promise<unknown> {
+	private async createOmniVideoTask(token: string, body: unknown): Promise<string> {
+		let lastError = 'Task creation failed'
+		for (const baseUrl of OMNI_BASE_URLS) {
+			const response = await requestUrl({
+				url: `${baseUrl}/v1/videos/omni-video`,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${token}`,
+				},
+				body: JSON.stringify(body),
+				throw: false,
+			})
+
+			const data = response.json
+			if (response.status < 400 && data?.code === 0) {
+				const taskId = data?.data?.task_id
+				if (!taskId) throw new Error('Kling Omni: no task_id in create response')
+				return taskId
+			}
+			lastError = data?.message || `Task creation failed (HTTP ${response.status})`
+			const shouldTryNextRegion = response.status === 401
+				|| response.status === 404
+				|| /access key not found/i.test(lastError)
+			if (!shouldTryNextRegion) break
+		}
+		throw new Error(`Kling Omni: ${lastError}`)
+	}
+
+	private async pollTask(token: string, url: string): Promise<unknown> {
 		const response = await requestUrl({
-			url: `${BASE_URL}${path}`,
+			url,
 			method: 'GET',
 			headers: { 'Authorization': `Bearer ${token}` },
+			throw: false,
 		})
 		return response.json
 	}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -253,7 +253,7 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'kling',
 		name: 'Kling',
-		docUrl: 'https://app.klingai.com/global/dev/document-api/',
+		docUrl: 'https://klingai.com/document-api/api/video/3-0-omni/video-omni',
 		fields: [
 			{ key: 'klingAk', label: 'Access Key', placeholder: 'AK', type: 'password' },
 			{ key: 'klingSk', label: 'Secret Key', placeholder: 'SK', type: 'password' },
@@ -470,7 +470,7 @@ export const PROVIDERS: ProviderSpec[] = [
 	{
 		id: 'apimart',
 		name: 'APIMart',
-		docUrl: 'https://docs.apimart.ai/en/api-reference/videos/omni-flash-ext/generation',
+		docUrl: 'https://docs.apimart.ai/en/api-reference/videos/kling-v3-omni/generation',
 		fields: [{ key: 'apimart', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
 		defaultRefDelivery: { image: 'relay', video: 'relay' },
 		isConfigured: (s) => !!s.providers.apimart,


### PR DESCRIPTION
## Summary

- add Kling 3.0 Omni through native Kling and APIMart
- support text, image, reference video, video editing, 3–15s, Standard/Pro/4K, audio, and multi-shot modes
- label shot controls as Multi shots / Single shot and audio controls as Audio Off / Audio On
- use the Kling Global endpoint with Beijing fallback

## Verification

- npm run test:kling-omni
- npm run check:catalog
- npm run audit:catalog (188 combinations)
- npm run lint:obsidian
- npm run build
- root npm run sync:check
- git diff --check
- direct API generation across both providers and Obsidian Canvas UI verification

Paired skill documentation: https://github.com/nextbound/bragi-canvas-skill/pull/39