### PR TITLE
Hide unavailable denoise action

### DIFF
--- a/scripts/verify-bfl-denoise.mjs
+++ b/scripts/verify-bfl-denoise.mjs
@@ -112,8 +112,13 @@ assert.match(
 )
 assert.match(
 	toolbarSource,
-	/if \(isImageNode\) \{[\s\S]*createMenuButton\('bragi-denoise', 'bragi-denoise', 'Denoise'/,
-	'Denoise button must be injected in the image-node toolbar branch.',
+	/canDenoiseImage\?: \(\) => boolean/,
+	'Canvas menu patch must accept a dynamic denoise availability predicate.',
+)
+assert.match(
+	toolbarSource,
+	/if \(isImageNode\) \{[\s\S]*if \(onDenoiseImage && \(!canDenoiseImage \|\| canDenoiseImage\(\)\)\)[\s\S]*createMenuButton\('bragi-denoise', 'bragi-denoise', 'Denoise'/,
+	'Denoise button must only be injected when the dynamic availability predicate passes.',
 )
 assert.match(
 	toolbarSource,
@@ -133,8 +138,13 @@ assert.doesNotMatch(
 )
 assert.match(
 	mainSource,
-	/\(node, activeCanvas\) => this\.openDenoiseImage\(node, activeCanvas\)/,
-	'Canvas menu denoise callback must enter the one-click denoise flow.',
+	/\(node, activeCanvas\) => this\.openDenoiseImage\(node, activeCanvas\),\s*\n\s*\(\) => this\.canDenoiseImage\(\)/,
+	'Canvas menu must pair the denoise callback with its dynamic availability predicate.',
+)
+assert.match(
+	mainSource,
+	/private canDenoiseImage\(\): boolean \{[\s\S]*if \(!pref\?\.enabled\) return false[\s\S]*getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*getActiveProvider\(model, pref\.selectedProvider, connectedProviders\) !== null/,
+	'Denoise availability must require the FLUX model to be enabled with an active configured provider.',
 )
 assert.match(
 	mainSource,
@@ -148,8 +158,8 @@ assert.doesNotMatch(
 )
 assert.match(
 	mainSource,
-	/getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*getActiveProvider\(model, this\.settings\.modelPrefs\[model\.id\]\?\.selectedProvider, connectedProviders\)/,
-	'Denoise action must resolve the current FLUX.2 Klein provider from model preferences.',
+	/if \(!pref\?\.enabled\) \{[\s\S]*Add FLUX\.2 Klein 9B in settings to use denoise[\s\S]*getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*getActiveProvider\(model, pref\.selectedProvider, connectedProviders\)/,
+	'Denoise action must require the enabled FLUX model and resolve its current configured provider.',
 )
 assert.ok(
 	mainSource.includes("createPlaceholderNode(canvas, 'Denoising image…'"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -408,6 +408,7 @@ export default class BragiCanvas extends Plugin {
 			(node, activeCanvas) => openImageAnnotationTool(this, activeCanvas, node, 'box'),
 			(node, activeCanvas) => openVideoEditTool(this, activeCanvas, node),
 			(node, activeCanvas) => this.openDenoiseImage(node, activeCanvas),
+			() => this.canDenoiseImage(),
 		)
 
 		patchPlaceholderContextMenu(canvas)
@@ -480,14 +481,28 @@ export default class BragiCanvas extends Plugin {
 		void this.handleImageDenoise(node, canvas)
 	}
 
+	private canDenoiseImage(): boolean {
+		const model = getModelById('flux-2-klein-9b')
+		if (!model) return false
+		const pref = this.settings.modelPrefs[model.id]
+		if (!pref?.enabled) return false
+		const connectedProviders = getConnectedConfiguredProviderIds(this.settings, model)
+		return getActiveProvider(model, pref.selectedProvider, connectedProviders) !== null
+	}
+
 	async handleImageDenoise(node: CanvasNode, canvas: Canvas): Promise<void> {
 		const model = getModelById('flux-2-klein-9b')
 		if (!model) {
 			new Notice('FLUX.2 Klein 9B is not available')
 			return
 		}
+		const pref = this.settings.modelPrefs[model.id]
+		if (!pref?.enabled) {
+			new Notice('Add FLUX.2 Klein 9B in settings to use denoise')
+			return
+		}
 		const connectedProviders = getConnectedConfiguredProviderIds(this.settings, model)
-		const activeProvider = getActiveProvider(model, this.settings.modelPrefs[model.id]?.selectedProvider, connectedProviders)
+		const activeProvider = getActiveProvider(model, pref.selectedProvider, connectedProviders)
 		if (!activeProvider) {
 			new Notice('Connect BFL, RunPod, or fal.ai to FLUX.2 Klein 9B in settings to use denoise')
 			return

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -623,6 +623,7 @@ export function patchCanvasMenu(
 	onAnnotateImage?: (node: CanvasNode, canvas: Canvas) => void,
 	onEditVideo?: (node: CanvasNode, canvas: Canvas) => void,
 	onDenoiseImage?: (node: CanvasNode, canvas: Canvas) => void,
+	canDenoiseImage?: () => boolean,
 ): void {
 	if (menuUninstaller) return
 
@@ -833,7 +834,7 @@ export function patchCanvasMenu(
 			}
 
 			if (isImageNode) {
-				if (onDenoiseImage) {
+				if (onDenoiseImage && (!canDenoiseImage || canDenoiseImage())) {
 					const denoiseBtn = createMenuButton('bragi-denoise', 'bragi-denoise', 'Denoise', () => {
 						onDenoiseImage(selectedNode, canvas)
 					})


### PR DESCRIPTION
## Summary

- only show Denoise for image nodes when FLUX.2 Klein 9B is enabled in Models
- require at least one connected and configured FLUX provider before showing the action
- keep the same availability guard in the click path
- extend the denoise regression script to cover dynamic toolbar visibility

## Validation

- `npm run test:bfl-denoise`
- `npm run test:fal-flux-klein`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `npm run build`
