### PR TITLE
Tune fal FLUX Klein base inference

### DIFF
--- a/scripts/verify-fal-flux-klein.mjs
+++ b/scripts/verify-fal-flux-klein.mjs
@@ -8,38 +8,48 @@ const packageSource = readFileSync('package.json', 'utf8')
 
 assert.match(
 	modelSource,
-	/fal: \{ apiModelId: 'fal-ai\/flux-2\/klein\/9b', refDelivery: \{ image: 'inline' \} \}/,
-	'FLUX.2 Klein 9B must connect to the fal distilled model with inline image references.',
+	/fal: \{ apiModelId: 'fal-ai\/flux-2\/klein\/9b\/base', refDelivery: \{ image: 'inline' \} \}/,
+	'FLUX.2 Klein 9B must connect to the fal base model with inline image references.',
 )
 
 assert.match(
 	providerSource,
-	/const FAL_FLUX_KLEIN_9B = 'fal-ai\/flux-2\/klein\/9b'/,
-	'fal FLUX Klein must use the 9B distilled text-to-image endpoint.',
+	/const FAL_FLUX_KLEIN_9B_BASE = 'fal-ai\/flux-2\/klein\/9b\/base'/,
+	'fal FLUX Klein must use the 9B base text-to-image endpoint.',
 )
 assert.match(
 	providerSource,
-	/const FAL_FLUX_KLEIN_9B_EDIT = .*FAL_FLUX_KLEIN_9B.*\/edit/,
-	'fal FLUX Klein must use the paired distilled edit endpoint for image inputs.',
+	/const FAL_FLUX_KLEIN_9B_BASE_EDIT = .*FAL_FLUX_KLEIN_9B_BASE.*\/edit/,
+	'fal FLUX Klein must use the paired base edit endpoint for image inputs.',
 )
-assert.doesNotMatch(
+assert.match(
 	providerSource,
 	/fal-ai\/flux-2\/klein\/9b\/base/,
-	'fal FLUX Klein must not route this test integration to the base model.',
+	'fal FLUX Klein must route this integration to the base model.',
 )
 assert.match(
 	providerSource,
-	/const FAL_FLUX_KLEIN_STEPS = 4[\s\S]*input\.num_inference_steps = FAL_FLUX_KLEIN_STEPS/,
-	'fal FLUX Klein distilled generation must use its native four inference steps.',
+	/const FAL_FLUX_KLEIN_STEPS = 5[\s\S]*input\.num_inference_steps = FAL_FLUX_KLEIN_STEPS/,
+	'fal FLUX Klein base generation must use five inference steps.',
 )
 assert.match(
 	providerSource,
-	/if \(refImages\.length > 0\) \{[\s\S]*modelId = FAL_FLUX_KLEIN_9B_EDIT[\s\S]*input\.image_urls = await Promise\.all\(refImages\.slice\(0, 4\)\.map\(uploadFalImageRef\)\)/,
-	'fal FLUX Klein must route up to four original upstream images to distilled edit.',
+	/const FAL_FLUX_KLEIN_GUIDANCE_SCALE = 1[\s\S]*input\.guidance_scale = FAL_FLUX_KLEIN_GUIDANCE_SCALE/,
+	'fal FLUX Klein base generation must use guidance scale 1.',
 )
 assert.match(
 	providerSource,
-	/modelId = FAL_FLUX_KLEIN_9B[\s\S]*input\.image_size = dimensionsFromParams\(params, targetLongEdge\)/,
+	/const FAL_FLUX_KLEIN_ENABLE_SAFETY_CHECKER = false[\s\S]*input\.enable_safety_checker = FAL_FLUX_KLEIN_ENABLE_SAFETY_CHECKER/,
+	'fal FLUX Klein base generation must disable the fal safety checker.',
+)
+assert.match(
+	providerSource,
+	/if \(refImages\.length > 0\) \{[\s\S]*modelId = FAL_FLUX_KLEIN_9B_BASE_EDIT[\s\S]*input\.image_urls = await Promise\.all\(refImages\.slice\(0, 4\)\.map\(uploadFalImageRef\)\)/,
+	'fal FLUX Klein must route up to four original upstream images to base edit.',
+)
+assert.match(
+	providerSource,
+	/modelId = FAL_FLUX_KLEIN_9B_BASE[\s\S]*input\.image_size = dimensionsFromParams\(params, targetLongEdge\)/,
 	'fal FLUX Klein text-to-image must honor the configured long-edge size.',
 )
 assert.match(

--- a/src/models/flux.ts
+++ b/src/models/flux.ts
@@ -19,7 +19,7 @@ export const flux2Klein9b: ModelConfig = {
 	supportedProviders: {
 		bfl: { apiModelId: 'flux-2-klein-9b', refDelivery: { image: 'inline' } },
 		runpod: { apiModelId: 'flux-2-klein-9b', refDelivery: { image: 'inline' } },
-		fal: { apiModelId: 'fal-ai/flux-2/klein/9b', refDelivery: { image: 'inline' } },
+		fal: { apiModelId: 'fal-ai/flux-2/klein/9b/base', refDelivery: { image: 'inline' } },
 	},
 	modes: ['text-to-image', 'image-ref-to-image'],
 	inferModeFromInputs: true,

--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -15,9 +15,11 @@ import {
 
 const FAL_RUN = 'https://fal.run'
 const FAL_QUEUE = 'https://queue.fal.run'
-const FAL_FLUX_KLEIN_9B = 'fal-ai/flux-2/klein/9b'
-const FAL_FLUX_KLEIN_9B_EDIT = `${FAL_FLUX_KLEIN_9B}/edit`
-const FAL_FLUX_KLEIN_STEPS = 4
+const FAL_FLUX_KLEIN_9B_BASE = 'fal-ai/flux-2/klein/9b/base'
+const FAL_FLUX_KLEIN_9B_BASE_EDIT = `${FAL_FLUX_KLEIN_9B_BASE}/edit`
+const FAL_FLUX_KLEIN_STEPS = 5
+const FAL_FLUX_KLEIN_GUIDANCE_SCALE = 1
+const FAL_FLUX_KLEIN_ENABLE_SAFETY_CHECKER = false
 const DEFAULT_FLUX_TARGET_LONG_EDGE = 2048
 
 function imageRefArray(value: unknown): string[] {
@@ -53,7 +55,7 @@ export class FalImageProvider implements ImageProvider {
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
 		let modelId = stringParam(params?.modelId, 'xai/grok-imagine-image')
 		const refImages = imageRefArray(params?.refImages)
-		const isFluxKlein = modelId === FAL_FLUX_KLEIN_9B || modelId === FAL_FLUX_KLEIN_9B_EDIT
+		const isFluxKlein = modelId === FAL_FLUX_KLEIN_9B_BASE || modelId === FAL_FLUX_KLEIN_9B_BASE_EDIT
 
 		// Build input based on model
 		const input: Record<string, unknown> = { prompt }
@@ -62,17 +64,19 @@ export class FalImageProvider implements ImageProvider {
 		if (isFluxKlein) {
 			const targetLongEdge = positiveIntParam(params?.targetLongEdge, DEFAULT_FLUX_TARGET_LONG_EDGE)
 			input.num_inference_steps = FAL_FLUX_KLEIN_STEPS
+			input.guidance_scale = FAL_FLUX_KLEIN_GUIDANCE_SCALE
+			input.enable_safety_checker = FAL_FLUX_KLEIN_ENABLE_SAFETY_CHECKER
 			input.output_format = 'png'
 			input.num_images = 1
 
 			if (refImages.length > 0) {
-				modelId = FAL_FLUX_KLEIN_9B_EDIT
+				modelId = FAL_FLUX_KLEIN_9B_BASE_EDIT
 				const preparedReference = await prepareReferenceImage(refImages[0], targetLongEdge)
 				input.image_urls = await Promise.all(refImages.slice(0, 4).map(uploadFalImageRef))
 				input.image_size = { width: preparedReference.width, height: preparedReference.height }
 				colorMatchReference = preparedReference.dataUri
 			} else {
-				modelId = FAL_FLUX_KLEIN_9B
+				modelId = FAL_FLUX_KLEIN_9B_BASE
 				input.image_size = dimensionsFromParams(params, targetLongEdge)
 			}
 		} else {


### PR DESCRIPTION
## Summary

- switch fal FLUX.2 Klein 9B back to the Base and Base/Edit endpoints
- set guidance scale to 1
- set inference steps to 5
- disable the fal safety checker
- preserve existing 2K sizing, PNG output, random seed behavior, and optional upstream color matching
- update the focused fal FLUX Klein regression checks

## Validation

- `npm run test:fal-flux-klein`
- `npm run test:bfl-denoise`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `npm run audit:catalog`
- `npm run build`
