### PR TITLE
Fix Legnext single-image result selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
     "test:bfl-denoise": "node scripts/verify-bfl-denoise.mjs",
     "test:fal-flux-klein": "node scripts/verify-fal-flux-klein.mjs",
+    "test:legnext-image-result": "node scripts/verify-legnext-image-result.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
     "test:kling-omni": "node scripts/verify-kling-omni.mjs",

--- a/scripts/verify-legnext-image-result.mjs
+++ b/scripts/verify-legnext-image-result.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import esbuild from 'esbuild'
+
+const tempDir = await mkdtemp(path.join(tmpdir(), 'bragi-legnext-image-result-'))
+const entry = path.join(tempDir, 'entry.ts')
+const outfile = path.join(tempDir, 'legnext-image-result.mjs')
+
+const obsidianStub = {
+	name: 'obsidian-stub',
+	setup(build) {
+		build.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'obsidian-stub' }))
+		build.onLoad({ filter: /.*/, namespace: 'obsidian-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const requestUrl = () => { throw new Error("requestUrl should not be called"); };',
+		}))
+	},
+}
+
+try {
+	await writeFile(entry, `
+		export { selectLegnextImageUrl } from ${JSON.stringify(path.resolve('src/providers/legnext.ts'))}
+	`)
+
+	await esbuild.build({
+		entryPoints: [entry],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile,
+		logLevel: 'silent',
+		plugins: [obsidianStub],
+	})
+
+	const { selectLegnextImageUrl } = await import(pathToFileURL(outfile).href)
+
+	assert.equal(
+		selectLegnextImageUrl({
+			image_url: 'https://cdn.legnext.ai/grid.png',
+			image_urls: [
+				'https://cdn.legnext.ai/image-0.png',
+				'https://cdn.legnext.ai/image-1.png',
+			],
+		}),
+		'https://cdn.legnext.ai/image-0.png',
+		'Legnext must prefer the first individual image over the four-image grid.',
+	)
+
+	assert.equal(
+		selectLegnextImageUrl({ image_url: 'https://cdn.legnext.ai/grid.png' }),
+		'https://cdn.legnext.ai/grid.png',
+		'Legnext must keep the composite image as a backward-compatible fallback.',
+	)
+
+	assert.equal(
+		selectLegnextImageUrl({ image_urls: ['', 'https://cdn.legnext.ai/image-1.png'] }),
+		'https://cdn.legnext.ai/image-1.png',
+		'Legnext must ignore empty individual image URLs.',
+	)
+
+	assert.equal(
+		selectLegnextImageUrl({ image_url: '', image_urls: [] }),
+		undefined,
+		'Legnext must reject empty image results.',
+	)
+
+	console.log('Legnext image result checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/providers/legnext.ts
+++ b/src/providers/legnext.ts
@@ -6,6 +6,23 @@ import { optionalStringParam, stringParam } from './params'
 
 const BASE_URL = 'https://api.legnext.ai/api'
 
+interface LegnextImageOutput {
+	image_url?: unknown
+	image_urls?: unknown
+}
+
+export function selectLegnextImageUrl(output: LegnextImageOutput | null | undefined): string | undefined {
+	// Legnext returns split images in image_urls and the four-image preview grid in image_url.
+	const individualUrl = Array.isArray(output?.image_urls)
+		? output.image_urls.find((url): url is string => typeof url === 'string' && url.length > 0)
+		: undefined
+	if (individualUrl) return individualUrl
+
+	return typeof output?.image_url === 'string' && output.image_url.length > 0
+		? output.image_url
+		: undefined
+}
+
 /**
  * Legnext AI provider for Midjourney image generation.
  * Async: POST /v1/diffusion → poll GET /v1/job/{id} → download image.
@@ -107,7 +124,7 @@ export class LegnextProvider implements ImageProvider {
 
 			const data = response.json
 			if (data.status === 'completed') {
-				const url = data.output?.image_url || data.output?.image_urls?.[0]
+				const url = selectLegnextImageUrl(data.output)
 				if (!url) throw new Error('Legnext: No image URL in completed job')
 				return url
 			}


### PR DESCRIPTION
## What changed

- Prefer Legnext `output.image_urls` individual results over the composite `output.image_url` grid.
- Keep the composite image as a backward-compatible fallback.
- Add a focused regression script covering individual-image priority, fallback behavior, empty entries, and empty responses.

## Why

Legnext returns a four-image preview grid in `image_url` and individual images in `image_urls`. The provider selected `image_url` first, so every Midjourney generation displayed the four-up grid even when individual image URLs were available.

## Impact

Midjourney generations through Legnext now place the first valid individual result on the canvas instead of the composite four-image grid.

## Validation

- `npm run test:legnext-image-result`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `npm run audit:catalog`
- `npm run build`
