### PR TITLE
Add ElevenLabs voice changer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { startEdgeHighlight, stopEdgeHighlight } from './edge-highlight'
 import { startMediaNodeHover, stopMediaNodeHover } from './media-node-hover'
 import { exportCanvas, importCanvas } from './import-export'
 import type { PanelResult } from './panel'
-import type { AudioProvider, VideoProvider } from './providers/types'
+import type { AudioProvider, VideoProvider, VoiceOption } from './providers/types'
 import { BragiMcpServer } from './mcp-server'
 import { checkMigration } from './migrate-assets'
 import { startAttachmentRedirect } from './attachment-redirect'
@@ -34,6 +34,7 @@ import { ensureTokenRouterModelArkAsset, getTokenRouterModelArkCreds } from './t
 import { ensureToken360Asset, getToken360AssetCreds } from './token360-asset-flow'
 import { splitImageNodeIntoTiles } from './grid-split-flow'
 import { isSupportedLanguage, LanguageGateModal } from './ui/language-gate'
+import { VoicePickerModal } from './ui/voice-picker-modal'
 import { installAlwaysNewTab } from './always-new-tab'
 import type { Canvas, CanvasNode } from './types/canvas-internal'
 import type { VoiceSourceMode, RefModality, ModelConfig } from './models/types'
@@ -391,6 +392,7 @@ export default class BragiCanvas extends Plugin {
 				(node) => this.openPanel('audio', node),
 				(node) => { void this.handleSTT(node) },
 				(node) => { void this.handleAudioIsolation(node) },
+				(node) => this.openVoiceChanger(node),
 			(node) => {
 				const result = duplicateWithConnections(getCanvasFromNode(node), node)
 				if (result) this.refreshCanvasRefsAfterMutation(result.canvas)
@@ -1103,6 +1105,75 @@ export default class BragiCanvas extends Plugin {
 		}
 	}
 
+	openVoiceChanger(node: CanvasNode) {
+		if (!this.settings.providers.elevenlabs) {
+			new Notice('Add your provider key in settings to use voice changer')
+			return
+		}
+		const model = getModelById('elevenlabs-tts-v3')
+		if (!model) {
+			new Notice('Voices are not available')
+			return
+		}
+		const voiceParam = model.params.find(param => param.id === 'voice')
+		new VoicePickerModal(this.app, {
+			settings: this.settings,
+			model,
+			activeProvider: 'elevenlabs',
+			catalogProvider: 'elevenlabs',
+			apiModelId: 'eleven_multilingual_sts_v2',
+			staticOptions: voiceParam?.options || [],
+			voiceSource: 'builtin',
+			onSelect: (voice) => {
+				void this.handleVoiceChanger(node, voice)
+			},
+		}).open()
+	}
+
+	/**
+	 * Voice changer: audio file node -> transformed audio file node.
+	 */
+	async handleVoiceChanger(node: CanvasNode, voice: VoiceOption) {
+		const nodeData = node.getData() as unknown
+		const filePath = nodeData.file
+		if (!filePath) return
+
+		const spec = getProvider('elevenlabs')
+		const provider = spec?.makeAudio?.({
+			settings: this.settings,
+			app: this.app,
+			outputDir: this.getOutputDir(),
+		})
+		if (!provider || !providerSupportsVoiceChange(provider)) {
+			new Notice('Voice changer is not available')
+			return
+		}
+
+		const canvas = getCanvasFromNode(node)
+		const placeholder = createPlaceholderNode(canvas, `Changing voice to ${voice.name || 'target voice'}…`, node, computeOutputSize('audio'))
+		new Notice(`Changing voice to ${voice.name || 'target voice'}…`)
+
+		try {
+			const binary = await this.app.vault.adapter.readBinary(filePath)
+			const ext = getFileExtension(filePath, 'mp3')
+			const result = await provider.changeVoice({
+				voiceId: voice.id,
+				modelId: 'eleven_multilingual_sts_v2',
+				audioBytes: binary,
+				filename: `audio.${ext}`,
+				mimeType: audioMimeType(filePath),
+				outputFormat: 'mp3_44100_128',
+			})
+			this.rememberGeneratedAsset(result.filePath)
+			replacePlaceholderWithFile(canvas, placeholder, result.filePath, node)
+			new Notice('Voice changed')
+		} catch (err: unknown) {
+			console.error('Bragi Canvas voice changer error:', err)
+			markNodeFailed(placeholder, err.message || 'Voice changer failed')
+			new Notice(`Voice changer failed: ${err.message}`)
+		}
+	}
+
 	private getNodeAssetIdMap(node: CanvasNode): Record<string, string> {
 		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
 		const ids = { ...(data.bragiAssetIds || {}) }
@@ -1350,6 +1421,10 @@ function isCustomVoiceRecord(value: unknown): value is CustomVoiceRecord {
 
 function providerSupportsVoiceClone(provider: AudioProvider): provider is AudioProvider & { cloneVoice: NonNullable<AudioProvider['cloneVoice']> } {
 	return typeof provider.cloneVoice === 'function'
+}
+
+function providerSupportsVoiceChange(provider: AudioProvider): provider is AudioProvider & { changeVoice: NonNullable<AudioProvider['changeVoice']> } {
+	return typeof provider.changeVoice === 'function'
 }
 
 function providerSupportsVoiceDesign(provider: AudioProvider): provider is AudioProvider & { designVoice: NonNullable<AudioProvider['designVoice']> } {

--- a/src/providers/elevenlabs.ts
+++ b/src/providers/elevenlabs.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- ElevenLabs API responses arrive as runtime-shaped JSON narrowed at use sites. */
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceCloneOptions, VoiceCloneResult, VoiceOption } from './types'
+import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceChangeOptions, VoiceCloneOptions, VoiceCloneResult, VoiceOption } from './types'
 import { optionalStringParam, stringParam } from './params'
 
 const BASE_URL = 'https://api.elevenlabs.io'
@@ -156,6 +156,47 @@ export class ElevenLabsProvider implements AudioProvider {
 				voice.category,
 			].some(value => String(value || '').toLowerCase().includes(query))
 		})
+	}
+
+	async changeVoice(options: VoiceChangeOptions): Promise<GenerateAudioResult> {
+		if (!options.voiceId) throw new Error('ElevenLabs voice changer needs a target voice.')
+		if (!options.audioBytes) throw new Error('ElevenLabs voice changer needs audio bytes from a source file.')
+
+		const modelId = options.modelId || 'eleven_multilingual_sts_v2'
+		const outputFormat = options.outputFormat || DEFAULT_OUTPUT_FORMAT
+		const boundary = '----BragiElevenLabsBoundary' + Math.random().toString(36).slice(2)
+		const parts: Uint8Array[] = []
+
+		appendMultipartFile(
+			parts,
+			boundary,
+			'audio',
+			options.filename || 'audio.mp3',
+			options.mimeType || 'audio/mpeg',
+			new Uint8Array(options.audioBytes),
+		)
+		appendMultipartField(parts, boundary, 'model_id', modelId)
+		if (options.removeBackgroundNoise === true) appendMultipartField(parts, boundary, 'remove_background_noise', 'true')
+		if (typeof options.seed === 'number' && Number.isSafeInteger(options.seed)) {
+			appendMultipartField(parts, boundary, 'seed', String(options.seed))
+		}
+		parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
+
+		const response = await requestUrl({
+			url: `${BASE_URL}/v1/speech-to-speech/${encodeURIComponent(options.voiceId)}?output_format=${encodeURIComponent(outputFormat)}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': `multipart/form-data; boundary=${boundary}`,
+				'xi-api-key': this.apiKey,
+			},
+			body: concatBytes(parts),
+			throw: false,
+		})
+
+		if (response.status === 401 || response.status === 403) throw new Error(`ElevenLabs auth: ${parseErr(response)}`)
+		if (response.status >= 400) throw new Error(`ElevenLabs voice changer: ${parseErr(response)}`)
+
+		return this.saveAudio(response.arrayBuffer, 'voice_change')
 	}
 
 	async cloneVoice(options: VoiceCloneOptions): Promise<VoiceCloneResult> {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -23,6 +23,17 @@ export interface GenerateAudioResult {
 	filePath: string
 }
 
+export interface VoiceChangeOptions {
+	voiceId: string
+	modelId?: string
+	audioBytes: ArrayBuffer
+	filename?: string
+	mimeType?: string
+	outputFormat?: string
+	removeBackgroundNoise?: boolean
+	seed?: number
+}
+
 export interface VoiceOption {
 	id: string
 	name: string
@@ -79,6 +90,7 @@ export interface AudioProvider {
 	name: string
 	generateAudio(prompt: string, options: { mode: 'tts' | 'music' | 'sound-effect', modelId?: string, [k: string]: unknown }): Promise<GenerateAudioResult>
 	listVoices?(options?: ListVoicesOptions): Promise<VoiceOption[]>
+	changeVoice?(options: VoiceChangeOptions): Promise<GenerateAudioResult>
 	cloneVoice?(options: VoiceCloneOptions): Promise<VoiceCloneResult>
 	designVoice?(options: VoiceDesignOptions): Promise<VoiceDesignResult>
 }

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -360,7 +360,7 @@ function clearMenuInjection(menuEl: HTMLElement): void {
 	menuEl.classList.remove('bragi-annotation-menu-split')
 	menuEl.classList.remove('bragi-annotation-menu-inline')
 	menuEl
-		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more, .bragi-actions-separator')
+		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-voice-change, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more, .bragi-actions-separator')
 		.forEach((el) => el.remove())
 
 	for (const btn of getNativeMenuButtons(menuEl)) {
@@ -615,6 +615,7 @@ export function patchCanvasMenu(
 	onGenerateAudio?: (node: CanvasNode) => void,
 	onSTT?: (node: CanvasNode) => void,
 	onIsolateAudio?: (node: CanvasNode) => void,
+	onVoiceChange?: (node: CanvasNode) => void,
 	onDuplicate?: (node: CanvasNode) => void,
 	onBatchGenerate?: (type: 'image' | 'video' | 'text' | 'audio', nodes: CanvasNode[]) => void,
 	onPanorama?: (node: CanvasNode) => void,
@@ -901,6 +902,12 @@ export function patchCanvasMenu(
 						onIsolateAudio(selectedNode)
 					})
 					menuEl.appendChild(isolateBtn)
+				}
+				if (onVoiceChange) {
+					const voiceBtn = createMenuButton('bragi-voice-change', 'audio-lines', 'Voice changer', () => {
+						onVoiceChange(selectedNode)
+					})
+					menuEl.appendChild(voiceBtn)
 				}
 				createMarkButton(menuEl, canvas, selectedNodes)
 				const downloadBtn = createMenuButton('bragi-download', 'bragi-download', 'Download', () => {
@@ -1258,7 +1265,7 @@ export function unpatchCanvasMenu(): void {
 
 export function removeToolbarButtons(): void {
 	activeDocument.querySelectorAll('.bragi-inline-tool-bottom-bar, .bragi-video-edit-bar, .bragi-video-edit-offscreen').forEach(el => el.remove())
-	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-annotate, .bragi-annotation-tool, .bragi-annotation-control, .bragi-annotation-color-button, .bragi-annotation-toolstrip, .bragi-annotation-separator, .bragi-annotation-undo, .bragi-annotation-redo, .bragi-annotation-exit, .bragi-annotation-save, .bragi-video-edit-open, .bragi-video-edit-exit, .bragi-more').forEach(el => {
+	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-voice-change, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-annotate, .bragi-annotation-tool, .bragi-annotation-control, .bragi-annotation-color-button, .bragi-annotation-toolstrip, .bragi-annotation-separator, .bragi-annotation-undo, .bragi-annotation-redo, .bragi-annotation-exit, .bragi-annotation-save, .bragi-video-edit-open, .bragi-video-edit-exit, .bragi-more').forEach(el => {
 		if (el.previousElementSibling?.classList.contains('canvas-menu-separator')) {
 			el.previousElementSibling.remove()
 		}


### PR DESCRIPTION
## Summary

- Adds native ElevenLabs Voice Changer support to the audio provider via `POST /v1/speech-to-speech/:voice_id`.
- Adds a `Voice changer` action to audio file nodes that reuses the existing voice picker, then writes the transformed audio back into the canvas as a generated audio node.
- Extends the audio provider interface with an optional `changeVoice` capability so the interaction stays provider-scoped.

## Notes

- Uses the existing ElevenLabs provider key from settings; no API keys are committed.
- Defaults to `eleven_multilingual_sts_v2` and `mp3_44100_128`, matching ElevenLabs Voice Changer guidance.
- Keeps background noise removal off by default because Bragi already has a separate audio isolation action.

## Validation

- `npm run lint:obsidian`
- `npm run build`
- `npm run check:catalog`
