### PR TITLE
Allow Kling Omni video edits with image references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed Kling 3.0 Omni video editing so native Kling and APIMart requests can combine one base video with reference images.
+- Added payload regression coverage for Kling 3.0 Omni base-video edits with multiple image references.
+
 ## 1.29.2
 
 - Fixed Legnext image result selection so single-image outputs prefer the first individual image instead of the composite preview grid.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -53,8 +53,8 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - APIMart endpoint: `POST https://api.apimart.ai/v1/videos/generations`; task status uses `GET /v1/tasks/{task_id}`.
 - Supported modes are text-to-video, first-frame, first-last-frame, image reference, feature-video reference, and base-video edit.
 - Native Kling uses `image_list` entries with `first_frame` / `end_frame`; APIMart uses `image_with_roles` with `first_frame` / `last_frame`.
-- Reference-image mode adds missing `<<<image_N>>>` tokens so every ordered canvas image participates. Native Kling accepts up to 7 images without a video and 4 with a feature video; APIMart feature-video mode accepts at most one first-frame image.
-- Video reference maps to `video_list.refer_type = feature`; video edit maps to `base`, omits duration/aspect ratio, disables generated audio, and follows the source clip duration.
+- Reference-image mode adds missing `<<<image_N>>>` tokens so every ordered canvas image participates. Native Kling accepts up to 7 images without a video and 4 with either a feature or base video; APIMart feature-video mode accepts at most one first-frame image.
+- Video reference maps to `video_list.refer_type = feature`; video edit maps to `base` and may combine the base video with ordinary reference images (`image_list` on Kling, `image_urls` on APIMart). Video edit adds missing image tokens, omits duration/aspect ratio, disables generated audio, and follows the source clip duration.
 - Duration is an integer from 3 through 15. Quality values are `std`, `pro`, and `4k`. Generated audio is unavailable when `video_list` is present.
 - Keep the generator bar compact: expose duration, ratio, quality, the mode-relevant audio control, and a `Multi shots` / `Single shot` toggle. `Multi shots` is the default and maps to intelligent splitting (`multi_shot = true`, `shot_type = intelligence`). Advanced callers may still pass custom `multi_prompt` shot lists and `element_list` directly.
 

--- a/scripts/verify-kling-omni.mjs
+++ b/scripts/verify-kling-omni.mjs
@@ -70,12 +70,18 @@ try {
 		keep_original_sound: 'yes',
 	}])
 
-	const officialEdit = buildOfficialKlingOmniRequest('Replace the sky', {
+	const officialEdit = buildOfficialKlingOmniRequest('Replace the sky using the references', {
 		genMode: 'video-edit',
+		refImages: ['https://refs/sky.png', 'https://refs/palette.png'],
 		refVideos: ['https://refs/base.mp4'],
 		keep_original_sound: 'yes',
 		duration: 12,
 	})
+	assert.match(officialEdit.prompt, /<<<image_1>>> <<<image_2>>>/)
+	assert.deepEqual(officialEdit.image_list, [
+		{ image_url: 'https://refs/sky.png' },
+		{ image_url: 'https://refs/palette.png' },
+	])
 	assert.equal(officialEdit.duration, undefined)
 	assert.equal(officialEdit.aspect_ratio, undefined)
 	assert.equal(officialEdit.sound, 'off')
@@ -129,10 +135,13 @@ try {
 	assert.equal(apimartAdvanced.multi_prompt.length, 2)
 	assert.equal(apimartAdvanced.element_list.length, 1)
 
-	const apimartEdit = buildApimartKlingOmniRequest('Remove the sign', {
+	const apimartEdit = buildApimartKlingOmniRequest('Replace the sign using the references', {
 		genMode: 'video-edit',
+		refImages: ['https://refs/sign.png', 'https://refs/type.png'],
 		refVideos: ['https://refs/base.mp4'],
 	})
+	assert.match(apimartEdit.prompt, /<<<image_1>>> <<<image_2>>>/)
+	assert.deepEqual(apimartEdit.image_urls, ['https://refs/sign.png', 'https://refs/type.png'])
 	assert.equal(apimartEdit.duration, undefined)
 	assert.equal(apimartEdit.audio, undefined)
 	assert.deepEqual(apimartEdit.video_list, [{

--- a/src/providers/kling-omni-payload.ts
+++ b/src/providers/kling-omni-payload.ts
@@ -73,9 +73,6 @@ function validateInputs(genMode: string, refImages: string[], refVideos: string[
 	if ((genMode === 'video-ref' || genMode === 'video-edit') && refVideos.length !== 1) {
 		throw new Error(`${provider} Kling Omni ${genMode} mode requires exactly one reference video.`)
 	}
-	if (genMode === 'video-edit' && refImages.length > 0) {
-		throw new Error(`${provider} Kling Omni video edit cannot be combined with image references.`)
-	}
 	if (!['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'multi-image-ref', 'video-ref', 'video-edit'].includes(genMode)) {
 		throw new Error(`${provider} Kling Omni does not support ${genMode} mode.`)
 	}
@@ -146,6 +143,10 @@ export function buildOfficialKlingOmniRequest(prompt: string, params: JsonObject
 			refer_type: 'base',
 			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
 		}]
+		if (refImages.length > 0) {
+			body.image_list = refImages.map(imageUrl => ({ image_url: imageUrl }))
+			finalPrompt = withMissingReferences(finalPrompt, 'image', refImages.length)
+		}
 	}
 
 	body.prompt = finalPrompt
@@ -202,6 +203,10 @@ export function buildApimartKlingOmniRequest(prompt: string, params: JsonObject 
 			refer_type: 'base',
 			keep_original_sound: stringValue(params.keep_original_sound, 'no'),
 		}]
+		if (refImages.length > 0) {
+			body.image_urls = refImages
+			finalPrompt = withMissingReferences(finalPrompt, 'image', refImages.length)
+		}
 	}
 
 	body.prompt = finalPrompt


### PR DESCRIPTION
## What changed

- Allow Kling 3.0 Omni `video-edit` to accept one base video plus reference images.
- Send images as `image_list` for native Kling and `image_urls` for APIMart.
- Add missing `<<<image_N>>>` prompt references automatically.
- Add regression coverage for both provider request shapes.

## Why

Bragi had an incorrect shared validation rule that rejected reference images during base-video editing. The Kling and APIMart contracts only make base-video editing mutually exclusive with first/last-frame inputs, not ordinary reference images.

Paired skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/44

## Validation

- `npm run test:kling-omni`
- `npm run build`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `npm run audit:catalog`
- `git diff --check`
- Monorepo sync check: `Bragi sync check passed (1.29.2, 27 MCP tools).`