### PR TITLE
Add ElevenLabs Voice Changer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added ElevenLabs Voice Changer for audio nodes using `eleven_multilingual_sts_v2`: the selected audio supplies content and emotion, one incoming audio supplies the target voice, and every click creates an independent parallel output node.
+- Reused cached ElevenLabs custom voices across TTS and Voice Changer, with in-flight clone deduplication for parallel conversions.
 - Fixed Kling 3.0 Omni video editing so native Kling and APIMart requests can combine one base video with reference images.
 - Added payload regression coverage for Kling 3.0 Omni base-video edits with multiple image references.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You can also manually copy `manifest.json`, `main.js`, and `styles.css` from the
 
 Incoming directed edges are treated as upstream references. Text nodes contribute prompt text, image nodes become image references, video nodes can be used for supported video workflows and Gemini text understanding, and audio or PDF nodes can be used by multimodal text models such as Gemini 3.5 Flash.
 
+On an audio file node, **Voice Changer** uses the selected audio for content, timing, and emotion, and exactly one incoming audio node as the target voice reference. The action requires a configured ElevenLabs provider and creates a new audio node for every click, so multiple conversions can run in parallel.
+
 ## MCP server
 
 The MCP server is disabled by default. When enabled in settings, it listens on `127.0.0.1` and exposes canvas operations to local MCP clients. You can configure the port and an optional access token. If a token is set, clients must send `Authorization: Bearer <token>` on every request.
@@ -69,6 +71,8 @@ No provider API keys are bundled with the plugin or included in release assets.
 ## Network and data disclosure
 
 Bragi Canvas sends prompts and selected upstream reference files to the AI providers configured by the user when a generation is run. Some providers require publicly fetchable reference URLs; for those workflows, Bragi Canvas may upload temporary copies of selected reference files to the built-in Bragi Relay service so the provider can fetch them. Gemini multimodal text generation uses inline image data, and sends upstream video, audio, and PDF refs through Bragi Relay as `fileData.fileUri` inputs. Relay-hosted files are intended as temporary transfer files and are not used for client-side telemetry.
+
+ElevenLabs Voice Changer sends the selected source audio directly to ElevenLabs. Its incoming target-voice audio may be sent once to create a reusable custom ElevenLabs voice; Bragi Canvas stores the returned voice ID in canvas node metadata and reuses it for later conversions.
 
 When a canvas is opened or activated, Bragi Canvas may check the latest public GitHub release for this plugin to show an update reminder. This request does not include vault contents, prompts, provider credentials, or user analytics data.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:kling-omni": "node scripts/verify-kling-omni.mjs",
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
+    "test:elevenlabs-voice-changer": "node scripts/verify-elevenlabs-voice-changer.mjs",
     "test:byteplus-asset-error-reason": "node scripts/verify-byteplus-asset-error-reason.mjs",
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
     "test:svnewapi-video-params": "node scripts/verify-svnewapi-video-params.mjs",

--- a/scripts/verify-elevenlabs-voice-changer.mjs
+++ b/scripts/verify-elevenlabs-voice-changer.mjs
@@ -1,0 +1,178 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import assert from 'node:assert/strict'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const mainSource = readFileSync('src/main.ts', 'utf8')
+const providerSource = readFileSync('src/providers/elevenlabs.ts', 'utf8')
+const providerTypesSource = readFileSync('src/providers/types.ts', 'utf8')
+const toolbarSource = readFileSync('src/toolbar.ts', 'utf8')
+const stylesSource = readFileSync('src/styles.css', 'utf8')
+const voiceChangerHandler = mainSource.match(/async handleVoiceChanger\(node: CanvasNode\): Promise<void> \{[\s\S]*?\n\t\}\n\n\t\/\*\*\n\t \* Speech to Text/)?.[0] || ''
+
+function assertOrder(source, first, second, message) {
+	const firstIndex = source.indexOf(first)
+	const secondIndex = source.indexOf(second)
+	assert.notEqual(firstIndex, -1, `${message}: missing "${first}"`)
+	assert.notEqual(secondIndex, -1, `${message}: missing "${second}"`)
+	assert.ok(firstIndex < secondIndex, message)
+}
+
+assert.match(
+	providerTypesSource,
+	/export interface VoiceChangeOptions \{[\s\S]*voiceId: string[\s\S]*audioBytes: ArrayBuffer[\s\S]*\}/,
+	'Audio provider types must describe the source audio and target voice ID.',
+)
+assert.match(
+	providerTypesSource,
+	/changeVoice\?\(options: VoiceChangeOptions\): Promise<GenerateAudioResult>/,
+	'Audio providers must expose Voice Changer as a capability instead of a text-to-audio mode.',
+)
+assert.match(
+	providerSource,
+	/async changeVoice\(options: VoiceChangeOptions\)[\s\S]*'audio'[\s\S]*appendMultipartField\(parts, boundary, 'model_id', modelId\)/,
+	'ElevenLabs Voice Changer must send the selected source audio and speech-to-speech model as multipart fields.',
+)
+assert.match(
+	providerSource,
+	/modelId = options\.modelId \|\| 'eleven_multilingual_sts_v2'/,
+	'ElevenLabs Voice Changer must default to the multilingual speech-to-speech model.',
+)
+assert.match(
+	providerSource,
+	/\/v1\/speech-to-speech\/\$\{encodeURIComponent\(options\.voiceId\)\}\?output_format=/,
+	'ElevenLabs Voice Changer must address the target voice ID in the speech-to-speech endpoint.',
+)
+assert.match(
+	providerSource,
+	/return this\.saveAudio\(response\.arrayBuffer, 'voice_changer'\)/,
+	'Voice Changer responses must be saved as new local audio files.',
+)
+
+assert.match(
+	toolbarSource,
+	/onVoiceChanger\?: \(node: CanvasNode\) => void,[\s\S]*canVoiceChanger\?: \(node: CanvasNode\) => boolean/,
+	'The audio toolbar must accept a Voice Changer action and dynamic availability predicate.',
+)
+assert.match(
+	toolbarSource,
+	/enabled \? 'Voice Changer' : 'Requires ElevenLabs and 1 incoming audio'/,
+	'The toolbar must use the approved active and disabled tooltip copy.',
+)
+assert.match(
+	toolbarSource,
+	/if \(!enabled\) \{[\s\S]*classList\.add\('is-disabled'\)[\s\S]*aria-disabled/,
+	'The unavailable Voice Changer action must remain visible but disabled.',
+)
+assert.match(
+	stylesSource,
+	/\.bragi-voice-changer\.is-disabled[\s\S]*cursor: not-allowed/,
+	'The disabled Voice Changer button must retain hover support for its requirement tooltip.',
+)
+
+assert.match(
+	mainSource,
+	/private canVoiceChanger\(node: CanvasNode\): boolean \{\s*if \(!this\.settings\.providers\.elevenlabs\) return false\s*return getUpstreamInputs\(getCanvasFromNode\(node\), node\)\.audios\.length === 1\s*\}/,
+	'Voice Changer must require ElevenLabs and exactly one directed incoming audio reference.',
+)
+assert.match(
+	mainSource,
+	/createPlaceholderNode\(canvas, 'Voice Changer', node, computeOutputSize\('audio'\)\)/,
+	'Every click must immediately create a normal audio generation placeholder from the selected source node.',
+)
+assertOrder(
+	voiceChangerHandler,
+	"createPlaceholderNode(canvas, 'Voice Changer', node, computeOutputSize('audio'))",
+	'await applyUpstreamVoiceReference(',
+	'The output placeholder must exist before voice cloning or conversion begins.',
+)
+assert.match(
+	voiceChangerHandler,
+	/applyUpstreamVoiceReference\([\s\S]*incomingAudios,[\s\S]*provider\.changeVoice\([\s\S]*audioBytes: sourceBytes/,
+	'The incoming audio must supply the target voice while the selected node supplies the converted source audio.',
+)
+assert.match(
+	voiceChangerHandler,
+	/replacePlaceholderWithFile\(canvas, placeholder, result\.filePath, node\)/,
+	'Each Voice Changer call must replace its own right-side placeholder with a new audio node.',
+)
+assert.match(
+	mainSource,
+	/const voiceCloneInFlight = new Map<string, Promise<VoiceCloneResult>>\(\)[\s\S]*voiceCloneInFlight\.get\(cloneKey\)[\s\S]*voiceCloneInFlight\.set\(cloneKey, clonePromise\)/,
+	'Parallel conversions must share an in-flight target voice clone without serializing the conversions themselves.',
+)
+assert.doesNotMatch(
+	mainSource,
+	/(voiceChangerInFlight|isChangingVoice|changingVoiceNodes)/,
+	'Voice Changer must not add a processing lock that prevents parallel clicks.',
+)
+
+const tempDir = mkdtempSync(join(tmpdir(), 'bragi-elevenlabs-voice-changer-'))
+const bundledProvider = join(tempDir, 'elevenlabs-provider.mjs')
+try {
+	await build({
+		entryPoints: ['src/providers/elevenlabs.ts'],
+		outfile: bundledProvider,
+		bundle: true,
+		format: 'esm',
+		platform: 'node',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export async function requestUrl(options) {
+							process.__bragiElevenLabsRequest = options
+							return { status: 200, arrayBuffer: new Uint8Array([9, 8, 7]).buffer }
+						}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const { ElevenLabsProvider } = await import(pathToFileURL(bundledProvider).href)
+	const writes = []
+	const app = {
+		vault: {
+			adapter: {
+				exists: async () => true,
+				mkdir: async () => {},
+				writeBinary: async (path, data) => writes.push({ path, data }),
+			},
+		},
+	}
+	const provider = new ElevenLabsProvider('test-key', app, '_bragi/assets')
+	const result = await provider.changeVoice({
+		voiceId: 'target/voice',
+		modelId: 'eleven_multilingual_sts_v2',
+		audioBytes: new Uint8Array([1, 2, 3, 4]).buffer,
+		filename: 'source.wav',
+		mimeType: 'audio/wav',
+	})
+	const request = process.__bragiElevenLabsRequest
+	assert.equal(request.method, 'POST', 'Voice Changer must use POST.')
+	assert.equal(
+		request.url,
+		'https://api.elevenlabs.io/v1/speech-to-speech/target%2Fvoice?output_format=mp3_44100_128',
+		'Voice Changer must encode the target voice ID and request the default MP3 output.',
+	)
+	assert.equal(request.headers['xi-api-key'], 'test-key', 'Voice Changer must authenticate with the configured ElevenLabs key.')
+	assert.match(request.headers['Content-Type'], /^multipart\/form-data; boundary=/, 'Voice Changer must send multipart audio.')
+	const multipart = Buffer.from(request.body).toString('latin1')
+	assert.match(multipart, /name="audio"; filename="source\.wav"\r\nContent-Type: audio\/wav/, 'Multipart audio must preserve the source filename and MIME type.')
+	assert.match(multipart, /name="model_id"\r\n\r\neleven_multilingual_sts_v2/, 'Multipart audio must include the multilingual speech-to-speech model.')
+	assert.equal(writes.length, 1, 'A successful response must write exactly one output file.')
+	assert.match(writes[0].path, /^_bragi\/assets\/voice_changer_\d+\.mp3$/, 'The output must be a new Voice Changer MP3 asset.')
+	assert.deepEqual([...new Uint8Array(writes[0].data)], [9, 8, 7], 'The provider must save the binary ElevenLabs response unchanged.')
+	assert.equal(result.filePath, writes[0].path, 'The provider result must point to the saved output asset.')
+} finally {
+	delete process.__bragiElevenLabsRequest
+	rmSync(tempDir, { recursive: true, force: true })
+}
+
+console.log('ElevenLabs Voice Changer checks passed.')

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ import { startEdgeHighlight, stopEdgeHighlight } from './edge-highlight'
 import { startMediaNodeHover, stopMediaNodeHover } from './media-node-hover'
 import { exportCanvas, importCanvas } from './import-export'
 import type { PanelResult } from './panel'
-import type { AudioProvider, VideoProvider } from './providers/types'
+import type { AudioProvider, VideoProvider, VoiceCloneResult } from './providers/types'
 import { BragiMcpServer } from './mcp-server'
 import { checkMigration } from './migrate-assets'
 import { startAttachmentRedirect } from './attachment-redirect'
@@ -52,6 +52,8 @@ const SEEDANCE_ASSET_PROVIDER_LABELS: Record<SeedanceAssetProviderId, string> = 
 	byteplus: 'BytePlus',
 	bytedance: 'Volcengine',
 }
+
+const ELEVENLABS_VOICE_CHANGER_MODEL_ID = 'eleven_multilingual_sts_v2'
 
 export default class BragiCanvas extends Plugin {
 	settings: BragiSettings = DEFAULT_SETTINGS
@@ -389,6 +391,8 @@ export default class BragiCanvas extends Plugin {
 				(node) => this.openPanel('video', node),
 				(node) => this.openPanel('text', node),
 				(node) => this.openPanel('audio', node),
+				(node) => { void this.handleVoiceChanger(node) },
+				(node) => this.canVoiceChanger(node),
 				(node) => { void this.handleSTT(node) },
 				(node) => { void this.handleAudioIsolation(node) },
 			(node) => {
@@ -559,6 +563,11 @@ export default class BragiCanvas extends Plugin {
 	private async readImageDataUri(filePath: string): Promise<string> {
 		const binary = await this.app.vault.adapter.readBinary(filePath)
 		return `data:${imageMimeType(filePath)};base64,${arrayBufferToBase64(binary)}`
+	}
+
+	private canVoiceChanger(node: CanvasNode): boolean {
+		if (!this.settings.providers.elevenlabs) return false
+		return getUpstreamInputs(getCanvasFromNode(node), node).audios.length === 1
 	}
 
 	// ── Generation logic ────────────────────────────────────────
@@ -972,6 +981,83 @@ export default class BragiCanvas extends Plugin {
 	}
 
 	/**
+	 * Voice Changer: selected audio supplies content/timing; exactly one incoming
+	 * audio supplies the target voice reference.
+	 */
+	async handleVoiceChanger(node: CanvasNode): Promise<void> {
+		const canvas = getCanvasFromNode(node)
+		const incomingAudios = getUpstreamInputs(canvas, node).audios
+		if (!this.settings.providers.elevenlabs || incomingAudios.length !== 1) {
+			// eslint-disable-next-line obsidianmd/ui/sentence-case -- Approved requirement copy preserves the ElevenLabs brand name.
+			new Notice('Requires ElevenLabs and 1 incoming audio')
+			return
+		}
+
+		const nodeData = node.getData() as { file?: string }
+		const sourcePath = nodeData.file || ''
+		if (!sourcePath) {
+			new Notice('Voice changer could not find the source audio file')
+			return
+		}
+
+		const spec = getProvider('elevenlabs')
+		const provider = spec?.makeAudio?.({
+			settings: this.settings,
+			app: this.app,
+			outputDir: this.getOutputDir(),
+		})
+		if (!provider || !providerSupportsVoiceChange(provider)) {
+			// eslint-disable-next-line obsidianmd/ui/sentence-case -- Preserve the ElevenLabs brand name.
+			new Notice('ElevenLabs voice changer is not available')
+			return
+		}
+
+		const placeholder = createPlaceholderNode(canvas, 'Voice Changer', node, computeOutputSize('audio'))
+		this.syncGenerating.add(placeholder.id)
+
+		try {
+			const voiceParams: Record<string, unknown> = {}
+			const voiceRecord = await applyUpstreamVoiceReference(
+				this.app,
+				canvas,
+				provider,
+				'elevenlabs',
+				this.settings,
+				ELEVENLABS_VOICE_CHANGER_MODEL_ID,
+				incomingAudios,
+				0,
+				voiceParams,
+			)
+			const voiceId = typeof voiceParams.voice === 'string' ? voiceParams.voice : voiceRecord.voiceId
+			const sourceBytes = await this.app.vault.adapter.readBinary(sourcePath)
+			const extension = getFileExtension(sourcePath, 'mp3')
+			const result = await provider.changeVoice({
+				voiceId,
+				modelId: ELEVENLABS_VOICE_CHANGER_MODEL_ID,
+				audioBytes: sourceBytes,
+				filename: `source.${extension}`,
+				mimeType: audioMimeType(sourcePath),
+			})
+
+			this.rememberGeneratedAsset(result.filePath)
+			replacePlaceholderWithFile(canvas, placeholder, result.filePath, node)
+			const outputNode = findFileNodeByPath(canvas, result.filePath)
+			if (outputNode) {
+				upsertCustomVoiceRecord(outputNode, await customVoiceRecordForOutput(this.app, result.filePath, voiceRecord))
+				await canvas.requestSave?.()
+			}
+			new Notice('Voice changed')
+		} catch (err: unknown) {
+			console.error('Bragi Canvas Voice Changer error:', err)
+			const message = err instanceof Error ? err.message : String(err)
+			markNodeFailed(placeholder, message || 'Voice Changer failed')
+			new Notice(`Voice Changer failed: ${message}`)
+		} finally {
+			this.syncGenerating.delete(placeholder.id)
+		}
+	}
+
+	/**
 	 * Speech to Text: audio file node → text node
 	 */
 	async handleSTT(node: CanvasNode) {
@@ -1356,6 +1442,10 @@ function providerSupportsVoiceDesign(provider: AudioProvider): provider is Audio
 	return typeof provider.designVoice === 'function'
 }
 
+function providerSupportsVoiceChange(provider: AudioProvider): provider is AudioProvider & { changeVoice: NonNullable<AudioProvider['changeVoice']> } {
+	return typeof provider.changeVoice === 'function'
+}
+
 function findFileNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
 	for (const node of canvas.nodes.values()) {
 		const data = node.getData() as Record<string, unknown>
@@ -1422,10 +1512,12 @@ function reusableVoiceRecord(
 		record.kind === 'clone'
 		&& record.provider === activeProvider
 		&& record.region === region
-		&& record.modelId === modelId
+		&& (activeProvider === 'elevenlabs' || record.modelId === modelId)
 		&& record.sourceHash === sourceHash
 	) || null
 }
+
+const voiceCloneInFlight = new Map<string, Promise<VoiceCloneResult>>()
 
 async function customVoiceRecordForOutput(
 	app: BragiCanvas['app'],
@@ -1480,22 +1572,41 @@ async function applyUpstreamVoiceReference(
 		return existing
 	}
 
-	new Notice('Creating voice reference...')
-	const ext = getFileExtension(sourcePath, 'mp3')
-	const mimeType = audioMimeType(sourcePath)
-	const filename = `voice.${ext}`
-	const audioUrl = activeProvider === 'dashscope'
-		? await uploadRef(undefined, binary, filename, mimeType)
-		: undefined
-	const clone = await provider.cloneVoice({
-		modelId,
-		audioUrl,
-		audioBytes: binary,
-		filename,
-		mimeType,
+	const cloneKey = [
+		activeProvider,
+		region,
+		activeProvider === 'elevenlabs' ? 'global-voice' : modelId,
 		sourceHash,
-		sourcePath,
-	})
+	].join(':')
+	let clonePromise = voiceCloneInFlight.get(cloneKey)
+	if (!clonePromise) {
+		new Notice('Creating voice reference...')
+		clonePromise = (async () => {
+			const ext = getFileExtension(sourcePath, 'mp3')
+			const mimeType = audioMimeType(sourcePath)
+			const filename = `voice.${ext}`
+			const audioUrl = activeProvider === 'dashscope'
+				? await uploadRef(undefined, binary, filename, mimeType)
+				: undefined
+			return provider.cloneVoice({
+				modelId,
+				audioUrl,
+				audioBytes: binary,
+				filename,
+				mimeType,
+				sourceHash,
+				sourcePath,
+			})
+		})()
+		voiceCloneInFlight.set(cloneKey, clonePromise)
+	}
+
+	let clone: VoiceCloneResult
+	try {
+		clone = await clonePromise
+	} finally {
+		if (voiceCloneInFlight.get(cloneKey) === clonePromise) voiceCloneInFlight.delete(cloneKey)
+	}
 
 	const record: CustomVoiceRecord = {
 		kind: 'clone',

--- a/src/providers/elevenlabs.ts
+++ b/src/providers/elevenlabs.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- ElevenLabs API responses arrive as runtime-shaped JSON narrowed at use sites. */
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceCloneOptions, VoiceCloneResult, VoiceOption } from './types'
+import type { AudioProvider, GenerateAudioResult, ListVoicesOptions, VoiceChangeOptions, VoiceCloneOptions, VoiceCloneResult, VoiceOption } from './types'
 import { optionalStringParam, stringParam } from './params'
 
 const BASE_URL = 'https://api.elevenlabs.io'
@@ -203,6 +203,53 @@ export class ElevenLabsProvider implements AudioProvider {
 			name: voiceName,
 			requiresVerification: typeof payload.requires_verification === 'boolean' ? payload.requires_verification : undefined,
 		}
+	}
+
+	/**
+	 * Voice Changer: POST /v1/speech-to-speech/{voice_id}
+	 * The source audio supplies content, timing, and emotion; voice_id supplies
+	 * the target voice created from the incoming reference audio.
+	 */
+	async changeVoice(options: VoiceChangeOptions): Promise<GenerateAudioResult> {
+		if (!options.audioBytes) {
+			throw new Error('ElevenLabs Voice Changer needs source audio bytes.')
+		}
+
+		const modelId = options.modelId || 'eleven_multilingual_sts_v2'
+		const outputFormat = options.outputFormat || DEFAULT_OUTPUT_FORMAT
+		const boundary = '----BragiElevenLabsBoundary' + Math.random().toString(36).slice(2)
+		const parts: Uint8Array[] = []
+
+		appendMultipartFile(
+			parts,
+			boundary,
+			'audio',
+			options.filename || 'source.mp3',
+			options.mimeType || 'audio/mpeg',
+			new Uint8Array(options.audioBytes),
+		)
+		appendMultipartField(parts, boundary, 'model_id', modelId)
+		parts.push(new TextEncoder().encode(`--${boundary}--\r\n`))
+
+		const response = await requestUrl({
+			url: `${BASE_URL}/v1/speech-to-speech/${encodeURIComponent(options.voiceId)}?output_format=${encodeURIComponent(outputFormat)}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': `multipart/form-data; boundary=${boundary}`,
+				'xi-api-key': this.apiKey,
+			},
+			body: concatBytes(parts),
+			throw: false,
+		})
+
+		if (response.status === 401 || response.status === 403) {
+			throw new Error(`ElevenLabs Voice Changer auth: ${parseErr(response)}`)
+		}
+		if (response.status >= 400) {
+			throw new Error(`ElevenLabs Voice Changer: ${parseErr(response)}`)
+		}
+
+		return this.saveAudio(response.arrayBuffer, 'voice_changer')
 	}
 
 	/**

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -75,10 +75,20 @@ export interface VoiceDesignResult {
 	previewUrl?: string
 }
 
+export interface VoiceChangeOptions {
+	voiceId: string
+	modelId?: string
+	audioBytes: ArrayBuffer
+	filename?: string
+	mimeType?: string
+	outputFormat?: string
+}
+
 export interface AudioProvider {
 	name: string
 	generateAudio(prompt: string, options: { mode: 'tts' | 'music' | 'sound-effect', modelId?: string, [k: string]: unknown }): Promise<GenerateAudioResult>
 	listVoices?(options?: ListVoicesOptions): Promise<VoiceOption[]>
 	cloneVoice?(options: VoiceCloneOptions): Promise<VoiceCloneResult>
 	designVoice?(options: VoiceDesignOptions): Promise<VoiceDesignResult>
+	changeVoice?(options: VoiceChangeOptions): Promise<GenerateAudioResult>
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -636,6 +636,17 @@
 	--icon-size: 20px;
 }
 
+.bragi-canvas-menu .bragi-voice-changer.is-disabled {
+	opacity: 0.35;
+	cursor: not-allowed;
+}
+
+.bragi-canvas-menu .bragi-voice-changer.is-disabled:hover,
+.bragi-canvas-menu .bragi-voice-changer.is-disabled:active {
+	background: transparent;
+	color: var(--bragi-text);
+}
+
 .bragi-canvas-menu .bragi-labeled-menu-button {
 	display: inline-flex;
 	align-items: center;

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -360,7 +360,7 @@ function clearMenuInjection(menuEl: HTMLElement): void {
 	menuEl.classList.remove('bragi-annotation-menu-split')
 	menuEl.classList.remove('bragi-annotation-menu-inline')
 	menuEl
-		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more, .bragi-actions-separator')
+		.querySelectorAll('.bragi-menu-injected, .bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-voice-changer, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-more, .bragi-actions-separator')
 		.forEach((el) => el.remove())
 
 	for (const btn of getNativeMenuButtons(menuEl)) {
@@ -613,6 +613,8 @@ export function patchCanvasMenu(
 	onGenerateVideo: (node: CanvasNode) => void,
 	onGenerateText?: (node: CanvasNode) => void,
 	onGenerateAudio?: (node: CanvasNode) => void,
+	onVoiceChanger?: (node: CanvasNode) => void,
+	canVoiceChanger?: (node: CanvasNode) => boolean,
 	onSTT?: (node: CanvasNode) => void,
 	onIsolateAudio?: (node: CanvasNode) => void,
 	onDuplicate?: (node: CanvasNode) => void,
@@ -890,6 +892,22 @@ export function patchCanvasMenu(
 			}
 
 			if (isAudioNode) {
+				if (onVoiceChanger) {
+					const enabled = canVoiceChanger?.(selectedNode) ?? true
+					const voiceChangerBtn = createMenuButton(
+						'bragi-voice-changer',
+						'bragi-gen-audio',
+						enabled ? 'Voice Changer' : 'Requires ElevenLabs and 1 incoming audio',
+						() => {
+							if (enabled) onVoiceChanger(selectedNode)
+						},
+					)
+					if (!enabled) {
+						voiceChangerBtn.classList.add('is-disabled')
+						voiceChangerBtn.setAttribute('aria-disabled', 'true')
+					}
+					menuEl.appendChild(voiceChangerBtn)
+				}
 				if (onSTT) {
 					const sttBtn = createMenuButton('bragi-stt', 'bragi-stt', 'Speech to text', () => {
 						onSTT(selectedNode)
@@ -1258,7 +1276,7 @@ export function unpatchCanvasMenu(): void {
 
 export function removeToolbarButtons(): void {
 	activeDocument.querySelectorAll('.bragi-inline-tool-bottom-bar, .bragi-video-edit-bar, .bragi-video-edit-offscreen').forEach(el => el.remove())
-	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-annotate, .bragi-annotation-tool, .bragi-annotation-control, .bragi-annotation-color-button, .bragi-annotation-toolstrip, .bragi-annotation-separator, .bragi-annotation-undo, .bragi-annotation-redo, .bragi-annotation-exit, .bragi-annotation-save, .bragi-video-edit-open, .bragi-video-edit-exit, .bragi-more').forEach(el => {
+	activeDocument.querySelectorAll('.bragi-gen-image, .bragi-gen-video, .bragi-gen-text, .bragi-gen-audio, .bragi-voice-changer, .bragi-stt, .bragi-isolate, .bragi-denoise, .bragi-download, .bragi-asset-btn, .bragi-duplicate, .bragi-pin, .bragi-pano, .bragi-split, .bragi-grid, .bragi-compose, .bragi-annotate, .bragi-annotation-tool, .bragi-annotation-control, .bragi-annotation-color-button, .bragi-annotation-toolstrip, .bragi-annotation-separator, .bragi-annotation-undo, .bragi-annotation-redo, .bragi-annotation-exit, .bragi-annotation-save, .bragi-video-edit-open, .bragi-video-edit-exit, .bragi-more').forEach(el => {
 		if (el.previousElementSibling?.classList.contains('canvas-menu-separator')) {
 			el.previousElementSibling.remove()
 		}

--- a/styles.css
+++ b/styles.css
@@ -636,6 +636,17 @@
 	--icon-size: 20px;
 }
 
+.bragi-canvas-menu .bragi-voice-changer.is-disabled {
+	opacity: 0.35;
+	cursor: not-allowed;
+}
+
+.bragi-canvas-menu .bragi-voice-changer.is-disabled:hover,
+.bragi-canvas-menu .bragi-voice-changer.is-disabled:active {
+	background: transparent;
+	color: var(--bragi-text);
+}
+
 .bragi-canvas-menu .bragi-labeled-menu-button {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
## What changed

- Add an ElevenLabs Voice Changer action to audio-node toolbars.
- Use the selected audio for content, timing, and emotion and exactly one incoming audio node as the target voice reference.
- Call ElevenLabs Speech-to-Speech with `eleven_multilingual_sts_v2` and save each response as a new right-side audio node.
- Keep the toolbar action available during generation; parallel clicks create independent outputs while sharing an in-flight voice clone.
- Show `Requires ElevenLabs and 1 incoming audio` when the action is unavailable.

## Why

ElevenLabs Speech-to-Speech is an audio-to-audio capability rather than a text-to-audio model, so it needs a dedicated audio-node interaction instead of the normal generation panel.

## Paired documentation

- nextbound/bragi-canvas-skill#45

## Validation

- `npm run build`
- `npm run lint:obsidian`
- `npm run test:elevenlabs-voice-changer`
- `npm run check:catalog`
- `git diff --check`
- Cross-repository `sync-check.mjs` (1.29.2, 27 MCP tools)
- Live ElevenLabs test: two concurrent Speech-to-Speech requests returned HTTP 200 with independent MP3 outputs.
- Live Obsidian UI test: active and disabled labels verified; two clicks created and completed two separate right-side audio nodes.
