### PR TITLE
feat: add Pika Kling provider

### DIFF
--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -58,6 +58,16 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Duration is an integer from 3 through 15. Quality values are `std`, `pro`, and `4k`. Generated audio is unavailable when `video_list` is present.
 - Keep the generator bar compact: expose duration, ratio, quality, the mode-relevant audio control, and a `Multi shots` / `Single shot` toggle. `Multi shots` is the default and maps to intelligent splitting (`multi_shot = true`, `shot_type = intelligence`). Advanced callers may still pass custom `multi_prompt` shot lists and `element_list` directly.
 
+## Pika Kling
+
+- Base URL: `https://api.dev.pika.art`. Authenticate every request with the configured Pika key in the `X-API-Key` header.
+- Bragi Kling 3.0 maps to Pika `kling-v3`. Text-to-video and first-frame generation route through `/v1/media/kling/kling-v3/{quality}/text-to-video` and `/v1/media/kling/kling-v3/{quality}/image-to-video`; motion control uses `/v1/media/kling/kling-v3/motion-control`.
+- Kling 3.0 quality values map `std` to Pika `standard` and preserve `pro` and `4k`. Pika does not expose Kling 3.0 first-last-frame generation.
+- Bragi Kling 3.0 Omni maps only its first-frame mode to Pika `kling-o3` at `/v1/media/kling/kling-o3/image-to-video`. Hide the native Omni quality and multi-shot controls for this provider.
+- Send Pika reference images and videos as Bragi temporary Relay HTTPS URLs.
+- Poll all submitted tasks through `GET /v1/media/jobs/{id}`. On completion, use `output.video.url`, falling back to `GET /v1/media/jobs/{id}/content` when the status payload omits the content URL.
+- Do not add Pika Kling O1 or map it to an existing Bragi model: Pika exposes it only as video-to-video and Bragi has no exact catalogue match. Pika also has no exact Kling 2.6 mapping.
+
 ## SuChuang Gemini Omni
 
 - Endpoint: `POST https://api.wuyinkeji.com/api/async/video_google_omni`.

--- a/docs/superpowers/plans/2026-07-28-pika-provider.md
+++ b/docs/superpowers/plans/2026-07-28-pika-provider.md
@@ -1,0 +1,455 @@
+# Pika Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Pika as a configured video provider for Bragi's existing Kling 3.0 and Kling 3.0 Omni models, with exact mode restrictions and no Kling O1 catalogue entry.
+
+**Architecture:** A focused `PikaVideoProvider` owns Pika request routing, validation, polling, and downloads behind Bragi's existing `VideoProvider` interface. Catalogue data restricts Pika to the exact model/mode matches, while registry and settings changes expose one API-key field and preserve opt-in model connections.
+
+**Tech Stack:** TypeScript 5.8, Obsidian `requestUrl`, esbuild, Node assertion-based verification scripts, existing Bragi catalogue and settings migration helpers.
+
+## Global Constraints
+
+- Do not add a Kling O1 model or map Pika Kling O1 to Kling 3.0 Omni.
+- Pika supports Kling 3.0 modes `text-to-video`, `first-frame`, and `motion-control`; it does not support `first-last-frame`.
+- Pika Kling O3 maps only to Bragi Kling 3.0 Omni `first-frame`.
+- Pika reference images and videos use Bragi Relay HTTPS URLs.
+- Newly supported provider/model pairs remain disabled until the user explicitly connects them.
+- Never store or log the supplied Pika API key, temporary URLs, or live-test media.
+- Use sentence case for all user-visible copy.
+- Run `npm run lint:obsidian`, `npm run build`, catalogue checks, and `git diff --check` before the PR.
+
+---
+
+### Task 1: Pika request routing and async provider lifecycle
+
+**Files:**
+- Create: `src/providers/pika.ts`
+- Create: `scripts/verify-pika-provider.mjs`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `VideoProvider`, `GenerateVideoResult`, Obsidian `App`, and `requestUrl`.
+- Produces: `buildPikaVideoRequest(prompt: string, params?: Record<string, unknown>): { path: string; body: Record<string, unknown> }`, `PikaVideoProvider`, and `testPikaConnection(apiKey: string)`.
+
+- [ ] **Step 1: Write the failing payload and lifecycle verification**
+
+Create `scripts/verify-pika-provider.mjs`. Bundle `src/providers/pika.ts` through
+esbuild with an `obsidian` stub whose `requestUrl` records requests and returns
+queued responses. Assert these exact payload contracts:
+
+```js
+const stdText = buildPikaVideoRequest('A slow pan', {
+  modelId: 'kling-v3',
+  genMode: 'text-to-video',
+  mode: 'std',
+  duration: '5',
+  aspect_ratio: '16:9',
+})
+assert.equal(stdText.path, '/v1/media/kling/kling-v3/standard/text-to-video')
+assert.deepEqual(stdText.body, {
+  prompt: 'A slow pan',
+  duration: '5',
+  aspect_ratio: '16:9',
+})
+
+const proImage = buildPikaVideoRequest('Blink and smile', {
+  modelId: 'kling-v3',
+  genMode: 'first-frame',
+  mode: 'pro',
+  duration: '10',
+  aspect_ratio: '9:16',
+  refImages: ['https://relay.example/start.png'],
+})
+assert.equal(proImage.path, '/v1/media/kling/kling-v3/pro/image-to-video')
+assert.equal(proImage.body.image, 'https://relay.example/start.png')
+
+const motion = buildPikaVideoRequest('Follow the dance', {
+  modelId: 'kling-v3',
+  genMode: 'motion-control',
+  refImages: ['https://relay.example/character.png'],
+  refVideos: ['https://relay.example/motion.mp4'],
+  character_orientation: 'video',
+  keep_original_sound: 'yes',
+})
+assert.equal(motion.path, '/v1/media/kling/kling-v3/motion-control')
+assert.deepEqual(motion.body, {
+  prompt: 'Follow the dance',
+  image_url: 'https://relay.example/character.png',
+  video_url: 'https://relay.example/motion.mp4',
+  character_orientation: 'video',
+  keep_original_sound: 'yes',
+})
+
+const omni = buildPikaVideoRequest('Wake up', {
+  modelId: 'kling-o3',
+  genMode: 'first-frame',
+  duration: 12,
+  sound: 'on',
+  refImages: ['https://relay.example/omni.png'],
+})
+assert.equal(omni.path, '/v1/media/kling/kling-o3/image-to-video')
+assert.deepEqual(omni.body, {
+  prompt: 'Wake up',
+  image_url: 'https://relay.example/omni.png',
+  duration: 12,
+  sound: 'on',
+})
+```
+
+Also assert:
+
+```js
+assert.throws(
+  () => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-last-frame' }),
+  /does not support first-last-frame/,
+)
+assert.throws(
+  () => buildPikaVideoRequest('x', { modelId: 'kling-o3', genMode: 'text-to-video' }),
+  /only supports first-frame/,
+)
+assert.throws(
+  () => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-frame', refImages: [] }),
+  /requires one reference image/,
+)
+```
+
+The request stub must then verify:
+
+```js
+const submit = await provider.generateVideo('Blink', {
+  modelId: 'kling-v3',
+  genMode: 'first-frame',
+  refImages: ['https://relay.example/start.png'],
+})
+assert.deepEqual(submit, { done: false, taskId: 'job-1' })
+assert.equal(requests[0].headers['X-API-Key'], 'test-key')
+
+assert.deepEqual(await provider.checkStatus('queued-job'), {
+  done: false,
+  taskId: 'queued-job',
+})
+await assert.rejects(() => provider.checkStatus('failed-job'), /render rejected/)
+
+const complete = await provider.checkStatus('complete-job')
+assert.match(complete.filePath, /^assets\/pika_video_\d+\.mp4$/)
+assert.equal(writes.length, 1)
+```
+
+Add the package script:
+
+```json
+"test:pika-provider": "node scripts/verify-pika-provider.mjs"
+```
+
+- [ ] **Step 2: Run the verification and confirm RED**
+
+Run: `npm run test:pika-provider`
+
+Expected: FAIL because `src/providers/pika.ts` does not exist.
+
+- [ ] **Step 3: Implement the minimal provider**
+
+Create `src/providers/pika.ts` with these public definitions:
+
+```ts
+const PIKA_API_BASE = 'https://api.dev.pika.art'
+
+export interface PikaVideoRequest {
+  path: string
+  body: Record<string, unknown>
+}
+
+export function buildPikaVideoRequest(
+  prompt: string,
+  params: Record<string, unknown> = {},
+): PikaVideoRequest
+
+export class PikaVideoProvider implements VideoProvider {
+  name = 'Pika'
+  constructor(apiKey: string, app: App, outputDir: string)
+  generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult>
+  checkStatus(taskId: string): Promise<GenerateVideoResult>
+}
+
+export async function testPikaConnection(apiKey: string): Promise<{
+  ok: boolean
+  message: string
+}>
+```
+
+Route `mode: 'std'` to `standard`, preserve `pro` and `4k`, validate Pika's
+documented enums, and include optional `negative_prompt` and `cfg_scale` only
+when explicitly supplied. Submit with:
+
+```ts
+await requestUrl({
+  url: `${PIKA_API_BASE}${request.path}`,
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-API-Key': this.apiKey,
+  },
+  body: JSON.stringify(request.body),
+  throw: false,
+})
+```
+
+Parse `{ id, status }`, poll `GET /v1/media/jobs/{id}`, accept `queued` and
+`running`, throw `error` on `failed`, and on `completed` prefer
+`output.video.url`. If absent, fetch `GET /v1/media/jobs/{id}/content` and use
+its `url`. Download through `requestUrl`, ensure `outputDir` exists, and write
+`pika_video_${Date.now()}.mp4`.
+
+`testPikaConnection` must call `GET https://api.dev.pika.art/v1/models` with
+`X-API-Key`; return `Connected.` on 200 and `Invalid API key.` on 401/403.
+
+- [ ] **Step 4: Run the Pika verification and confirm GREEN**
+
+Run: `npm run test:pika-provider`
+
+Expected: PASS with `Pika provider checks passed.`
+
+- [ ] **Step 5: Commit the provider slice**
+
+```bash
+git add src/providers/pika.ts scripts/verify-pika-provider.mjs package.json
+git commit -m "feat: add Pika video provider"
+```
+
+---
+
+### Task 2: Settings, registry, and exact Kling catalogue mappings
+
+**Files:**
+- Modify: `scripts/verify-pika-provider.mjs`
+- Modify: `src/settings.ts:88-121,161-194`
+- Modify: `src/settings-migrations.ts:13`
+- Modify: `src/providers/registry.ts:7-33,255-272`
+- Modify: `src/models/kling.ts:55-63,139-168`
+
+**Interfaces:**
+- Consumes: `PikaVideoProvider`, `testPikaConnection`, `ProviderSpec`, and existing model-provider catalogue resolution.
+- Produces: `providers.pika`, registry provider ID `pika`, Kling 3.0 and Kling 3.0 Omni Pika mappings.
+
+- [ ] **Step 1: Extend the verification with failing wiring assertions**
+
+Before touching production wiring, add source assertions:
+
+```js
+assert.match(settingsSource, /pika: string/)
+assert.match(settingsSource, /pika: ''/)
+assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = 9/)
+assert.match(registrySource, /id: 'pika'[\s\S]*makeVideo:/)
+assert.match(registrySource, /testPikaConnection\(d\.pika \|\| ''\)/)
+assert.match(
+  modelSource,
+  /id: 'kling-3\.0'[\s\S]*pika: \{ apiModelId: 'kling-v3', aggregated: true, modes: \['text-to-video', 'first-frame', 'motion-control'\] \}/,
+)
+assert.match(
+  modelSource,
+  /id: 'kling-3\.0-omni'[\s\S]*pika: \{ apiModelId: 'kling-o3', modes: \['first-frame'\] \}/,
+)
+assert.doesNotMatch(modelSource, /id: 'kling-o1'/)
+```
+
+Assert the Pika quality override contains Standard, Pro, and 4K, and the Omni
+quality parameter is hidden for Pika.
+
+- [ ] **Step 2: Run the verification and confirm RED**
+
+Run: `npm run test:pika-provider`
+
+Expected: FAIL at the first missing Pika settings/registry/catalog assertion.
+
+- [ ] **Step 3: Add settings and migration support**
+
+Add:
+
+```ts
+providers: {
+  // existing fields...
+  pika: string
+}
+```
+
+and:
+
+```ts
+providers: {
+  // existing defaults...
+  pika: '',
+}
+```
+
+Bump:
+
+```ts
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 9
+```
+
+The centralized parser already iterates `Object.keys(defaults.providers)`, so no
+provider-specific migration function is added.
+
+- [ ] **Step 4: Register Pika**
+
+Import `PikaVideoProvider` and `testPikaConnection`, then add:
+
+```ts
+{
+  id: 'pika',
+  name: 'Pika',
+  docUrl: 'https://dev.pika.art/models',
+  fields: [{ key: 'pika', label: 'API key', placeholder: 'pk_...', type: 'password' }],
+  defaultRefDelivery: { image: 'relay', video: 'relay' },
+  isConfigured: (s) => !!s.providers.pika,
+  makeVideo: ({ settings, app, outputDir }) =>
+    new PikaVideoProvider(settings.providers.pika, app, outputDir),
+  testConnection: (d) => testPikaConnection(d.pika || ''),
+},
+```
+
+- [ ] **Step 5: Add exact catalogue mappings and parameter overrides**
+
+For Kling 3.0:
+
+```ts
+pika: {
+  apiModelId: 'kling-v3',
+  aggregated: true,
+  modes: ['text-to-video', 'first-frame', 'motion-control'],
+},
+```
+
+Add this override to the Kling 3.0 `mode` parameter:
+
+```ts
+providerOverrides: {
+  pika: {
+    options: [
+      { label: 'Standard', value: 'std' },
+      { label: 'Pro', value: 'pro' },
+      { label: '4K', value: '4k' },
+    ],
+  },
+},
+```
+
+For Kling 3.0 Omni:
+
+```ts
+pika: { apiModelId: 'kling-o3', modes: ['first-frame'] },
+```
+
+Add `providerOverrides: { pika: { hidden: true } }` to Omni's `mode` parameter
+because the Pika O3 endpoint has no quality selector. Also hide Omni
+`multi_shot` for Pika because Pika O3 image-to-video rejects that field.
+
+- [ ] **Step 6: Run focused and catalogue verification**
+
+Run:
+
+```bash
+npm run test:pika-provider
+npm run check:catalog
+npm run audit:catalog
+```
+
+Expected: all three commands pass with no catalogue errors.
+
+- [ ] **Step 7: Commit the wiring slice**
+
+```bash
+git add scripts/verify-pika-provider.mjs src/settings.ts src/settings-migrations.ts src/providers/registry.ts src/models/kling.ts
+git commit -m "feat: connect Pika to Kling models"
+```
+
+---
+
+### Task 3: Documentation, coupled skill update, and full verification
+
+**Files:**
+- Modify: `docs/model-provider-rules.md`
+- Modify: `scripts/verify-pika-provider.mjs`
+- External paired repository: `nextbound/bragi-canvas-skill`
+
+**Interfaces:**
+- Consumes: completed Pika provider and catalogue mappings.
+- Produces: durable provider behavior documentation, paired skill reference update, and PR-ready verification evidence.
+
+- [ ] **Step 1: Add a failing documentation assertion**
+
+Add:
+
+```js
+assert.match(
+  modelRulesSource,
+  /## Pika Kling[\s\S]*Kling 3\\.0[\\s\\S]*Kling 3\\.0 Omni/,
+)
+```
+
+- [ ] **Step 2: Run the verification and confirm RED**
+
+Run: `npm run test:pika-provider`
+
+Expected: FAIL because `docs/model-provider-rules.md` has no Pika Kling section.
+
+- [ ] **Step 3: Document the provider contract**
+
+Add `## Pika Kling` to `docs/model-provider-rules.md` with:
+
+- base URL and `X-API-Key` authentication;
+- the exact Kling 3.0 and O3 route/mode mapping;
+- Standard/Pro/4K route selection;
+- Bragi Relay requirements;
+- shared jobs polling and content fallback;
+- explicit exclusion of Kling O1 and Kling 2.6.
+
+- [ ] **Step 4: Update the paired skill repository**
+
+Create branch `feat/pika-provider` in `nextbound/bragi-canvas-skill`. Update its
+model/provider reference so it lists Pika for Kling 3.0 and Kling 3.0 Omni with
+the same effective modes and excludes Kling O1. Commit, push, and create a PR
+that cross-links the plugin PR. If repository access is unavailable, record the
+exact missing permission in the plugin PR instead of claiming completion.
+
+- [ ] **Step 5: Run the full local verification matrix**
+
+Run:
+
+```bash
+npm run test:pika-provider
+npm run test:kling-omni
+npm run check:catalog
+npm run audit:catalog
+npm run lint:obsidian
+npm run build
+git diff --check
+git status --short --branch
+```
+
+Expected: every command exits 0, lint/build output has no errors, diff check is
+silent, and only intended files are modified.
+
+- [ ] **Step 6: Run the non-generating live Pika check**
+
+Call `GET https://api.dev.pika.art/v1/models` with the supplied `X-API-Key`.
+Expected: HTTP 200. Do not submit a valid media generation request.
+
+- [ ] **Step 7: Commit documentation**
+
+```bash
+git add docs/model-provider-rules.md scripts/verify-pika-provider.mjs
+git commit -m "docs: document Pika Kling mappings"
+```
+
+- [ ] **Step 8: Push and open the plugin PR**
+
+Push `feat/pika-provider` to the user's fork and open a ready PR against
+`nextbound/bragi-canvas:main`. Include:
+
+- exact model/mode mappings;
+- local verification commands and results;
+- non-generating API authentication result;
+- explicit statement that no API key or live output was committed;
+- the paired skill PR link or precise access blocker.

--- a/docs/superpowers/specs/2026-07-28-pika-provider-design.md
+++ b/docs/superpowers/specs/2026-07-28-pika-provider-design.md
@@ -1,0 +1,133 @@
+# Pika provider design
+
+## Goal
+
+Add Pika as a video provider for the Kling models that already exist in Bragi
+Canvas, using exact model-family matches and without introducing a new model.
+
+## Model mapping
+
+| Bragi model | Pika media route family | Effective Bragi modes |
+| --- | --- | --- |
+| Kling 3.0 (`kling-3.0`) | `kling-v3` | `text-to-video`, `first-frame`, `motion-control` |
+| Kling 3.0 Omni (`kling-3.0-omni`) | `kling-o3` | `first-frame` |
+| Kling 2.6 (`kling-2.6`) | None | None |
+
+Pika's `kling-o1` route is intentionally excluded. Kling O1 is the predecessor
+of Kling 3.0 Omni rather than the same model, and Bragi does not currently have a
+Kling O1 catalogue entry. Adding it would be a separate model-addition change.
+
+## Pika endpoints
+
+The provider uses `https://api.dev.pika.art` with `X-API-Key` authentication.
+
+Kling 3.0 is routed by Bragi mode and quality:
+
+- `POST /v1/media/kling/kling-v3/{standard|pro|4k}/text-to-video`
+- `POST /v1/media/kling/kling-v3/{standard|pro|4k}/image-to-video`
+- `POST /v1/media/kling/kling-v3/motion-control`
+
+Kling 3.0 Omni uses:
+
+- `POST /v1/media/kling/kling-o3/image-to-video`
+
+All submitted jobs use the shared Pika status API:
+
+- `GET /v1/media/jobs/{request_id}`
+- `GET /v1/media/jobs/{request_id}/content` when the completed status payload
+  does not already include a usable video URL
+
+## Catalogue behavior
+
+Pika is added to `supportedProviders` only for the two exact model matches.
+Kling 3.0 is marked as aggregated for Pika because the provider routes one Bragi
+model to multiple Pika endpoints. Its Pika mode list excludes
+`first-last-frame`, which Pika does not expose.
+
+The existing Kling quality parameter receives a Pika override with Standard,
+Pro, and 4K options. Kling 3.0 Omni's Pika mapping hides quality because the O3
+endpoint has no quality selector. Existing duration, ratio, audio, and
+motion-control parameters are reused where Pika accepts them; unsupported
+parameters are omitted from the request rather than sent speculatively.
+
+Adding Pika support must not enable a model or connect Pika to a model for
+existing users. The normal Add Provider and Manage Models flows remain the only
+way to enable the new connection.
+
+## Reference media
+
+Pika receives public HTTPS URLs. Bragi continues to prepare local reference
+images and videos through its built-in temporary relay before invoking the
+provider.
+
+Request mapping:
+
+- Kling 3.0 image-to-video: first image becomes `image`.
+- Kling 3.0 Omni image-to-video: first image becomes `image_url`.
+- Kling 3.0 motion control: first image becomes `image_url`; first video becomes
+  `video_url`.
+
+Missing required reference media fails locally with a provider-specific error
+before submission.
+
+## Provider lifecycle
+
+`PikaVideoProvider` implements Bragi's existing `VideoProvider` interface.
+
+1. Validate the active model, generation mode, required references, duration,
+   quality, and Pika-supported values.
+2. Build the mode-specific Pika request without mutating input params.
+3. Submit the request with the configured API key.
+4. Return `{ done: false, taskId }`.
+5. Poll the shared job endpoint from `checkStatus`.
+6. Return pending for `queued` and `running`.
+7. On `completed`, resolve the video URL from the job payload or content
+   endpoint, download it, and write it under the configured output directory.
+8. On `failed` or malformed responses, throw a redacted error that never
+   includes the API key.
+
+## Settings and connection test
+
+Add `providers.pika` as a password field with an empty default. The centralized
+settings migration/parser picks up the new default-backed string field, and the
+settings schema version is advanced explicitly.
+
+The provider registry exposes Pika with video support and relay delivery for
+images and videos. Its connection test calls a non-generating authenticated API
+endpoint so Test Connection does not consume media credits.
+
+No API key, generated media URL, or live-test asset is stored in the repository.
+
+## Testing and verification
+
+Implementation follows test-first development:
+
+- Payload tests cover each supported Kling 3.0 mode and the Kling O3 mapping.
+- Validation tests cover unsupported modes, missing references, invalid quality,
+  and out-of-range values.
+- Provider tests cover authenticated submission, queued/running/completed/failed
+  polling, content URL fallback, and vault download behavior with stubbed
+  network responses.
+- Wiring tests cover settings defaults and migration, registry setup, catalogue
+  mappings, mode restrictions, parameter overrides, and package scripts.
+
+Before the PR is opened, run:
+
+- the Pika-specific verification script
+- `npm run check:catalog`
+- `npm run audit:catalog`
+- existing Kling verification
+- `npm run lint:obsidian`
+- `npm run build`
+- `git diff --check`
+
+Live API verification is limited to authenticated, non-generating validation
+requests unless explicit approval is given to spend Pika generation credits.
+
+## Documentation coupling
+
+The plugin repository requires model/provider changes to be reflected in
+`nextbound/bragi-canvas-skill`. The plugin PR must call out the corresponding
+skill documentation update. If a paired skill PR cannot be created from the
+current workspace, that dependency must be reported explicitly rather than
+silently omitted.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
     "test:svnewapi-video-params": "node scripts/verify-svnewapi-video-params.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
-    "test:text-multimodal": "node scripts/verify-text-multimodal.mjs"
+    "test:text-multimodal": "node scripts/verify-text-multimodal.mjs",
+    "test:pika-provider": "node scripts/verify-pika-provider.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -221,6 +221,61 @@ try {
 	assert.deepEqual(await testPikaConnection('valid-key'), { ok: true, message: 'Connected.' })
 	process.__bragiPikaRequestHandler = async () => ({ status: 401, json: { message: 'Unauthorized' } })
 	assert.deepEqual(await testPikaConnection('bad-key'), { ok: false, message: 'Invalid API key.' })
+
+	const [settingsSource, migrationsSource, registrySource, modelSource] = await Promise.all([
+		readFile('src/settings.ts', 'utf8'),
+		readFile('src/settings-migrations.ts', 'utf8'),
+		readFile('src/providers/registry.ts', 'utf8'),
+		readFile('src/models/kling.ts', 'utf8'),
+	])
+	assert.match(settingsSource, /pika: string/, 'Settings type must include providers.pika.')
+	assert.match(settingsSource, /pika: ''/, 'Default settings must include an empty Pika key.')
+	assert.match(
+		migrationsSource,
+		/CURRENT_SETTINGS_SCHEMA_VERSION = 9/,
+		'Adding a provider credential must advance the settings schema version.',
+	)
+	assert.match(
+		registrySource,
+		/import \{ PikaVideoProvider, testPikaConnection \} from '\.\/pika'/,
+		'Provider registry must import the Pika implementation and connection test.',
+	)
+	assert.match(
+		registrySource,
+		/id: 'pika'[\s\S]*?name: 'Pika'[\s\S]*?defaultRefDelivery: \{ image: 'relay', video: 'relay' \}[\s\S]*?makeVideo:/,
+		'Provider registry must expose Pika as a relay-backed video provider.',
+	)
+	assert.match(
+		registrySource,
+		/testConnection: \(d\) => testPikaConnection\(d\.pika \|\| ''\)/,
+		'Provider registry must use the non-generating Pika connection test.',
+	)
+	assert.match(
+		modelSource,
+		/id: 'kling-3\.0'[\s\S]*?pika: \{[\s\S]*?apiModelId: 'kling-v3'[\s\S]*?aggregated: true[\s\S]*?modes: \['text-to-video', 'first-frame', 'motion-control'\][\s\S]*?\}/,
+		'Kling 3.0 must map Pika to the exact supported modes.',
+	)
+	assert.match(
+		modelSource,
+		/id: 'mode'[\s\S]*?providerOverrides: \{[\s\S]*?pika: \{[\s\S]*?label: 'Standard', value: 'std'[\s\S]*?label: 'Pro', value: 'pro'[\s\S]*?label: '4K', value: '4k'/,
+		'Kling 3.0 must expose Pika Standard, Pro, and 4K quality routes.',
+	)
+	assert.match(
+		modelSource,
+		/id: 'kling-3\.0-omni'[\s\S]*?pika: \{ apiModelId: 'kling-o3', modes: \['first-frame'\] \}/,
+		'Kling 3.0 Omni must map Pika O3 to first-frame only.',
+	)
+	assert.match(
+		modelSource,
+		/id: 'mode'[\s\S]*?providerOverrides: \{ pika: \{ hidden: true \} \}/,
+		'Kling 3.0 Omni must hide its unsupported quality selector for Pika.',
+	)
+	assert.match(
+		modelSource,
+		/id: 'multi_shot'[\s\S]*?providerOverrides: \{ pika: \{ hidden: true \} \}/,
+		'Kling 3.0 Omni must hide its unsupported multi-shot selector for Pika.',
+	)
+	assert.doesNotMatch(modelSource, /id: 'kling-o1'/, 'This change must not add a mismatched Kling O1 model.')
 
 	console.log('Pika provider checks passed.')
 } finally {

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-pika-provider-'))
+const bundlePath = join(tempDir, 'pika-provider.mjs')
+
+try {
+	await build({
+		entryPoints: ['src/providers/pika.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: bundlePath,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export async function requestUrl(options) {
+							return process.__bragiPikaRequestHandler(options)
+						}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const {
+		buildPikaVideoRequest,
+		PikaVideoProvider,
+		testPikaConnection,
+	} = await import(`${pathToFileURL(bundlePath).href}?t=${Date.now()}`)
+
+	const stdText = buildPikaVideoRequest('A slow pan', {
+		modelId: 'kling-v3',
+		genMode: 'text-to-video',
+		mode: 'std',
+		duration: '5',
+		aspect_ratio: '16:9',
+	})
+	assert.equal(stdText.path, '/v1/media/kling/kling-v3/standard/text-to-video')
+	assert.deepEqual(stdText.body, {
+		prompt: 'A slow pan',
+		duration: '5',
+		aspect_ratio: '16:9',
+	})
+
+	const proImage = buildPikaVideoRequest('Blink and smile', {
+		modelId: 'kling-v3',
+		genMode: 'first-frame',
+		mode: 'pro',
+		duration: '10',
+		aspect_ratio: '9:16',
+		refImages: ['https://relay.example/start.png'],
+	})
+	assert.equal(proImage.path, '/v1/media/kling/kling-v3/pro/image-to-video')
+	assert.deepEqual(proImage.body, {
+		prompt: 'Blink and smile',
+		image: 'https://relay.example/start.png',
+		duration: '10',
+		aspect_ratio: '9:16',
+	})
+
+	const motion = buildPikaVideoRequest('Follow the dance', {
+		modelId: 'kling-v3',
+		genMode: 'motion-control',
+		refImages: ['https://relay.example/character.png'],
+		refVideos: ['https://relay.example/motion.mp4'],
+		character_orientation: 'video',
+		keep_original_sound: 'yes',
+	})
+	assert.equal(motion.path, '/v1/media/kling/kling-v3/motion-control')
+	assert.deepEqual(motion.body, {
+		prompt: 'Follow the dance',
+		image_url: 'https://relay.example/character.png',
+		video_url: 'https://relay.example/motion.mp4',
+		character_orientation: 'video',
+		keep_original_sound: 'yes',
+	})
+
+	const omni = buildPikaVideoRequest('Wake up', {
+		modelId: 'kling-o3',
+		genMode: 'first-frame',
+		duration: 12,
+		sound: 'on',
+		refImages: ['https://relay.example/omni.png'],
+	})
+	assert.equal(omni.path, '/v1/media/kling/kling-o3/image-to-video')
+	assert.deepEqual(omni.body, {
+		prompt: 'Wake up',
+		image_url: 'https://relay.example/omni.png',
+		duration: 12,
+		sound: 'on',
+	})
+
+	assert.throws(
+		() => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-last-frame' }),
+		/does not support first-last-frame/,
+	)
+	assert.throws(
+		() => buildPikaVideoRequest('x', { modelId: 'kling-o3', genMode: 'text-to-video' }),
+		/only supports first-frame/,
+	)
+	assert.throws(
+		() => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-frame', refImages: [] }),
+		/requires one reference image/,
+	)
+	assert.throws(
+		() => buildPikaVideoRequest('x', {
+			modelId: 'kling-v3',
+			genMode: 'motion-control',
+			refImages: ['https://relay.example/character.png'],
+			refVideos: [],
+		}),
+		/requires one reference image and one reference video/,
+	)
+	assert.throws(
+		() => buildPikaVideoRequest('x', {
+			modelId: 'kling-o3',
+			genMode: 'first-frame',
+			duration: 16,
+			refImages: ['https://relay.example/start.png'],
+		}),
+		/duration must be a whole number from 3 to 15/,
+	)
+
+	const requests = []
+	const writes = []
+	const app = {
+		vault: {
+			adapter: {
+				exists: async () => true,
+				mkdir: async () => {},
+				writeBinary: async (path, data) => writes.push({ path, data }),
+			},
+		},
+	}
+	const provider = new PikaVideoProvider('test-key', app, 'assets')
+
+	process.__bragiPikaRequestHandler = async (request) => {
+		requests.push(request)
+		return { status: 200, json: { id: 'job-1', status: 'queued' } }
+	}
+	const submit = await provider.generateVideo('Blink', {
+		modelId: 'kling-v3',
+		genMode: 'first-frame',
+		refImages: ['https://relay.example/start.png'],
+	})
+	assert.deepEqual(submit, { done: false, taskId: 'job-1' })
+	assert.equal(requests[0].url, 'https://api.dev.pika.art/v1/media/kling/kling-v3/standard/image-to-video')
+	assert.equal(requests[0].headers['X-API-Key'], 'test-key')
+
+	process.__bragiPikaRequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/jobs/queued-job')) {
+			return { status: 200, json: { id: 'queued-job', status: 'running' } }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	assert.deepEqual(await provider.checkStatus('queued-job'), {
+		done: false,
+		taskId: 'queued-job',
+	})
+
+	process.__bragiPikaRequestHandler = async (request) => {
+		requests.push(request)
+		return { status: 200, json: { id: 'failed-job', status: 'failed', error: 'render rejected' } }
+	}
+	await assert.rejects(() => provider.checkStatus('failed-job'), /render rejected/)
+
+	process.__bragiPikaRequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/jobs/complete-job')) {
+			return {
+				status: 200,
+				json: {
+					id: 'complete-job',
+					status: 'completed',
+					output: {
+						media_type: 'video',
+						video: { url: 'https://cdn.example/result.mp4', content_type: 'video/mp4' },
+					},
+				},
+			}
+		}
+		if (request.url === 'https://cdn.example/result.mp4') {
+			return { status: 200, arrayBuffer: new Uint8Array([1, 2, 3]).buffer }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	const complete = await provider.checkStatus('complete-job')
+	assert.match(complete.filePath, /^assets\/pika_video_\d+\.mp4$/)
+	assert.equal(writes.length, 1)
+	assert.deepEqual([...new Uint8Array(writes[0].data)], [1, 2, 3])
+
+	process.__bragiPikaRequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/jobs/content-job')) {
+			return { status: 200, json: { id: 'content-job', status: 'completed' } }
+		}
+		if (request.url.endsWith('/jobs/content-job/content')) {
+			return { status: 200, json: { url: 'https://cdn.example/content-result.mp4' } }
+		}
+		if (request.url === 'https://cdn.example/content-result.mp4') {
+			return { status: 200, arrayBuffer: new Uint8Array([4, 5, 6]).buffer }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	const contentFallback = await provider.checkStatus('content-job')
+	assert.match(contentFallback.filePath, /^assets\/pika_video_\d+\.mp4$/)
+	assert.equal(writes.length, 2)
+
+	process.__bragiPikaRequestHandler = async () => ({ status: 200, json: { object: 'list', data: [] } })
+	assert.deepEqual(await testPikaConnection('valid-key'), { ok: true, message: 'Connected.' })
+	process.__bragiPikaRequestHandler = async () => ({ status: 401, json: { message: 'Unauthorized' } })
+	assert.deepEqual(await testPikaConnection('bad-key'), { ok: false, message: 'Invalid API key.' })
+
+	console.log('Pika provider checks passed.')
+} finally {
+	delete process.__bragiPikaRequestHandler
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -222,11 +222,12 @@ try {
 	process.__bragiPikaRequestHandler = async () => ({ status: 401, json: { message: 'Unauthorized' } })
 	assert.deepEqual(await testPikaConnection('bad-key'), { ok: false, message: 'Invalid API key.' })
 
-	const [settingsSource, migrationsSource, registrySource, modelSource] = await Promise.all([
+	const [settingsSource, migrationsSource, registrySource, modelSource, modelRulesSource] = await Promise.all([
 		readFile('src/settings.ts', 'utf8'),
 		readFile('src/settings-migrations.ts', 'utf8'),
 		readFile('src/providers/registry.ts', 'utf8'),
 		readFile('src/models/kling.ts', 'utf8'),
+		readFile('docs/model-provider-rules.md', 'utf8'),
 	])
 	assert.match(settingsSource, /pika: string/, 'Settings type must include providers.pika.')
 	assert.match(settingsSource, /pika: ''/, 'Default settings must include an empty Pika key.')
@@ -276,6 +277,11 @@ try {
 		'Kling 3.0 Omni must hide its unsupported multi-shot selector for Pika.',
 	)
 	assert.doesNotMatch(modelSource, /id: 'kling-o1'/, 'This change must not add a mismatched Kling O1 model.')
+	assert.match(
+		modelRulesSource,
+		/## Pika Kling[\s\S]*Kling 3\.0[\s\S]*Kling 3\.0 Omni/,
+		'Provider rules must document the Pika Kling 3.0 and Kling 3.0 Omni mappings.',
+	)
 
 	console.log('Pika provider checks passed.')
 } finally {

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -63,6 +63,22 @@ const KLING_PARAMS: ModelParam[] = [
 	},
 ]
 
+const KLING_3_PARAMS: ModelParam[] = KLING_PARAMS.map((param) => param.id === 'mode'
+	? {
+		...param,
+		providerOverrides: {
+			...param.providerOverrides,
+			pika: {
+				options: [
+					{ label: 'Standard', value: 'std' },
+					{ label: 'Pro', value: 'pro' },
+					{ label: '4K', value: '4k' },
+				],
+			},
+		},
+	}
+	: param)
+
 const KLING_OMNI_TIMED_MODES = ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref'] as const
 const KLING_OMNI_RATIO_MODES = ['text-to-video', 'image-ref', 'video-ref'] as const
 
@@ -99,6 +115,7 @@ const KLING_OMNI_PARAMS: ModelParam[] = [
 			{ label: 'Pro', value: 'pro' },
 			{ label: '4K', value: '4k' },
 		],
+		providerOverrides: { pika: { hidden: true } },
 		default: 'std',
 	},
 	{
@@ -121,6 +138,7 @@ const KLING_OMNI_PARAMS: ModelParam[] = [
 			{ label: 'Multi shots', value: 'true' },
 			{ label: 'Single shot', value: 'false' },
 		],
+		providerOverrides: { pika: { hidden: true } },
 		default: 'true',
 	},
 	{
@@ -142,6 +160,11 @@ export const kling3: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		kling: { apiModelId: 'kling-v3' },
+		pika: {
+			apiModelId: 'kling-v3',
+			aggregated: true,
+			modes: ['text-to-video', 'first-frame', 'motion-control'],
+		},
 		// APIMart exposes Kling only via its Motion Control endpoint.
 		apimart: { apiModelId: 'kling-v3-motion-control', modes: ['motion-control'] },
 		fal: { apiModelId: 'fal-ai/kling-video/v3/pro', modes: ['text-to-video', 'first-frame', 'first-last-frame'] },
@@ -152,7 +175,7 @@ export const kling3: ModelConfig = {
 	// T2V + first-frame (image→video) + first-last-frame (start+end keyframe)
 	// + motion-control (character image + reference motion video, V3.0 only)
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'motion-control'],
-	params: KLING_PARAMS,
+	params: KLING_3_PARAMS,
 }
 
 export const klingOmni3: ModelConfig = {
@@ -161,6 +184,7 @@ export const klingOmni3: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		kling: { apiModelId: 'kling-v3-omni' },
+		pika: { apiModelId: 'kling-o3', modes: ['first-frame'] },
 		apimart: { apiModelId: 'kling-v3-omni' },
 	},
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-edit'],

--- a/src/providers/pika.ts
+++ b/src/providers/pika.ts
@@ -1,0 +1,303 @@
+import type { App } from 'obsidian'
+import { requestUrl } from 'obsidian'
+import type { GenerateVideoResult, VideoProvider } from './types'
+
+const PIKA_API_BASE = 'https://api.dev.pika.art'
+const KLING_V3_MODEL_ID = 'kling-v3'
+const KLING_O3_MODEL_ID = 'kling-o3'
+const KLING_V3_DURATIONS = new Set(['5', '10'])
+const KLING_O3_RATIOS = new Set(['16:9', '9:16', '1:1'])
+const PIKA_SOUNDS = new Set(['on', 'off'])
+const MOTION_ORIENTATIONS = new Set(['image', 'video'])
+const KEEP_SOUND_VALUES = new Set(['yes', 'no'])
+
+type UnknownRecord = Record<string, unknown>
+
+export interface PikaVideoRequest {
+	path: string
+	body: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function stringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return []
+	return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+function optionalString(body: UnknownRecord, key: string, value: unknown): void {
+	if (typeof value === 'string' && value.trim()) body[key] = value
+}
+
+function parseQuality(value: unknown): 'standard' | 'pro' | '4k' {
+	const quality = stringValue(value, 'std')
+	if (quality === 'std' || quality === 'standard') return 'standard'
+	if (quality === 'pro' || quality === '4k') return quality
+	throw new Error('Pika Kling 3.0 quality must be Standard, Pro, or 4K.')
+}
+
+function parseV3Duration(value: unknown): string {
+	const duration = stringValue(value, '5')
+	if (!KLING_V3_DURATIONS.has(duration)) {
+		throw new Error('Pika Kling 3.0 duration must be 5 or 10 seconds.')
+	}
+	return duration
+}
+
+function parseO3Duration(value: unknown): number {
+	const duration = typeof value === 'number' ? value : Number.parseInt(stringValue(value, '5'), 10)
+	if (!Number.isInteger(duration) || duration < 3 || duration > 15) {
+		throw new Error('Pika Kling O3 duration must be a whole number from 3 to 15.')
+	}
+	return duration
+}
+
+function parseAspectRatio(value: unknown): string {
+	const ratio = stringValue(value, '16:9')
+	if (!KLING_O3_RATIOS.has(ratio)) {
+		throw new Error('Pika aspect ratio must be 16:9, 9:16, or 1:1.')
+	}
+	return ratio
+}
+
+function addCommonOptionalParams(body: UnknownRecord, params: UnknownRecord): void {
+	if (params.sound !== undefined) {
+		const sound = stringValue(params.sound)
+		if (!PIKA_SOUNDS.has(sound)) throw new Error('Pika sound must be on or off.')
+		body.sound = sound
+	}
+	optionalString(body, 'negative_prompt', params.negative_prompt)
+	if (params.cfg_scale !== undefined) {
+		const cfgScale = typeof params.cfg_scale === 'number'
+			? params.cfg_scale
+			: Number.parseFloat(stringValue(params.cfg_scale))
+		if (!Number.isFinite(cfgScale) || cfgScale < 0 || cfgScale > 1) {
+			throw new Error('Pika CFG scale must be between 0 and 1.')
+		}
+		body.cfg_scale = cfgScale
+	}
+}
+
+export function buildPikaVideoRequest(
+	prompt: string,
+	params: Record<string, unknown> = {},
+): PikaVideoRequest {
+	const modelId = stringValue(params.modelId, KLING_V3_MODEL_ID)
+	const genMode = stringValue(params.genMode, 'text-to-video')
+	const refImages = stringArray(params.refImages)
+	const refVideos = stringArray(params.refVideos)
+
+	if (!prompt.trim()) throw new Error('Pika requires a prompt.')
+
+	if (modelId === KLING_O3_MODEL_ID) {
+		if (genMode !== 'first-frame') {
+			throw new Error('Pika Kling O3 only supports first-frame generation.')
+		}
+		if (refImages.length < 1) {
+			throw new Error('Pika Kling O3 first-frame generation requires one reference image.')
+		}
+		const body: UnknownRecord = {
+			prompt,
+			image_url: refImages[0],
+			duration: parseO3Duration(params.duration),
+		}
+		if (params.aspect_ratio !== undefined || params.aspectRatio !== undefined) {
+			body.aspect_ratio = parseAspectRatio(params.aspect_ratio ?? params.aspectRatio)
+		}
+		if (params.sound !== undefined) {
+			const sound = stringValue(params.sound)
+			if (!PIKA_SOUNDS.has(sound)) throw new Error('Pika sound must be on or off.')
+			body.sound = sound
+		}
+		return {
+			path: '/v1/media/kling/kling-o3/image-to-video',
+			body,
+		}
+	}
+
+	if (modelId !== KLING_V3_MODEL_ID) {
+		throw new Error(`Pika does not support model "${modelId}".`)
+	}
+	if (genMode === 'first-last-frame') {
+		throw new Error('Pika Kling 3.0 does not support first-last-frame generation.')
+	}
+	if (genMode === 'motion-control') {
+		if (refImages.length < 1 || refVideos.length < 1) {
+			throw new Error('Pika Kling 3.0 motion control requires one reference image and one reference video.')
+		}
+		const orientation = stringValue(params.character_orientation, 'video')
+		if (!MOTION_ORIENTATIONS.has(orientation)) {
+			throw new Error('Pika motion-control orientation must be image or video.')
+		}
+		const keepOriginalSound = stringValue(params.keep_original_sound, 'yes')
+		if (!KEEP_SOUND_VALUES.has(keepOriginalSound)) {
+			throw new Error('Pika motion-control source audio must be yes or no.')
+		}
+		return {
+			path: '/v1/media/kling/kling-v3/motion-control',
+			body: {
+				prompt,
+				image_url: refImages[0],
+				video_url: refVideos[0],
+				character_orientation: orientation,
+				keep_original_sound: keepOriginalSound,
+			},
+		}
+	}
+	if (genMode !== 'text-to-video' && genMode !== 'first-frame') {
+		throw new Error(`Pika Kling 3.0 does not support ${genMode || 'the selected mode'}.`)
+	}
+
+	const quality = parseQuality(params.mode)
+	const body: UnknownRecord = {
+		prompt,
+		duration: parseV3Duration(params.duration),
+		aspect_ratio: parseAspectRatio(params.aspect_ratio ?? params.aspectRatio),
+	}
+	addCommonOptionalParams(body, params)
+
+	if (genMode === 'first-frame') {
+		if (refImages.length < 1) {
+			throw new Error('Pika Kling 3.0 first-frame generation requires one reference image.')
+		}
+		body.image = refImages[0]
+	}
+
+	return {
+		path: `/v1/media/kling/kling-v3/${quality}/${genMode === 'first-frame' ? 'image-to-video' : 'text-to-video'}`,
+		body,
+	}
+}
+
+function errorDetail(response: { status: number; json?: unknown; text?: string }): string {
+	const data = isRecord(response.json) ? response.json : null
+	const detail = data?.message ?? data?.error ?? response.text ?? `HTTP ${response.status}`
+	if (typeof detail === 'string') return detail
+	try {
+		return JSON.stringify(detail)
+	} catch {
+		return `HTTP ${response.status}`
+	}
+}
+
+function jobStatus(data: UnknownRecord): string {
+	return stringValue(data.status)
+}
+
+function completedVideoUrl(data: UnknownRecord): string {
+	const output = isRecord(data.output) ? data.output : null
+	const video = output && isRecord(output.video) ? output.video : null
+	return stringValue(video?.url)
+}
+
+export class PikaVideoProvider implements VideoProvider {
+	name = 'Pika'
+	private apiKey: string
+	private app: App
+	private outputDir: string
+
+	constructor(apiKey: string, app: App, outputDir: string) {
+		this.apiKey = apiKey
+		this.app = app
+		this.outputDir = outputDir
+	}
+
+	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const request = buildPikaVideoRequest(prompt, params)
+		const response = await requestUrl({
+			url: `${PIKA_API_BASE}${request.path}`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-API-Key': this.apiKey,
+			},
+			body: JSON.stringify(request.body),
+			throw: false,
+		})
+		if (response.status === 401 || response.status === 403) throw new Error('Pika: invalid API key')
+		if (response.status >= 400) throw new Error(`Pika: ${errorDetail(response)}`)
+
+		const data: unknown = response.json
+		if (!isRecord(data)) throw new Error('Pika: malformed task response')
+		const taskId = stringValue(data.id)
+		if (!taskId) throw new Error('Pika: no task ID in response')
+		if (jobStatus(data) === 'failed') {
+			throw new Error(`Pika: ${stringValue(data.error, 'task submission failed')}`)
+		}
+		return { done: false, taskId }
+	}
+
+	async checkStatus(taskId: string): Promise<GenerateVideoResult> {
+		const response = await requestUrl({
+			url: `${PIKA_API_BASE}/v1/media/jobs/${encodeURIComponent(taskId)}`,
+			method: 'GET',
+			headers: { 'X-API-Key': this.apiKey },
+			throw: false,
+		})
+		if (response.status === 401 || response.status === 403) throw new Error('Pika: invalid API key')
+		if (response.status >= 400) throw new Error(`Pika: ${errorDetail(response)}`)
+
+		const data: unknown = response.json
+		if (!isRecord(data)) throw new Error('Pika: malformed task status response')
+		const status = jobStatus(data)
+		if (status === 'queued' || status === 'running') return { done: false, taskId }
+		if (status === 'failed') {
+			throw new Error(`Pika: task failed — ${stringValue(data.error, 'no reason provided')}`)
+		}
+		if (status !== 'completed') {
+			throw new Error(`Pika: unknown task status "${status || 'missing'}"`)
+		}
+
+		let url = completedVideoUrl(data)
+		if (!url) {
+			const contentResponse = await requestUrl({
+				url: `${PIKA_API_BASE}/v1/media/jobs/${encodeURIComponent(taskId)}/content`,
+				method: 'GET',
+				headers: { 'X-API-Key': this.apiKey },
+				throw: false,
+			})
+			if (contentResponse.status >= 400) throw new Error(`Pika: ${errorDetail(contentResponse)}`)
+			const content: unknown = contentResponse.json
+			url = isRecord(content) ? stringValue(content.url) : ''
+		}
+		if (!url) throw new Error('Pika: completed task has no video URL')
+
+		return { done: true, filePath: await this.downloadVideo(url) }
+	}
+
+	private async downloadVideo(url: string): Promise<string> {
+		const response = await requestUrl({ url, throw: false })
+		if (response.status >= 400) throw new Error(`Pika: failed to download video — HTTP ${response.status}`)
+		const filePath = `${this.outputDir}/pika_video_${Date.now()}.mp4`
+		const adapter = this.app.vault.adapter
+		if (!await adapter.exists(this.outputDir)) await adapter.mkdir(this.outputDir)
+		await adapter.writeBinary(filePath, response.arrayBuffer)
+		return filePath
+	}
+}
+
+export async function testPikaConnection(apiKey: string): Promise<{ ok: boolean; message: string }> {
+	if (!apiKey.trim()) return { ok: false, message: 'API key is empty.' }
+	try {
+		const response = await requestUrl({
+			url: `${PIKA_API_BASE}/v1/models`,
+			method: 'GET',
+			headers: { 'X-API-Key': apiKey },
+			throw: false,
+		})
+		if (response.status === 200) return { ok: true, message: 'Connected.' }
+		if (response.status === 401 || response.status === 403) return { ok: false, message: 'Invalid API key.' }
+		return { ok: false, message: `Unexpected status ${response.status}.` }
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error)
+		return { ok: false, message: `Network error: ${message}` }
+	}
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -9,6 +9,7 @@ import { GeminiProvider } from './gemini'
 import { SeedreamProvider } from './seedream'
 import { SeedanceProvider } from './seedance'
 import { KlingProvider } from './kling'
+import { PikaVideoProvider, testPikaConnection } from './pika'
 import { VeoProvider } from './veo'
 import { FalImageProvider, FalVideoProvider } from './fal'
 import { FalAudioProvider } from './fal-audio'
@@ -268,6 +269,17 @@ export const PROVIDERS: ProviderSpec[] = [
 		makeVideo: ({ settings, app, outputDir }) =>
 			new KlingProvider(settings.providers.klingAk, settings.providers.klingSk, app, outputDir),
 		// Kling uses JWT with HMAC-SHA256; auth is complex. Skip network test for now — Save will fail fast at first use.
+	},
+	{
+		id: 'pika',
+		name: 'Pika',
+		docUrl: 'https://dev.pika.art/models',
+		fields: [{ key: 'pika', label: 'API key', placeholder: 'pk_...', type: 'password' }],
+		defaultRefDelivery: { image: 'relay', video: 'relay' },
+		isConfigured: (s) => !!s.providers.pika,
+		makeVideo: ({ settings, app, outputDir }) =>
+			new PikaVideoProvider(settings.providers.pika, app, outputDir),
+		testConnection: (d) => testPikaConnection(d.pika || ''),
 	},
 	{
 		id: 'fal',

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 8
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 9
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,6 +102,7 @@ export interface BragiSettings {
 			bfl: string
 			runpod: string
 			fal: string
+			pika: string
 		minimax: string
 		elevenlabs: string
 		legnext: string
@@ -175,6 +176,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 			bfl: '',
 			runpod: '',
 			fal: '',
+			pika: '',
 		minimax: '',
 		elevenlabs: '',
 		legnext: '',


### PR DESCRIPTION
## Summary

- add Pika as a configurable async video provider with request validation, job polling, result download, and a non-generating connection test
- map Pika Kling v3 to Bragi Kling 3.0 for `text-to-video`, `first-frame`, and `motion-control`, including Standard, Pro, and 4K routes
- map Pika Kling O3 only to Bragi Kling 3.0 Omni `first-frame`; hide unsupported Omni controls and intentionally exclude Kling O1 and Kling 2.6
- document the provider contract and add regression coverage for payloads, lifecycle, settings, registry, and catalog wiring

## Validation

- all 17 repository `test:*` scripts passed
- `npm run check:catalog` — 45 models valid
- `npm run audit:catalog` — 198 model/provider/mode combinations, no anomalies
- `npm run lint:obsidian`
- `npm run build`
- `git diff --check upstream/main...HEAD`
- non-generating `GET /v1/models` authentication check returned HTTP 200

No billable media generation was submitted. No API key or live output is included in this branch.

## Paired skill

- https://github.com/nextbound/bragi-canvas-skill/pull/48
