### PR TITLE
Add audio Seedance asset IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added provider-scoped Seedance Asset ID binding to audio file nodes through the canvas context menu and MCP, with `asset://` reuse during video generation.
+
 ## 1.30.1
 
 - Removed forbidden `obsidianmd/ui/sentence-case` disable comments from Voice Changer UI copy.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Incoming directed edges are treated as upstream references. Text nodes contribut
 
 On an audio file node, **Voice Changer** uses the selected audio for content, timing, and emotion, and exactly one incoming audio node as the target voice reference. The action requires a configured ElevenLabs provider and creates a new audio node for every click, so multiple conversions can run in parallel.
 
+Image and audio file nodes can store provider-scoped Seedance Asset IDs. Right-click the file node, choose **Set Seedance asset ID**, select TokenRouter, BytePlus, or Volcengine, then save or clear the ID. When that file is connected as a Seedance reference, Bragi passes the saved value as an `asset://` reference for the matching provider.
+
 ## MCP server
 
 The MCP server is disabled by default. When enabled in settings, it listens on `127.0.0.1` and exposes canvas operations to local MCP clients. You can configure the port and an optional access token. If a token is set, clients must send `Authorization: Bearer <token>` on every request.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
     "test:elevenlabs-voice-changer": "node scripts/verify-elevenlabs-voice-changer.mjs",
+    "test:audio-asset-id": "node scripts/verify-audio-asset-id.mjs",
     "test:byteplus-asset-error-reason": "node scripts/verify-byteplus-asset-error-reason.mjs",
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
     "test:svnewapi-video-params": "node scripts/verify-svnewapi-video-params.mjs",

--- a/scripts/verify-audio-asset-id.mjs
+++ b/scripts/verify-audio-asset-id.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import esbuild from 'esbuild'
+
+const tempDir = await mkdtemp(path.join(tmpdir(), 'bragi-audio-asset-id-'))
+const outfile = path.join(tempDir, 'asset-ids.mjs')
+
+try {
+	await esbuild.build({
+		entryPoints: ['src/asset-ids.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile,
+		logLevel: 'silent',
+	})
+
+	const assetIds = await import(pathToFileURL(outfile).href)
+	assert.equal(assetIds.getSeedanceAssetMediaKind('refs/face.png'), 'image')
+	assert.equal(assetIds.getSeedanceAssetMediaKind('refs/voice.mp3'), 'audio')
+	assert.equal(assetIds.getSeedanceAssetMediaKind('refs/voice.m4a'), 'audio')
+	assert.equal(assetIds.getSeedanceAssetMediaKind('refs/clip.mp4'), null)
+
+	let nodeData = { type: 'file', file: 'refs/voice.mp3' }
+	const audioNode = {
+		getData: () => nodeData,
+		setData: next => { nodeData = next },
+	}
+	const canvas = { nodes: new Map([['audio-node', audioNode]]) }
+
+	assetIds.setNodeAssetId(audioNode, 'bytedance', 'asset-audio-1')
+	assert.deepEqual(nodeData.bragiAssetIds, { bytedance: 'asset-audio-1' })
+	assert.equal(assetIds.getNodeAssetId(audioNode, 'bytedance'), 'asset-audio-1')
+	assert.deepEqual(
+		assetIds.getAssetIdsForFiles(canvas, ['refs/voice.mp3'], 'bytedance'),
+		{ 'refs/voice.mp3': 'asset-audio-1' },
+	)
+
+	assetIds.setNodeAssetId(audioNode, 'bytedance', '')
+	assert.equal(nodeData.bragiAssetIds, undefined)
+
+	const mainSource = await readFile('src/main.ts', 'utf8')
+	const mcpSource = await readFile('src/mcp-tool-registry.ts', 'utf8')
+
+	assert.match(
+		mainSource,
+		/if \(!getSeedanceAssetMediaKind\(filePath\)\) return/,
+		'canvas context menu must accept every supported Seedance asset media kind',
+	)
+	assert.match(
+		mainSource,
+		/const audioAssetIdMap = supportsSeedanceAssetRefs[\s\S]*getAssetIdsForFiles\(canvas, uniqueAudios, activeProvider\)/,
+		'video generation must collect provider-scoped asset IDs from upstream audio nodes',
+	)
+
+	const audioFlowStart = mainSource.indexOf('// Upload reference audios')
+	const audioFlowEnd = mainSource.indexOf('// Prepare reference videos', audioFlowStart)
+	assert.notEqual(audioFlowStart, -1)
+	assert.notEqual(audioFlowEnd, -1)
+	const audioFlow = mainSource.slice(audioFlowStart, audioFlowEnd)
+	assert.match(
+		audioFlow,
+		/else if \(audioAssetIdMap\[audioPath\]\) \{[\s\S]*refAudios\.push\(`asset:\/\/\$\{audioAssetIdMap\[audioPath\]\}`\)/,
+		'manually bound audio asset IDs must be passed to Seedance as asset:// references',
+	)
+	assert.ok(
+		audioFlow.indexOf('else if (tokenRouterModelArkCreds)') < audioFlow.indexOf('else if (audioAssetIdMap[audioPath])'),
+		'configured TokenRouter ModelArk assets must still validate the cached ID before reuse',
+	)
+	assert.match(
+		mcpSource,
+		/Bind a provider-specific Seedance Asset ID to an image or audio file node/,
+		'MCP set_asset_id description must document audio node support',
+	)
+	assert.match(
+		mcpSource,
+		/!getSeedanceAssetMediaKind\(d\.file \|\| ''\)/,
+		'MCP set_asset_id must use the same image/audio validation as the context menu',
+	)
+
+	console.log('Audio Asset ID checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/asset-ids.ts
+++ b/src/asset-ids.ts
@@ -1,0 +1,82 @@
+import type { Canvas, CanvasNode } from './types/canvas-internal'
+
+export type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
+
+export const SEEDANCE_ASSET_PROVIDER_LABELS: Record<SeedanceAssetProviderId, string> = {
+	tokenrouter: 'TokenRouter',
+	byteplus: 'BytePlus',
+	bytedance: 'Volcengine',
+}
+
+const ASSET_ID_IMAGE_EXTS = /\.(png|jpg|jpeg|webp|bmp|tiff?|gif|heic|heif)$/i
+const ASSET_ID_AUDIO_EXTS = /\.(mp3|wav|flac|m4a|ogg|aac|opus)$/i
+
+type AssetNodeData = {
+	bragiAssetId?: string
+	bragiAssetIds?: Record<string, string>
+}
+
+export type SeedanceAssetMediaKind = 'image' | 'audio'
+
+export function getSeedanceAssetMediaKind(filePath: string): SeedanceAssetMediaKind | null {
+	if (ASSET_ID_IMAGE_EXTS.test(filePath)) return 'image'
+	if (ASSET_ID_AUDIO_EXTS.test(filePath)) return 'audio'
+	return null
+}
+
+export function findFileNodeByPath(canvas: Canvas, filePath: string): CanvasNode | null {
+	const nodes = canvas.nodes instanceof Map
+		? Array.from(canvas.nodes.values())
+		: canvas.nodes as unknown as CanvasNode[]
+	for (const node of nodes) {
+		const data = node.getData()
+		if (data.type === 'file' && data.file === filePath) return node
+	}
+	return null
+}
+
+export function getNodeAssetIdMap(node: CanvasNode): Record<string, string> {
+	const data = node.getData() as AssetNodeData
+	const ids = { ...(data.bragiAssetIds || {}) }
+	if (data.bragiAssetId && !ids.legacy) ids.legacy = data.bragiAssetId
+	return ids
+}
+
+export function getNodeAssetId(node: CanvasNode, provider: string): string {
+	const data = node.getData() as AssetNodeData
+	const scoped = data.bragiAssetIds?.[provider]
+	if (scoped) return scoped
+	if ((provider === 'bytedance' || provider === 'byteplus') && data.bragiAssetId) return data.bragiAssetId
+	return ''
+}
+
+export function setNodeAssetId(node: CanvasNode, provider: SeedanceAssetProviderId, assetId: string): void {
+	const data = node.getData() as AssetNodeData
+	const hadScopedId = !!data.bragiAssetIds?.[provider]
+	const ids = { ...(data.bragiAssetIds || {}) }
+	if (assetId) ids[provider] = assetId
+	else delete ids[provider]
+
+	const next: AssetNodeData = { ...data }
+	if (Object.keys(ids).length > 0) next.bragiAssetIds = ids
+	else delete next.bragiAssetIds
+	if (!assetId && !hadScopedId && (provider === 'bytedance' || provider === 'byteplus')) {
+		delete next.bragiAssetId
+	}
+	node.setData(next)
+}
+
+export function getAssetIdsForFiles(
+	canvas: Canvas,
+	filePaths: string[],
+	provider?: string,
+): Record<string, string> {
+	const result: Record<string, string> = {}
+	for (const filePath of filePaths) {
+		const fileNode = findFileNodeByPath(canvas, filePath)
+		if (!fileNode || !provider) continue
+		const assetId = getNodeAssetId(fileNode, provider)
+		if (assetId) result[filePath] = assetId
+	}
+	return result
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,14 +44,7 @@ import { checkForPluginUpdate, markUpdatePrompted, shouldShowAutomaticUpdateProm
 import { UpdateReminderModal } from './ui/update-modal'
 import { dashScopeRegion } from './providers/dashscope'
 import { BFL_DENOISE_PROMPT } from './providers/bfl'
-
-type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
-
-const SEEDANCE_ASSET_PROVIDER_LABELS: Record<SeedanceAssetProviderId, string> = {
-	tokenrouter: 'TokenRouter',
-	byteplus: 'BytePlus',
-	bytedance: 'Volcengine',
-}
+import { getAssetIdsForFiles, getNodeAssetId, getNodeAssetIdMap, getSeedanceAssetMediaKind, SEEDANCE_ASSET_PROVIDER_LABELS, setNodeAssetId, type SeedanceAssetProviderId } from './asset-ids'
 
 const ELEVENLABS_VOICE_CHANGER_MODEL_ID = 'eleven_multilingual_sts_v2'
 
@@ -98,16 +91,16 @@ export default class BragiCanvas extends Plugin {
 		// from getting swapped out when the user clicks another file.
 		this.register(installAlwaysNewTab(this.app))
 
-		// Right-click menu: Set Asset ID on image nodes
+		// Right-click menu: Set Asset ID on image and audio nodes
 		this.registerEvent(
 			// @ts-ignore — internal API
 			this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNode) => {
 				const nodeData = node.getData()
 				if (nodeData.type !== 'file') return
 				const filePath = (nodeData as { file?: string }).file || ''
-				if (!/\.(png|jpg|jpeg|webp|bmp|tiff?|gif|heic|heif)$/i.test(filePath)) return
+				if (!getSeedanceAssetMediaKind(filePath)) return
 
-				const assetIds = this.getNodeAssetIdMap(node)
+				const assetIds = getNodeAssetIdMap(node)
 				const scopedCount = Object.keys(assetIds).length
 				menu.addItem((item) => {
 					item.setTitle(scopedCount ? `Seedance asset IDs: ${scopedCount}` : 'Set Seedance asset ID')
@@ -736,6 +729,9 @@ export default class BragiCanvas extends Plugin {
 				// image/audio/video, which the gateway turns into Ark content[] roles.
 				|| (activeProvider === 'svnewapi' && isSeedanceModel)
 			const assetIdMap = supportsSeedanceAssetRefs ? getAssetIds(canvas, node, activeProvider) : {}
+			const audioAssetIdMap = supportsSeedanceAssetRefs
+				? getAssetIdsForFiles(canvas, uniqueAudios, activeProvider)
+				: {}
 			const token360AssetCreds = (activeProvider === 'token360' && isSeedanceModel && uniqueImages.length > 0)
 				? getToken360AssetCreds(this)
 				: null
@@ -783,6 +779,8 @@ export default class BragiCanvas extends Plugin {
 						refAudios.push(await ensureBytePlusAsset(this, canvas, audioPath, bytePlusCreds))
 					} else if (tokenRouterModelArkCreds) {
 						refAudios.push(await ensureTokenRouterModelArkAsset(this, canvas, audioPath, tokenRouterModelArkCreds))
+					} else if (audioAssetIdMap[audioPath]) {
+						refAudios.push(`asset://${audioAssetIdMap[audioPath]}`)
 					} else {
 						refAudios.push(await this.prepareReferenceMedia(activeProvider, model, 'audio', audioPath))
 					}
@@ -1187,37 +1185,6 @@ export default class BragiCanvas extends Plugin {
 		}
 	}
 
-	private getNodeAssetIdMap(node: CanvasNode): Record<string, string> {
-		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
-		const ids = { ...(data.bragiAssetIds || {}) }
-		if (data.bragiAssetId && !ids.legacy) ids.legacy = data.bragiAssetId
-		return ids
-	}
-
-	private getNodeAssetId(node: CanvasNode, provider: SeedanceAssetProviderId): string {
-		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
-		const scoped = data.bragiAssetIds?.[provider]
-		if (scoped) return scoped
-		if ((provider === 'bytedance' || provider === 'byteplus') && data.bragiAssetId) return data.bragiAssetId
-		return ''
-	}
-
-	private setNodeAssetId(node: CanvasNode, provider: SeedanceAssetProviderId, assetId: string): void {
-		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
-		const hadScopedId = !!data.bragiAssetIds?.[provider]
-		const ids = { ...(data.bragiAssetIds || {}) }
-		if (assetId) ids[provider] = assetId
-		else delete ids[provider]
-
-		const next: typeof data = { ...data }
-		if (Object.keys(ids).length > 0) next.bragiAssetIds = ids
-		else delete next.bragiAssetIds
-		if (!assetId && !hadScopedId && (provider === 'bytedance' || provider === 'byteplus')) {
-			delete next.bragiAssetId
-		}
-		node.setData(next)
-	}
-
 	showAssetIdModal(node: CanvasNode): void {
 		const data = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
 		let providerId: SeedanceAssetProviderId = data.bragiAssetIds?.tokenrouter
@@ -1227,13 +1194,13 @@ export default class BragiCanvas extends Plugin {
 				: (data.bragiAssetIds?.bytedance || data.bragiAssetId)
 					? 'bytedance'
 					: 'tokenrouter'
-		let currentId = this.getNodeAssetId(node, providerId)
+		let currentId = getNodeAssetId(node, providerId)
 
 		const modal = new Modal(this.app)
 		modal.modalEl.classList.add('bragi-modal')
 		modal.titleEl.setText('Set seedance asset ID')
 		modal.contentEl.createEl('p', {
-			text: 'Asset ids are provider-specific. The same image can have separate tokenrouter, byteplus, and volcengine ids.',
+			text: 'Asset ids are provider-specific. The same file can have separate tokenrouter, byteplus, and volcengine ids.',
 			cls: 'setting-item-description',
 		})
 
@@ -1250,7 +1217,7 @@ export default class BragiCanvas extends Plugin {
 					.setValue(providerId)
 					.onChange(value => {
 						providerId = value as SeedanceAssetProviderId
-						currentId = this.getNodeAssetId(node, providerId)
+						currentId = getNodeAssetId(node, providerId)
 						inputValue = currentId
 						if (inputEl) inputEl.value = currentId
 					})
@@ -1270,7 +1237,7 @@ export default class BragiCanvas extends Plugin {
 
 		const clearBtn = btnContainer.createEl('button', { text: 'Clear' })
 		clearBtn.addEventListener('click', () => {
-			this.setNodeAssetId(node, providerId, '')
+			setNodeAssetId(node, providerId, '')
 			new Notice(`${SEEDANCE_ASSET_PROVIDER_LABELS[providerId]} asset ID cleared`)
 			modal.close()
 		})
@@ -1282,10 +1249,10 @@ export default class BragiCanvas extends Plugin {
 		saveBtn.addEventListener('click', () => {
 			const val = inputValue.trim()
 			if (val) {
-				this.setNodeAssetId(node, providerId, val)
+				setNodeAssetId(node, providerId, val)
 				new Notice(`${SEEDANCE_ASSET_PROVIDER_LABELS[providerId]} asset ID saved`)
 			} else {
-				this.setNodeAssetId(node, providerId, '')
+				setNodeAssetId(node, providerId, '')
 			}
 			modal.close()
 		})

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -14,6 +14,7 @@ import { getOrderedTextRefs } from './text-refs'
 import { getOrderedImages } from './ref-thumbnails'
 import type { TaskQueue, TaskSnapshot } from './task-queue'
 import type { BragiSettings } from './settings'
+import { getSeedanceAssetMediaKind, setNodeAssetId, type SeedanceAssetProviderId } from './asset-ids'
 
 export type GetCanvas = () => Canvas | null
 export type RunGeneration = (node: CanvasNode, result: PanelResult) => Promise<{
@@ -27,7 +28,6 @@ export interface McpToolResult {
 type ToolArgs<Args extends ToolSchema> = z.infer<z.ZodObject<Args>>
 
 type JsonMap = Record<string, unknown>
-type SeedanceAssetProviderId = 'tokenrouter' | 'byteplus' | 'bytedance'
 type BragiCanvasNodeData = AllCanvasNodeData & {
 	bragiAssetId?: string
 	bragiAssetIds?: Record<string, string>
@@ -908,7 +908,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 		{
 			category: 'Files / assets',
 			name: 'set_asset_id',
-			description: 'Bind a provider-specific Seedance Asset ID to an image file node. Used for face-reference asset://<id> protocol. Pass empty string to clear.',
+			description: 'Bind a provider-specific Seedance Asset ID to an image or audio file node. Pass empty string to clear.',
 			inputSchema: {
 				nodeId: z.string(),
 				provider: z.enum(['tokenrouter', 'byteplus', 'bytedance']).optional().describe('Asset provider namespace. Defaults to tokenrouter.'),
@@ -918,17 +918,11 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 				const canvas = requireCanvas(getCanvas)
 				const node = findNode(canvas, nodeId)
 				const d = node.getData() as BragiCanvasNodeData
-				if (d.type !== 'file' || !/\.(png|jpg|jpeg|webp|bmp|tiff?|gif|heic|heif)$/i.test(d.file || '')) {
-					throw new Error('Asset ID only applies to image file nodes')
+				if (d.type !== 'file' || !getSeedanceAssetMediaKind(d.file || '')) {
+					throw new Error('Asset ID only applies to image or audio file nodes')
 				}
 				const providerId = (provider || 'tokenrouter') as SeedanceAssetProviderId
-				const next = { ...d }
-				const ids = { ...(next.bragiAssetIds || {}) }
-				if (assetId) ids[providerId] = assetId
-				else delete ids[providerId]
-				if (Object.keys(ids).length > 0) next.bragiAssetIds = ids
-				else delete next.bragiAssetIds
-				node.setData(next)
+				setNodeAssetId(node, providerId, assetId)
 				void canvas.requestSave()
 				return ok({ nodeId, provider: providerId, assetId: assetId || null })
 			},

--- a/src/ref-thumbnails.ts
+++ b/src/ref-thumbnails.ts
@@ -4,6 +4,7 @@ import type { Canvas, CanvasNode } from './types/canvas-internal'
 import { getUpstreamInputs } from './edge-parser'
 import { clearIncomingRefAttachments, isGeneratingPlaceholderNode } from './generating-node'
 import { beginRefDrag, endRefDrag, isRefDragActive } from './ref-drag-guard'
+import { findFileNodeByPath, getAssetIdsForFiles, getNodeAssetIdMap } from './asset-ids'
 
 const STRIP_CLASS = 'bragi-ref-strip'
 const NODE_HAS_REFS_CLASS = 'bragi-has-refs'
@@ -102,8 +103,8 @@ export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App):
 		wrapper.appendChild(badge)
 
 		// Asset ID indicator — read from the source image node
-		const sourceImageNode = findImageNode(canvas, imgPath)
-		const assetIds = sourceImageNode ? getNodeAssetIds(sourceImageNode) : {}
+		const sourceImageNode = findFileNodeByPath(canvas, imgPath)
+		const assetIds = sourceImageNode ? getNodeAssetIdMap(sourceImageNode) : {}
 		const assetIdCount = Object.keys(assetIds).length
 
 		if (assetIdCount > 0) {
@@ -172,53 +173,12 @@ export function updateRefThumbnails(canvas: Canvas, node: CanvasNode, app: App):
 }
 
 /**
- * Find the canvas node for a given image file path.
- */
-function findImageNode(canvas: Canvas, imgPath: string): CanvasNode | null {
-	const nodes = canvas.nodes instanceof Map
-		? Array.from(canvas.nodes.values())
-		: canvas.nodes as unknown[]
-	for (const n of nodes) {
-		const d = n.getData()
-		if (d.type === 'file' && (d).file === imgPath) return n
-	}
-	return null
-}
-
-function getNodeAssetIds(node: CanvasNode): Record<string, string> {
-	const d = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
-	const ids = { ...(d.bragiAssetIds || {}) }
-	if (d.bragiAssetId && !ids.legacy) ids.legacy = d.bragiAssetId
-	return ids
-}
-
-function getProviderAssetId(node: CanvasNode, providerId?: string): string {
-	const d = node.getData() as { bragiAssetId?: string; bragiAssetIds?: Record<string, string> }
-	if (providerId) {
-		const scoped = d.bragiAssetIds?.[providerId]
-		if (scoped) return scoped
-		if ((providerId === 'bytedance' || providerId === 'byteplus') && d.bragiAssetId) return d.bragiAssetId
-		return ''
-	}
-	return d.bragiAssetId || ''
-}
-
-/**
  * Get asset ID map for a node's upstream images.
  * Reads provider-scoped bragiAssetIds first; legacy bragiAssetId only falls
  * back for Volcengine/BytePlus compatibility.
  */
 export function getAssetIds(canvas: Canvas, node: CanvasNode, providerId?: string): Record<string, string> {
-	const images = getOrderedImages(canvas, node)
-	const result: Record<string, string> = {}
-	for (const imgPath of images) {
-		const imgNode = findImageNode(canvas, imgPath)
-		if (imgNode) {
-			const assetId = getProviderAssetId(imgNode, providerId)
-			if (assetId) result[imgPath] = assetId
-		}
-	}
-	return result
+	return getAssetIdsForFiles(canvas, getOrderedImages(canvas, node), providerId)
 }
 
 export function refreshAllThumbnails(canvas: Canvas, app: App): void {


### PR DESCRIPTION
## What changed

- add the same provider-scoped Seedance Asset ID context-menu flow to audio nodes
- reuse saved audio IDs as `asset://...` references during Seedance generation
- allow MCP `set_asset_id` on image or audio nodes
- centralize Asset ID persistence and add regression coverage

## Why

Audio nodes could be uploaded automatically through provider asset libraries, but users could not bind an existing Asset ID like they could for images.

## Validation

- `npm run test:audio-asset-id`
- `npm run test:tokenrouter-modelark-assets`
- `npm run build`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `git diff --check`
