### PR TITLE
feat: add Seedance 2.0 4K resolution

### DIFF
--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -58,6 +58,7 @@ export const seedance2: ModelConfig = {
 				{ label: '480p', value: '480p' },
 				{ label: '720p', value: '720p' },
 				{ label: '1080p', value: '1080p' },
+				{ label: '4K', value: '4k' },
 			],
 			default: '720p',
 		},


### PR DESCRIPTION
## What changed

- add a 4K resolution option to Seedance 2.0
- send the exact provider value `4k`
- keep Seedance 2.0 Fast unchanged

## Impact

The option is available in the generation panel and the MCP-visible model schema.

## Validation

- `npm run build`
- `npm run lint:obsidian`
- `npm run check:catalog`
- `npm run audit:catalog` (194 combinations)
- targeted Seedance 2.0 / Fast resolution assertion
- paired `sync-check.mjs` (1.30.1, 27 MCP tools)

Paired Skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/50
