### PR TITLE
feat: add local NLM 35 denoise option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:update-check": "node scripts/verify-update-check.mjs",
     "test:gemini-video-text": "node scripts/verify-gemini-video-text.mjs",
     "test:bfl-denoise": "node scripts/verify-bfl-denoise.mjs",
+    "test:local-denoise": "node scripts/verify-local-denoise.mjs",
     "test:fal-flux-klein": "node scripts/verify-fal-flux-klein.mjs",
     "test:legnext-image-result": "node scripts/verify-legnext-image-result.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",

--- a/scripts/verify-bfl-denoise.mjs
+++ b/scripts/verify-bfl-denoise.mjs
@@ -10,6 +10,7 @@ const registrySource = readFileSync('src/providers/registry.ts', 'utf8')
 const modelSource = readFileSync('src/models/flux.ts', 'utf8')
 const modelIndexSource = readFileSync('src/models/index.ts', 'utf8')
 const settingsSource = readFileSync('src/settings.ts', 'utf8')
+const denoiseModalSource = readFileSync('src/ui/denoise-choice-modal.ts', 'utf8')
 
 function assertOrder(source, first, second, message) {
 	const firstIndex = source.indexOf(first)
@@ -131,26 +132,22 @@ assert.match(
 	'Denoise toolbar elements must be cleaned up by the toolbar cleanup paths.',
 )
 
-assert.doesNotMatch(
+assert.match(
 	mainSource,
-	/DenoiseImageModal/,
-	'Denoise should run directly from the toolbar instead of opening the old two-choice modal.',
+	/\(node, activeCanvas\) => this\.openDenoiseImage\(node, activeCanvas\),\s*\n\s*\)/,
+	'Canvas menu must keep Denoise visible independently of FLUX configuration.',
 )
 assert.match(
 	mainSource,
-	/\(node, activeCanvas\) => this\.openDenoiseImage\(node, activeCanvas\),\s*\n\s*\(\) => this\.canDenoiseImage\(\)/,
-	'Canvas menu must pair the denoise callback with its dynamic availability predicate.',
+	/private getFluxDenoiseContext\(\): \{ model: ModelConfig; activeProvider: string \} \| null \{[\s\S]*if \(!pref\?\.enabled\) return null[\s\S]*getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*activeProvider \? \{ model, activeProvider \} : null/,
+	'The dropdown must resolve FLUX availability from the enabled model and configured provider.',
 )
 assert.match(
 	mainSource,
-	/private canDenoiseImage\(\): boolean \{[\s\S]*if \(!pref\?\.enabled\) return false[\s\S]*getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*getActiveProvider\(model, pref\.selectedProvider, connectedProviders\) !== null/,
-	'Denoise availability must require the FLUX model to be enabled with an active configured provider.',
+	/openDenoiseImage\(node: CanvasNode, canvas: Canvas\): void \{[\s\S]*new DenoiseChoiceModal\(this\.app,[\s\S]*handleImageDenoise\(node, canvas, method\)/,
+	'Denoise must open the method dropdown before dispatching a workflow.',
 )
-assert.match(
-	mainSource,
-	/openDenoiseImage\(node: CanvasNode, canvas: Canvas\): void \{\s*\n\s*void this\.handleImageDenoise\(node, canvas\)/,
-	'One-click denoise must call handleImageDenoise directly.',
-)
+assert.match(denoiseModalSource, /addOption\([\s\S]*'flux'[\s\S]*FLUX\.2 Klein 9B/, 'The denoise dropdown must retain FLUX.2 Klein 9B.')
 assert.doesNotMatch(
 	mainSource,
 	/getProvider\('bfl'\)|this\.settings\.providers\.bfl/,
@@ -158,8 +155,8 @@ assert.doesNotMatch(
 )
 assert.match(
 	mainSource,
-	/if \(!pref\?\.enabled\) \{[\s\S]*Add FLUX\.2 Klein 9B in settings to use denoise[\s\S]*getConnectedConfiguredProviderIds\(this\.settings, model\)[\s\S]*getActiveProvider\(model, pref\.selectedProvider, connectedProviders\)/,
-	'Denoise action must require the enabled FLUX model and resolve its current configured provider.',
+	/private async handleFluxImageDenoise\(node: CanvasNode, canvas: Canvas\): Promise<void> \{[\s\S]*const context = this\.getFluxDenoiseContext\(\)[\s\S]*const \{ model, activeProvider \} = context/,
+	'FLUX denoise must reuse the resolved current provider.',
 )
 assert.ok(
 	mainSource.includes("createPlaceholderNode(canvas, 'Denoising image…'"),

--- a/scripts/verify-local-denoise.mjs
+++ b/scripts/verify-local-denoise.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { build } from 'esbuild'
+
+const denoiseSource = readFileSync('src/denoise.ts', 'utf8')
+const mainSource = readFileSync('src/main.ts', 'utf8')
+const modalSource = readFileSync('src/ui/denoise-choice-modal.ts', 'utf8')
+const settingsSource = readFileSync('src/settings.ts', 'utf8')
+const migrationsSource = readFileSync('src/settings-migrations.ts', 'utf8')
+
+assert.match(denoiseSource, /export const NLM_35_STRENGTH = 0\.35/, 'NLM strength must stay at the selected 35% blend.')
+assert.match(denoiseSource, /body: JSON\.stringify\(\{ image: dataUri, strength: NLM_35_STRENGTH \}\)/, 'The client must send the image and NLM 35 strength.')
+assert.match(modalSource, /private method: DenoiseMethod = 'nlm35'/, 'NLM 35 must be the default denoise choice.')
+assert.match(modalSource, /const nlmLabel = 'NLM 35 - Local CPU'[\s\S]*addOption\('nlm35', nlmLabel\)/, 'The modal must expose NLM 35.')
+assert.match(modalSource, /addOption\([\s\S]*'flux'[\s\S]*FLUX\.2 Klein 9B/, 'The modal must retain the FLUX choice.')
+assert.match(modalSource, /fluxOption\.disabled = !this\.options\.fluxAvailable/, 'Unavailable FLUX must be disabled in the dropdown.')
+assert.match(mainSource, /new DenoiseChoiceModal\(this\.app, \{[\s\S]*fluxAvailable: Boolean\(fluxContext\)[\s\S]*handleImageDenoise\(node, canvas, method\)/, 'The toolbar action must open the denoise choice modal.')
+assert.match(mainSource, /async handleImageDenoise\(node: CanvasNode, canvas: Canvas, method: DenoiseMethod = 'nlm35'\)/, 'The dispatcher must default to NLM 35.')
+assert.match(mainSource, /createPlaceholderNode\(canvas, 'NLM 35'/, 'NLM must use the normal generation placeholder.')
+assert.match(mainSource, /requestNlm35Denoise\(dataUri, this\.settings\.denoiseServiceUrl\)/, 'NLM must use the configured service endpoint.')
+assert.match(mainSource, /writeNlm35Result\(filePath, result\.bytes\)[\s\S]*replacePlaceholderWithFile\(canvas, placeholder, outputPath, node\)/, 'NLM output must replace the placeholder with a file node.')
+assert.match(settingsSource, /denoiseServiceUrl: string/, 'Settings must include the denoise service URL.')
+assert.match(settingsSource, /denoiseServiceUrl: DEFAULT_DENOISE_SERVICE_URL/, 'Settings must default to the localhost service.')
+assert.match(migrationsSource, /readOptionalString\(raw, 'denoiseServiceUrl'/, 'Settings migration must retain a configured service URL.')
+
+const bundle = await build({
+	entryPoints: ['src/denoise.ts'],
+	bundle: true,
+	write: false,
+	platform: 'node',
+	format: 'esm',
+	plugins: [{
+		name: 'obsidian-stub',
+		setup(builder) {
+			builder.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'stub' }))
+			builder.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({ contents: 'export const requestUrl = async () => { throw new Error("not mocked") }' }))
+		},
+	}],
+})
+
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString('base64')}`
+const denoise = await import(moduleUrl)
+let capturedRequest
+const result = await denoise.requestNlm35Denoise(
+	'data:image/png;base64,AA==',
+	'http://127.0.0.1:17776/',
+	async request => {
+		capturedRequest = request
+		return {
+			status: 200,
+			headers: {},
+			arrayBuffer: new ArrayBuffer(0),
+			text: '',
+			json: {
+				algorithm: 'nlm-35',
+				mimeType: 'image/png',
+				width: 24,
+				height: 16,
+				image: 'data:image/png;base64,AQID',
+			},
+		}
+	},
+)
+
+assert.equal(capturedRequest.url, 'http://127.0.0.1:17776/v1/denoise')
+assert.equal(capturedRequest.method, 'POST')
+assert.deepEqual(JSON.parse(capturedRequest.body), { image: 'data:image/png;base64,AA==', strength: 0.35 })
+assert.deepEqual([...new Uint8Array(result.bytes)], [1, 2, 3])
+assert.equal(result.width, 24)
+assert.equal(result.height, 16)
+
+await assert.rejects(
+	denoise.requestNlm35Denoise('data:image/png;base64,AA==', '', async () => ({
+		status: 503,
+		headers: {},
+		arrayBuffer: new ArrayBuffer(0),
+		text: '',
+		json: { error: 'service busy' },
+	})),
+	/service busy/,
+)
+
+console.log('Local NLM denoise checks passed.')

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -233,7 +233,7 @@ try {
 	assert.match(settingsSource, /pika: ''/, 'Default settings must include an empty Pika key.')
 	assert.match(
 		migrationsSource,
-		/CURRENT_SETTINGS_SCHEMA_VERSION = 9/,
+		/CURRENT_SETTINGS_SCHEMA_VERSION = 10/,
 		'Adding a provider credential must advance the settings schema version.',
 	)
 	assert.match(

--- a/src/denoise.ts
+++ b/src/denoise.ts
@@ -1,0 +1,103 @@
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from 'obsidian'
+
+export const DEFAULT_DENOISE_SERVICE_URL = 'http://127.0.0.1:17776'
+export const NLM_35_STRENGTH = 0.35
+
+type Requester = (request: RequestUrlParam | string) => Promise<RequestUrlResponse>
+
+interface NlmDenoisePayload {
+	image: string
+	mimeType: string
+	width: number
+	height: number
+	algorithm: string
+}
+
+export interface NlmDenoiseResult {
+	bytes: ArrayBuffer
+	mimeType: string
+	width: number
+	height: number
+}
+
+export function resolveDenoiseEndpoint(serviceUrl: string): string {
+	const base = serviceUrl.trim().replace(/\/+$/, '') || DEFAULT_DENOISE_SERVICE_URL
+	return base.endsWith('/v1/denoise') ? base : `${base}/v1/denoise`
+}
+
+export async function requestNlm35Denoise(
+	dataUri: string,
+	serviceUrl: string,
+	requester: Requester = requestUrl,
+): Promise<NlmDenoiseResult> {
+	const endpoint = resolveDenoiseEndpoint(serviceUrl)
+	let response: RequestUrlResponse
+	try {
+		response = await requester({
+			url: endpoint,
+			method: 'POST',
+			contentType: 'application/json',
+			body: JSON.stringify({ image: dataUri, strength: NLM_35_STRENGTH }),
+			throw: false,
+		})
+	} catch (error: unknown) {
+		throw new Error(`NLM 35 service is unavailable at ${endpoint}: ${errorMessage(error)}`)
+	}
+
+	const payload = response.json as unknown
+	if (response.status < 200 || response.status >= 300) {
+		throw new Error(readServiceError(payload) || `NLM 35 service returned HTTP ${response.status}`)
+	}
+	if (!isNlmDenoisePayload(payload)) {
+		throw new Error('NLM 35 service returned an invalid response')
+	}
+	if (payload.algorithm !== 'nlm-35') {
+		throw new Error(`NLM 35 service returned unexpected algorithm "${payload.algorithm}"`)
+	}
+
+	return {
+		bytes: decodeImageDataUri(payload.image, payload.mimeType),
+		mimeType: payload.mimeType,
+		width: payload.width,
+		height: payload.height,
+	}
+}
+
+function isNlmDenoisePayload(value: unknown): value is NlmDenoisePayload {
+	if (!value || typeof value !== 'object') return false
+	const payload = value as Record<string, unknown>
+	return typeof payload.image === 'string'
+		&& typeof payload.mimeType === 'string'
+		&& typeof payload.width === 'number'
+		&& Number.isInteger(payload.width)
+		&& payload.width > 0
+		&& typeof payload.height === 'number'
+		&& Number.isInteger(payload.height)
+		&& payload.height > 0
+		&& typeof payload.algorithm === 'string'
+}
+
+function decodeImageDataUri(dataUri: string, expectedMimeType: string): ArrayBuffer {
+	const match = /^data:([^;,]+);base64,([A-Za-z0-9+/=\s]+)$/.exec(dataUri)
+	if (!match || match[1] !== expectedMimeType) {
+		throw new Error('NLM 35 service returned invalid image data')
+	}
+	try {
+		const binary = atob(match[2].replace(/\s/g, ''))
+		const bytes = new Uint8Array(binary.length)
+		for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index)
+		return bytes.buffer
+	} catch {
+		throw new Error('NLM 35 service returned malformed base64 image data')
+	}
+}
+
+function readServiceError(value: unknown): string {
+	if (!value || typeof value !== 'object') return ''
+	const error = (value as Record<string, unknown>).error
+	return typeof error === 'string' ? error : ''
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access -- Obsidian Canvas internals and provider payloads are runtime-shaped data that this plugin narrows at use sites. */
-import { Plugin, Notice, requestUrl, Menu, Modal, Setting } from 'obsidian'
+import { Plugin, Notice, requestUrl, Menu, Modal, Setting, normalizePath } from 'obsidian'
 import { BragiSettings, DEFAULT_SETTINGS, BragiSettingTab, type GeneratedAssetRecord } from './settings'
 import { migrateSettings } from './settings-migrations'
 import { uploadRef } from './providers/upload'
@@ -45,6 +45,8 @@ import { UpdateReminderModal } from './ui/update-modal'
 import { dashScopeRegion } from './providers/dashscope'
 import { BFL_DENOISE_PROMPT } from './providers/bfl'
 import { getAssetIdsForFiles, getNodeAssetId, getNodeAssetIdMap, getSeedanceAssetMediaKind, SEEDANCE_ASSET_PROVIDER_LABELS, setNodeAssetId, type SeedanceAssetProviderId } from './asset-ids'
+import { requestNlm35Denoise } from './denoise'
+import { DenoiseChoiceModal, type DenoiseMethod } from './ui/denoise-choice-modal'
 
 const ELEVENLABS_VOICE_CHANGER_MODEL_ID = 'eleven_multilingual_sts_v2'
 
@@ -405,7 +407,6 @@ export default class BragiCanvas extends Plugin {
 			(node, activeCanvas) => openImageAnnotationTool(this, activeCanvas, node, 'box'),
 			(node, activeCanvas) => openVideoEditTool(this, activeCanvas, node),
 			(node, activeCanvas) => this.openDenoiseImage(node, activeCanvas),
-			() => this.canDenoiseImage(),
 		)
 
 		patchPlaceholderContextMenu(canvas)
@@ -475,35 +476,75 @@ export default class BragiCanvas extends Plugin {
 	}
 
 	openDenoiseImage(node: CanvasNode, canvas: Canvas): void {
-		void this.handleImageDenoise(node, canvas)
+		const fluxContext = this.getFluxDenoiseContext()
+		const fluxProviderName = fluxContext
+			? getProvider(fluxContext.activeProvider)?.name || fluxContext.activeProvider
+			: undefined
+		new DenoiseChoiceModal(this.app, {
+			fluxAvailable: Boolean(fluxContext),
+			fluxProviderName,
+			onChoose: method => { void this.handleImageDenoise(node, canvas, method) },
+		}).open()
 	}
 
-	private canDenoiseImage(): boolean {
+	private getFluxDenoiseContext(): { model: ModelConfig; activeProvider: string } | null {
 		const model = getModelById('flux-2-klein-9b')
-		if (!model) return false
+		if (!model) return null
 		const pref = this.settings.modelPrefs[model.id]
-		if (!pref?.enabled) return false
-		const connectedProviders = getConnectedConfiguredProviderIds(this.settings, model)
-		return getActiveProvider(model, pref.selectedProvider, connectedProviders) !== null
-	}
-
-	async handleImageDenoise(node: CanvasNode, canvas: Canvas): Promise<void> {
-		const model = getModelById('flux-2-klein-9b')
-		if (!model) {
-			new Notice('FLUX.2 Klein 9B is not available')
-			return
-		}
-		const pref = this.settings.modelPrefs[model.id]
-		if (!pref?.enabled) {
-			new Notice('Add FLUX.2 Klein 9B in settings to use denoise')
-			return
-		}
+		if (!pref?.enabled) return null
 		const connectedProviders = getConnectedConfiguredProviderIds(this.settings, model)
 		const activeProvider = getActiveProvider(model, pref.selectedProvider, connectedProviders)
-		if (!activeProvider) {
-			new Notice('Connect BFL, RunPod, or fal.ai to FLUX.2 Klein 9B in settings to use denoise')
+		return activeProvider ? { model, activeProvider } : null
+	}
+
+	async handleImageDenoise(node: CanvasNode, canvas: Canvas, method: DenoiseMethod = 'nlm35'): Promise<void> {
+		if (method === 'nlm35') {
+			await this.handleNlm35ImageDenoise(node, canvas)
 			return
 		}
+		await this.handleFluxImageDenoise(node, canvas)
+	}
+
+	private async handleNlm35ImageDenoise(node: CanvasNode, canvas: Canvas): Promise<void> {
+		const nodeData = node.getData() as { file?: string; width?: number; height?: number }
+		const filePath = nodeData.file || ''
+		if (!filePath) {
+			new Notice('No image file found')
+			return
+		}
+
+		const placeholder = createPlaceholderNode(canvas, 'NLM 35', node, {
+			w: Math.max(120, Math.round(nodeData.width || node.width || 400)),
+			h: Math.max(120, Math.round(nodeData.height || node.height || 300)),
+		})
+		this.syncGenerating.add(placeholder.id)
+
+		try {
+			new Notice('Running local denoise…')
+			const dataUri = await this.readImageDataUri(filePath)
+			const result = await requestNlm35Denoise(dataUri, this.settings.denoiseServiceUrl)
+			const outputPath = await this.writeNlm35Result(filePath, result.bytes)
+
+			this.rememberGeneratedAsset(outputPath)
+			replacePlaceholderWithFile(canvas, placeholder, outputPath, node)
+			new Notice('Denoised image ready')
+		} catch (err: unknown) {
+			console.error('Bragi Canvas NLM 35 denoise error:', err)
+			const message = err instanceof Error ? err.message : 'NLM 35 denoise failed'
+			markNodeFailed(placeholder, message)
+			new Notice(`NLM 35 failed: ${message}`)
+		} finally {
+			this.syncGenerating.delete(placeholder.id)
+		}
+	}
+
+	private async handleFluxImageDenoise(node: CanvasNode, canvas: Canvas): Promise<void> {
+		const context = this.getFluxDenoiseContext()
+		if (!context) {
+			new Notice('Connect BFL, RunPod, or fal.ai to FLUX.2 Klein 9B in settings to use AI refine')
+			return
+		}
+		const { model, activeProvider } = context
 
 		const nodeData = node.getData() as { file?: string; width?: number; height?: number }
 		const filePath = nodeData.file || ''
@@ -551,6 +592,22 @@ export default class BragiCanvas extends Plugin {
 		} finally {
 			this.syncGenerating.delete(placeholder.id)
 		}
+	}
+
+	private async writeNlm35Result(sourcePath: string, bytes: ArrayBuffer): Promise<string> {
+		const outputDir = normalizePath(this.getOutputDir())
+		const adapter = this.app.vault.adapter
+		let current = ''
+		for (const part of outputDir.split('/').filter(Boolean)) {
+			current = current ? `${current}/${part}` : part
+			if (!await adapter.exists(current)) await adapter.mkdir(current)
+		}
+
+		const sourceName = sourcePath.split('/').pop()?.replace(/\.[^.]+$/, '') || 'image'
+		const safeName = sourceName.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'image'
+		const outputPath = normalizePath(`${outputDir}/${safeName}_nlm35_${Date.now()}.png`)
+		await adapter.writeBinary(outputPath, bytes)
+		return outputPath
 	}
 
 	private async readImageDataUri(filePath: string): Promise<string> {

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 9
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 10
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {
@@ -306,6 +306,7 @@ function readSettings(raw: UnknownRecord, defaults: BragiSettings): { settings: 
 	readOptionalBoolean(raw, 'mcpEnabled', target, errors)
 	readOptionalPort(raw, 'mcpPort', target, errors)
 	readOptionalString(raw, 'mcpToken', target, errors)
+	readOptionalString(raw, 'denoiseServiceUrl', target, errors)
 	readOptionalStringArray(raw, 'knownCanvases', target, errors)
 	settings.generatedAssets = readGeneratedAssets(raw, errors)
 	settings.updatePrompt = readUpdatePrompt(raw, errors)
@@ -527,6 +528,7 @@ const RECOGNIZABLE_KEYS = [
 	'mcpEnabled',
 	'mcpPort',
 	'mcpToken',
+	'denoiseServiceUrl',
 	'knownCanvases',
 	'generatedAssets',
 	'updatePrompt',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ import { AddModelModal } from './ui/add-model-modal'
 import { ProviderModelsModal } from './ui/provider-models-modal'
 import { removeProvider } from './ui/remove-provider-modal'
 import { migrateSettings } from './settings-migrations'
+import { DEFAULT_DENOISE_SERVICE_URL } from './denoise'
 
 /** Legacy map kept because `renderModelGroup` looks up display names by id. */
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = (() => {
@@ -146,6 +147,7 @@ export interface BragiSettings {
 	knownCanvases: string[]
 	generatedAssets: GeneratedAssetRecord[]
 	updatePrompt: UpdatePromptState
+	denoiseServiceUrl: string
 
 	// MCP server
 	mcpEnabled: boolean
@@ -209,6 +211,7 @@ export const DEFAULT_SETTINGS: BragiSettings = {
 	knownCanvases: [],
 	generatedAssets: [],
 	updatePrompt: {},
+	denoiseServiceUrl: DEFAULT_DENOISE_SERVICE_URL,
 }
 
 export class BragiSettingTab extends PluginSettingTab {
@@ -268,6 +271,20 @@ export class BragiSettingTab extends PluginSettingTab {
 				.onClick(() => importInput.click()))
 
 		this.renderCloudStorageSection(containerEl)
+
+		// ── Denoise ──
+		addSettingHeading(containerEl, 'Denoise')
+
+		new Setting(containerEl)
+			.setName('CPU service URL')
+			.setDesc('Local CPU image-processing service. Local and hosted HTTP endpoints use the same API.')
+			.addText(text => text
+				.setPlaceholder(DEFAULT_DENOISE_SERVICE_URL)
+				.setValue(this.plugin.settings.denoiseServiceUrl)
+				.onChange(value => {
+					this.plugin.settings.denoiseServiceUrl = value.trim() || DEFAULT_DENOISE_SERVICE_URL
+					void this.plugin.saveSettings()
+				}))
 
 		// ── MCP server ──
 		addSettingHeading(containerEl, 'Mcp server')

--- a/src/ui/denoise-choice-modal.ts
+++ b/src/ui/denoise-choice-modal.ts
@@ -1,0 +1,72 @@
+import { Modal, Setting, type App } from 'obsidian'
+
+export type DenoiseMethod = 'nlm35' | 'flux'
+
+export interface DenoiseChoiceModalOptions {
+	fluxAvailable: boolean
+	fluxProviderName?: string
+	onChoose: (method: DenoiseMethod) => void
+}
+
+export class DenoiseChoiceModal extends Modal {
+	private method: DenoiseMethod = 'nlm35'
+
+	constructor(app: App, private readonly options: DenoiseChoiceModalOptions) {
+		super(app)
+	}
+
+	onOpen(): void {
+		const { contentEl, titleEl, modalEl } = this
+		modalEl.classList.add('bragi-modal', 'bragi-denoise-choice-modal')
+		titleEl.setText('Denoise image')
+
+		const methodSetting = new Setting(contentEl)
+			.setName('Method')
+			.setDesc('Local CPU denoise does not redraw or resize the image.')
+
+		methodSetting.addDropdown(dropdown => {
+			// eslint-disable-next-line obsidianmd/ui/sentence-case -- NLM and CPU are standard initialisms.
+			const nlmLabel = 'NLM 35 - Local CPU'
+			dropdown
+				.addOption('nlm35', nlmLabel)
+				.addOption(
+					'flux',
+					this.options.fluxAvailable
+						? `FLUX.2 Klein 9B - ${this.options.fluxProviderName || 'AI refine'}`
+						: 'FLUX.2 Klein 9B - Not configured',
+				)
+				.setValue(this.method)
+				.onChange(value => {
+					this.method = value as DenoiseMethod
+					methodSetting.setDesc(this.method === 'nlm35'
+						? 'Local CPU denoise does not redraw or resize the image.'
+						: 'AI refine can redraw details and applies upstream color matching when connected.')
+				})
+
+			const fluxOption = Array.from(dropdown.selectEl.options).find(option => option.value === 'flux')
+			if (fluxOption) fluxOption.disabled = !this.options.fluxAvailable
+		})
+
+		if (!this.options.fluxAvailable) {
+			contentEl.createEl('p', {
+				text: 'Configure FLUX.2 Klein 9B with BFL, RunPod, or fal.ai in Settings to enable AI refine.',
+				cls: 'setting-item-description',
+			})
+		}
+
+		const buttonRow = contentEl.createDiv({ cls: 'modal-button-container' })
+		const cancelButton = buttonRow.createEl('button', { text: 'Cancel' })
+		cancelButton.addEventListener('click', () => this.close())
+
+		const runButton = buttonRow.createEl('button', { text: 'Run denoise', cls: 'mod-cta' })
+		runButton.addEventListener('click', () => {
+			const method = this.method
+			this.close()
+			this.options.onChoose(method)
+		})
+	}
+
+	onClose(): void {
+		this.contentEl.empty()
+	}
+}


### PR DESCRIPTION
## Summary

- add a Denoise chooser with gentle local NLM 35 as the default and FLUX.2 Klein 9B as the existing AI refine path
- add a configurable local denoise service URL, settings migration, output handling, and focused regression coverage
- preserve the original image dimensions and the normal right-side generation-node workflow for local NLM results

## Runtime

The plugin calls a separately operated HTTP denoise service; the Python/OpenCV service runtime is intentionally not bundled into this repository. Manual runtime QA produced a normal right-side node at the original 1536x2048 dimensions without triggering a paid FLUX generation.

No paired Skill update is required because MCP tools, model catalog parameters, and return contracts are unchanged.

## Validation

- all 19 `test:*` scripts
- `npm run check:catalog`
- `npm run audit:catalog`
- `npm run lint:obsidian`
- `npm run build`
- `git diff --check origin/main...HEAD`
- secret scan of the PR diff