### PR TITLE
fix: use current Pika Kling model routes

### DIFF
--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -61,8 +61,8 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 ## Pika Kling
 
 - Base URL: `https://api.dev.pika.art`. Authenticate every request with the configured Pika key in the `X-API-Key` header.
-- Bragi Kling 3.0 maps to Pika `kling-3.0`. Text-to-video and first-frame generation route through `/v1/media/kling/kling-3.0/{quality}/text-to-video` and `/v1/media/kling/kling-3.0/{quality}/image-to-video`; motion control uses `/v1/media/kling/kling-3.0/motion-control`.
-- Kling 3.0 quality values map `std` to Pika `standard` and preserve `pro` and `4k`. Pika does not expose Kling 3.0 first-last-frame generation.
+- Bragi Kling 3.0 maps to Pika `kling-3.0`. Text-to-video and first-frame generation route through `/v1/media/kling/kling-3.0/text-to-video` and `/v1/media/kling/kling-3.0/image-to-video`; motion control uses `/v1/media/kling/kling-3.0/motion-control`.
+- Pika does not expose Bragi's Kling 3.0 quality selector or first-last-frame generation, so hide the quality selector for this provider.
 - Pika does not list a compatible Kling 3.0 Omni model, so Bragi does not expose Pika for Kling 3.0 Omni.
 - Send Pika reference images and videos as Bragi temporary Relay HTTPS URLs.
 - Poll all submitted tasks through `GET /v1/media/jobs/{id}`. On completion, use `output.video.url`, falling back to `GET /v1/media/jobs/{id}/content` when the status payload omits the content URL.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -61,9 +61,9 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 ## Pika Kling
 
 - Base URL: `https://api.dev.pika.art`. Authenticate every request with the configured Pika key in the `X-API-Key` header.
-- Bragi Kling 3.0 maps to Pika `kling-v3`. Text-to-video and first-frame generation route through `/v1/media/kling/kling-v3/{quality}/text-to-video` and `/v1/media/kling/kling-v3/{quality}/image-to-video`; motion control uses `/v1/media/kling/kling-v3/motion-control`.
+- Bragi Kling 3.0 maps to Pika `kling-3.0`. Text-to-video and first-frame generation route through `/v1/media/kling/kling-3.0/{quality}/text-to-video` and `/v1/media/kling/kling-3.0/{quality}/image-to-video`; motion control uses `/v1/media/kling/kling-3.0/motion-control`.
 - Kling 3.0 quality values map `std` to Pika `standard` and preserve `pro` and `4k`. Pika does not expose Kling 3.0 first-last-frame generation.
-- Bragi Kling 3.0 Omni maps only its first-frame mode to Pika `kling-o3` at `/v1/media/kling/kling-o3/image-to-video`. Hide the native Omni quality and multi-shot controls for this provider.
+- Pika does not list a compatible Kling 3.0 Omni model, so Bragi does not expose Pika for Kling 3.0 Omni.
 - Send Pika reference images and videos as Bragi temporary Relay HTTPS URLs.
 - Poll all submitted tasks through `GET /v1/media/jobs/{id}`. On completion, use `output.video.url`, falling back to `GET /v1/media/jobs/{id}/content` when the status payload omits the content URL.
 - Do not add Pika Kling O1 or map it to an existing Bragi model: Pika exposes it only as video-to-video and Bragi has no exact catalogue match. Pika also has no exact Kling 2.6 mapping.

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -39,13 +39,13 @@ try {
 	} = await import(`${pathToFileURL(bundlePath).href}?t=${Date.now()}`)
 
 	const stdText = buildPikaVideoRequest('A slow pan', {
-		modelId: 'kling-v3',
+		modelId: 'kling-3.0',
 		genMode: 'text-to-video',
 		mode: 'std',
 		duration: '5',
 		aspect_ratio: '16:9',
 	})
-	assert.equal(stdText.path, '/v1/media/kling/kling-v3/standard/text-to-video')
+	assert.equal(stdText.path, '/v1/media/kling/kling-3.0/standard/text-to-video')
 	assert.deepEqual(stdText.body, {
 		prompt: 'A slow pan',
 		duration: '5',
@@ -53,14 +53,14 @@ try {
 	})
 
 	const proImage = buildPikaVideoRequest('Blink and smile', {
-		modelId: 'kling-v3',
+		modelId: 'kling-3.0',
 		genMode: 'first-frame',
 		mode: 'pro',
 		duration: '10',
 		aspect_ratio: '9:16',
 		refImages: ['https://relay.example/start.png'],
 	})
-	assert.equal(proImage.path, '/v1/media/kling/kling-v3/pro/image-to-video')
+	assert.equal(proImage.path, '/v1/media/kling/kling-3.0/pro/image-to-video')
 	assert.deepEqual(proImage.body, {
 		prompt: 'Blink and smile',
 		image: 'https://relay.example/start.png',
@@ -69,14 +69,14 @@ try {
 	})
 
 	const motion = buildPikaVideoRequest('Follow the dance', {
-		modelId: 'kling-v3',
+		modelId: 'kling-3.0',
 		genMode: 'motion-control',
 		refImages: ['https://relay.example/character.png'],
 		refVideos: ['https://relay.example/motion.mp4'],
 		character_orientation: 'video',
 		keep_original_sound: 'yes',
 	})
-	assert.equal(motion.path, '/v1/media/kling/kling-v3/motion-control')
+	assert.equal(motion.path, '/v1/media/kling/kling-3.0/motion-control')
 	assert.deepEqual(motion.body, {
 		prompt: 'Follow the dance',
 		image_url: 'https://relay.example/character.png',
@@ -85,52 +85,38 @@ try {
 		keep_original_sound: 'yes',
 	})
 
-	const omni = buildPikaVideoRequest('Wake up', {
+	assert.throws(
+		() => buildPikaVideoRequest('Wake up', {
 		modelId: 'kling-o3',
 		genMode: 'first-frame',
 		duration: 12,
 		sound: 'on',
 		refImages: ['https://relay.example/omni.png'],
-	})
-	assert.equal(omni.path, '/v1/media/kling/kling-o3/image-to-video')
-	assert.deepEqual(omni.body, {
-		prompt: 'Wake up',
-		image_url: 'https://relay.example/omni.png',
-		duration: 12,
-		sound: 'on',
-	})
+		}),
+		/does not support model "kling-o3"/,
+	)
 
 	assert.throws(
-		() => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-last-frame' }),
+		() => buildPikaVideoRequest('x', { modelId: 'kling-3.0', genMode: 'first-last-frame' }),
 		/does not support first-last-frame/,
 	)
 	assert.throws(
 		() => buildPikaVideoRequest('x', { modelId: 'kling-o3', genMode: 'text-to-video' }),
-		/only supports first-frame/,
+		/does not support model "kling-o3"/,
 	)
 	assert.throws(
-		() => buildPikaVideoRequest('x', { modelId: 'kling-v3', genMode: 'first-frame', refImages: [] }),
+		() => buildPikaVideoRequest('x', { modelId: 'kling-3.0', genMode: 'first-frame', refImages: [] }),
 		/requires one reference image/,
 	)
 	assert.throws(
 		() => buildPikaVideoRequest('x', {
-			modelId: 'kling-v3',
+			modelId: 'kling-3.0',
 			genMode: 'motion-control',
 			refImages: ['https://relay.example/character.png'],
 			refVideos: [],
 		}),
 		/requires one reference image and one reference video/,
 	)
-	assert.throws(
-		() => buildPikaVideoRequest('x', {
-			modelId: 'kling-o3',
-			genMode: 'first-frame',
-			duration: 16,
-			refImages: ['https://relay.example/start.png'],
-		}),
-		/duration must be a whole number from 3 to 15/,
-	)
-
 	const requests = []
 	const writes = []
 	const app = {
@@ -149,12 +135,12 @@ try {
 		return { status: 200, json: { id: 'job-1', status: 'queued' } }
 	}
 	const submit = await provider.generateVideo('Blink', {
-		modelId: 'kling-v3',
+		modelId: 'kling-3.0',
 		genMode: 'first-frame',
 		refImages: ['https://relay.example/start.png'],
 	})
 	assert.deepEqual(submit, { done: false, taskId: 'job-1' })
-	assert.equal(requests[0].url, 'https://api.dev.pika.art/v1/media/kling/kling-v3/standard/image-to-video')
+	assert.equal(requests[0].url, 'https://api.dev.pika.art/v1/media/kling/kling-3.0/standard/image-to-video')
 	assert.equal(requests[0].headers['X-API-Key'], 'test-key')
 
 	process.__bragiPikaRequestHandler = async (request) => {
@@ -253,7 +239,7 @@ try {
 	)
 	assert.match(
 		modelSource,
-		/id: 'kling-3\.0'[\s\S]*?pika: \{[\s\S]*?apiModelId: 'kling-v3'[\s\S]*?aggregated: true[\s\S]*?modes: \['text-to-video', 'first-frame', 'motion-control'\][\s\S]*?\}/,
+		/id: 'kling-3\.0'[\s\S]*?pika: \{[\s\S]*?apiModelId: 'kling-3\.0'[\s\S]*?aggregated: true[\s\S]*?modes: \['text-to-video', 'first-frame', 'motion-control'\][\s\S]*?\}/,
 		'Kling 3.0 must map Pika to the exact supported modes.',
 	)
 	assert.match(
@@ -261,26 +247,12 @@ try {
 		/id: 'mode'[\s\S]*?providerOverrides: \{[\s\S]*?pika: \{[\s\S]*?label: 'Standard', value: 'std'[\s\S]*?label: 'Pro', value: 'pro'[\s\S]*?label: '4K', value: '4k'/,
 		'Kling 3.0 must expose Pika Standard, Pro, and 4K quality routes.',
 	)
-	assert.match(
-		modelSource,
-		/id: 'kling-3\.0-omni'[\s\S]*?pika: \{ apiModelId: 'kling-o3', modes: \['first-frame'\] \}/,
-		'Kling 3.0 Omni must map Pika O3 to first-frame only.',
-	)
-	assert.match(
-		modelSource,
-		/id: 'mode'[\s\S]*?providerOverrides: \{ pika: \{ hidden: true \} \}/,
-		'Kling 3.0 Omni must hide its unsupported quality selector for Pika.',
-	)
-	assert.match(
-		modelSource,
-		/id: 'multi_shot'[\s\S]*?providerOverrides: \{ pika: \{ hidden: true \} \}/,
-		'Kling 3.0 Omni must hide its unsupported multi-shot selector for Pika.',
-	)
+	assert.doesNotMatch(modelSource, /apiModelId: 'kling-o3'/, 'Pika must not expose an unavailable Kling O3 route.')
 	assert.doesNotMatch(modelSource, /id: 'kling-o1'/, 'This change must not add a mismatched Kling O1 model.')
 	assert.match(
 		modelRulesSource,
-		/## Pika Kling[\s\S]*Kling 3\.0[\s\S]*Kling 3\.0 Omni/,
-		'Provider rules must document the Pika Kling 3.0 and Kling 3.0 Omni mappings.',
+		/## Pika Kling[\s\S]*kling-3\.0[\s\S]*does not list a compatible Kling 3\.0 Omni model/,
+		'Provider rules must document the supported Pika Kling 3.0 route and unavailable Omni mapping.',
 	)
 
 	console.log('Pika provider checks passed.')

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -45,7 +45,7 @@ try {
 		duration: '5',
 		aspect_ratio: '16:9',
 	})
-	assert.equal(stdText.path, '/v1/media/kling/kling-3.0/standard/text-to-video')
+	assert.equal(stdText.path, '/v1/media/kling/kling-3.0/text-to-video')
 	assert.deepEqual(stdText.body, {
 		prompt: 'A slow pan',
 		duration: '5',
@@ -60,7 +60,7 @@ try {
 		aspect_ratio: '9:16',
 		refImages: ['https://relay.example/start.png'],
 	})
-	assert.equal(proImage.path, '/v1/media/kling/kling-3.0/pro/image-to-video')
+	assert.equal(proImage.path, '/v1/media/kling/kling-3.0/image-to-video')
 	assert.deepEqual(proImage.body, {
 		prompt: 'Blink and smile',
 		image: 'https://relay.example/start.png',
@@ -140,7 +140,7 @@ try {
 		refImages: ['https://relay.example/start.png'],
 	})
 	assert.deepEqual(submit, { done: false, taskId: 'job-1' })
-	assert.equal(requests[0].url, 'https://api.dev.pika.art/v1/media/kling/kling-3.0/standard/image-to-video')
+	assert.equal(requests[0].url, 'https://api.dev.pika.art/v1/media/kling/kling-3.0/image-to-video')
 	assert.equal(requests[0].headers['X-API-Key'], 'test-key')
 
 	process.__bragiPikaRequestHandler = async (request) => {
@@ -244,8 +244,8 @@ try {
 	)
 	assert.match(
 		modelSource,
-		/id: 'mode'[\s\S]*?providerOverrides: \{[\s\S]*?pika: \{[\s\S]*?label: 'Standard', value: 'std'[\s\S]*?label: 'Pro', value: 'pro'[\s\S]*?label: '4K', value: '4k'/,
-		'Kling 3.0 must expose Pika Standard, Pro, and 4K quality routes.',
+		/id: 'mode'[\s\S]*?providerOverrides: \{[\s\S]*?pika: \{ hidden: true \}/,
+		'Kling 3.0 must hide the quality selector Pika does not support.',
 	)
 	assert.doesNotMatch(modelSource, /apiModelId: 'kling-o3'/, 'Pika must not expose an unavailable Kling O3 route.')
 	assert.doesNotMatch(modelSource, /id: 'kling-o1'/, 'This change must not add a mismatched Kling O1 model.')

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -68,13 +68,7 @@ const KLING_3_PARAMS: ModelParam[] = KLING_PARAMS.map((param) => param.id === 'm
 		...param,
 		providerOverrides: {
 			...param.providerOverrides,
-			pika: {
-				options: [
-					{ label: 'Standard', value: 'std' },
-					{ label: 'Pro', value: 'pro' },
-					{ label: '4K', value: '4k' },
-				],
-			},
+			pika: { hidden: true },
 		},
 	}
 	: param)

--- a/src/models/kling.ts
+++ b/src/models/kling.ts
@@ -161,7 +161,7 @@ export const kling3: ModelConfig = {
 	supportedProviders: {
 		kling: { apiModelId: 'kling-v3' },
 		pika: {
-			apiModelId: 'kling-v3',
+			apiModelId: 'kling-3.0',
 			aggregated: true,
 			modes: ['text-to-video', 'first-frame', 'motion-control'],
 		},
@@ -184,7 +184,6 @@ export const klingOmni3: ModelConfig = {
 	type: 'video',
 	supportedProviders: {
 		kling: { apiModelId: 'kling-v3-omni' },
-		pika: { apiModelId: 'kling-o3', modes: ['first-frame'] },
 		apimart: { apiModelId: 'kling-v3-omni' },
 	},
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-edit'],

--- a/src/providers/pika.ts
+++ b/src/providers/pika.ts
@@ -3,10 +3,9 @@ import { requestUrl } from 'obsidian'
 import type { GenerateVideoResult, VideoProvider } from './types'
 
 const PIKA_API_BASE = 'https://api.dev.pika.art'
-const KLING_V3_MODEL_ID = 'kling-v3'
-const KLING_O3_MODEL_ID = 'kling-o3'
+const KLING_3_MODEL_ID = 'kling-3.0'
 const KLING_V3_DURATIONS = new Set(['5', '10'])
-const KLING_O3_RATIOS = new Set(['16:9', '9:16', '1:1'])
+const KLING_3_RATIOS = new Set(['16:9', '9:16', '1:1'])
 const PIKA_SOUNDS = new Set(['on', 'off'])
 const MOTION_ORIENTATIONS = new Set(['image', 'video'])
 const KEEP_SOUND_VALUES = new Set(['yes', 'no'])
@@ -52,17 +51,9 @@ function parseV3Duration(value: unknown): string {
 	return duration
 }
 
-function parseO3Duration(value: unknown): number {
-	const duration = typeof value === 'number' ? value : Number.parseInt(stringValue(value, '5'), 10)
-	if (!Number.isInteger(duration) || duration < 3 || duration > 15) {
-		throw new Error('Pika Kling O3 duration must be a whole number from 3 to 15.')
-	}
-	return duration
-}
-
 function parseAspectRatio(value: unknown): string {
 	const ratio = stringValue(value, '16:9')
-	if (!KLING_O3_RATIOS.has(ratio)) {
+	if (!KLING_3_RATIOS.has(ratio)) {
 		throw new Error('Pika aspect ratio must be 16:9, 9:16, or 1:1.')
 	}
 	return ratio
@@ -90,40 +81,14 @@ export function buildPikaVideoRequest(
 	prompt: string,
 	params: Record<string, unknown> = {},
 ): PikaVideoRequest {
-	const modelId = stringValue(params.modelId, KLING_V3_MODEL_ID)
+	const modelId = stringValue(params.modelId, KLING_3_MODEL_ID)
 	const genMode = stringValue(params.genMode, 'text-to-video')
 	const refImages = stringArray(params.refImages)
 	const refVideos = stringArray(params.refVideos)
 
 	if (!prompt.trim()) throw new Error('Pika requires a prompt.')
 
-	if (modelId === KLING_O3_MODEL_ID) {
-		if (genMode !== 'first-frame') {
-			throw new Error('Pika Kling O3 only supports first-frame generation.')
-		}
-		if (refImages.length < 1) {
-			throw new Error('Pika Kling O3 first-frame generation requires one reference image.')
-		}
-		const body: UnknownRecord = {
-			prompt,
-			image_url: refImages[0],
-			duration: parseO3Duration(params.duration),
-		}
-		if (params.aspect_ratio !== undefined || params.aspectRatio !== undefined) {
-			body.aspect_ratio = parseAspectRatio(params.aspect_ratio ?? params.aspectRatio)
-		}
-		if (params.sound !== undefined) {
-			const sound = stringValue(params.sound)
-			if (!PIKA_SOUNDS.has(sound)) throw new Error('Pika sound must be on or off.')
-			body.sound = sound
-		}
-		return {
-			path: '/v1/media/kling/kling-o3/image-to-video',
-			body,
-		}
-	}
-
-	if (modelId !== KLING_V3_MODEL_ID) {
+	if (modelId !== KLING_3_MODEL_ID) {
 		throw new Error(`Pika does not support model "${modelId}".`)
 	}
 	if (genMode === 'first-last-frame') {
@@ -142,7 +107,7 @@ export function buildPikaVideoRequest(
 			throw new Error('Pika motion-control source audio must be yes or no.')
 		}
 		return {
-			path: '/v1/media/kling/kling-v3/motion-control',
+			path: `/v1/media/kling/${KLING_3_MODEL_ID}/motion-control`,
 			body: {
 				prompt,
 				image_url: refImages[0],
@@ -172,7 +137,7 @@ export function buildPikaVideoRequest(
 	}
 
 	return {
-		path: `/v1/media/kling/kling-v3/${quality}/${genMode === 'first-frame' ? 'image-to-video' : 'text-to-video'}`,
+		path: `/v1/media/kling/${KLING_3_MODEL_ID}/${quality}/${genMode === 'first-frame' ? 'image-to-video' : 'text-to-video'}`,
 		body,
 	}
 }

--- a/src/providers/pika.ts
+++ b/src/providers/pika.ts
@@ -36,13 +36,6 @@ function optionalString(body: UnknownRecord, key: string, value: unknown): void 
 	if (typeof value === 'string' && value.trim()) body[key] = value
 }
 
-function parseQuality(value: unknown): 'standard' | 'pro' | '4k' {
-	const quality = stringValue(value, 'std')
-	if (quality === 'std' || quality === 'standard') return 'standard'
-	if (quality === 'pro' || quality === '4k') return quality
-	throw new Error('Pika Kling 3.0 quality must be Standard, Pro, or 4K.')
-}
-
 function parseV3Duration(value: unknown): string {
 	const duration = stringValue(value, '5')
 	if (!KLING_V3_DURATIONS.has(duration)) {
@@ -121,7 +114,6 @@ export function buildPikaVideoRequest(
 		throw new Error(`Pika Kling 3.0 does not support ${genMode || 'the selected mode'}.`)
 	}
 
-	const quality = parseQuality(params.mode)
 	const body: UnknownRecord = {
 		prompt,
 		duration: parseV3Duration(params.duration),
@@ -137,7 +129,7 @@ export function buildPikaVideoRequest(
 	}
 
 	return {
-		path: `/v1/media/kling/${KLING_3_MODEL_ID}/${quality}/${genMode === 'first-frame' ? 'image-to-video' : 'text-to-video'}`,
+		path: `/v1/media/kling/${KLING_3_MODEL_ID}/${genMode === 'first-frame' ? 'image-to-video' : 'text-to-video'}`,
 		body,
 	}
 }


### PR DESCRIPTION
## Summary

- route Pika Kling 3.0 requests through the current `kling-3.0` model ID
- remove the unavailable Pika Kling 3.0 Omni (`kling-o3`) catalogue entry
- update the Pika regression check and provider rules

## Root cause

Pika rejects the legacy `kling-v3` and `kling-o3` media routes. Its current model roster includes `kling/kling-3.0`, so selecting Omni previously failed before a generation job could be created.

## Validation

- `npm run test:pika-provider`
- `npm run build`