### PR TITLE
Update SVRouter gateway base URL

### DIFF
--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -10,7 +10,7 @@ import { resolveOpenAIImageSize } from './openai-image-size'
 import { resolveSeedreamImageSize } from './seedream'
 
 // Fixed SVRouter gateway root (OpenAI-compatible; requests append `/v1/...`).
-export const SVROUTER_BASE_URL = 'https://gateway.storyverseai.art'
+export const SVROUTER_BASE_URL = 'https://gateway.one-take-ai.com'
 
 /**
  * SVRouter — our self-hosted new-api / One-API gateway. It exposes stable `sv-*`


### PR DESCRIPTION
## Summary
- Update the fixed SVRouter gateway root to https://gateway.one-take-ai.com

## Verification
- Ran a live image generation request against https://gateway.one-take-ai.com/v1/images/generations using the prompt and references from /Users/ouying/obsidian/vault/dev-bragi-canvas/test/keyframe-83eb80e7-2d78-487d-be45-d9f2f8b21d17.canvas
- Received HTTP 200 with an image result URL