### PR TITLE
Add Wan 3.0 video generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs",
     "test:pika-provider": "node scripts/verify-pika-provider.mjs",
-    "test:mureka-music": "node scripts/verify-mureka-music.mjs"
+    "test:mureka-music": "node scripts/verify-mureka-music.mjs",
+    "test:dashscope-wan3": "node scripts/verify-dashscope-wan3.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-dashscope-wan3.mjs
+++ b/scripts/verify-dashscope-wan3.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-dashscope-wan3-'))
+
+try {
+	const outfile = join(tempDir, 'dashscope.mjs')
+	await build({
+		entryPoints: ['src/providers/dashscope.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export function normalizePath(value) { return value }
+						export async function requestUrl(options) { return process.__bragiWan3RequestHandler(options) }
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const { DashScopeVideoProvider } = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`)
+	const requests = []
+	process.__bragiWan3RequestHandler = async (request) => {
+		requests.push(request)
+		return { status: 200, json: { output: { task_id: `task-${requests.length}` } } }
+	}
+	const app = { vault: { adapter: {} } }
+	const provider = new DashScopeVideoProvider(
+		'test-key',
+		app,
+		'_bragi/assets',
+		'https://workspace.ap-southeast-1.maas.aliyuncs.com/api/v1',
+	)
+
+	assert.deepEqual(await provider.generateVideo('Moonlit rooftop', {
+		modelId: 'wan3.0-video',
+		genMode: 'text-to-video',
+	}), { done: false, taskId: 'task-1' })
+	assert.equal(requests[0].url, 'https://workspace.ap-southeast-1.maas.aliyuncs.com/api/v1/services/aigc/video-generation/video-synthesis')
+	assert.equal(requests[0].headers['X-DashScope-Async'], 'enable')
+	assert.deepEqual(JSON.parse(requests[0].body), {
+		model: 'wan3.0-video',
+		input: { prompt: 'Moonlit rooftop' },
+		parameters: {
+			resolution: '1080P',
+			ratio: 'adaptive',
+			duration: 5,
+			audio: true,
+			watermark: false,
+		},
+	})
+
+	await provider.generateVideo('Use Image 1, Video 1, and Audio 1', {
+		modelId: 'wan3.0-video',
+		genMode: 'video-ref',
+		refImages: ['https://example.com/ref.png'],
+		refVideos: ['https://example.com/ref.mp4'],
+		refAudios: ['https://example.com/ref.mp3'],
+		refPdfs: ['https://example.com/brief.pdf'],
+		resolution: '480P',
+		ratio: '9:16',
+		duration: '-1',
+		audio: 'false',
+		seed: 2147483648,
+	})
+	assert.deepEqual(JSON.parse(requests[1].body), {
+		model: 'wan3.0-video',
+		input: {
+			prompt: 'Use Image 1, Video 1, and Audio 1',
+			media: [
+				{ type: 'reference_image', url: 'https://example.com/ref.png' },
+				{ type: 'reference_video', url: 'https://example.com/ref.mp4' },
+				{ type: 'reference_audio', url: 'https://example.com/ref.mp3' },
+				{ type: 'file', url: 'https://example.com/brief.pdf' },
+			],
+		},
+		parameters: {
+			resolution: '480P',
+			ratio: '9:16',
+			duration: -1,
+			audio: false,
+			watermark: false,
+			seed: 2147483647,
+		},
+	})
+
+	await provider.generateVideo('Transition between frames', {
+		modelId: 'wan3.0-video',
+		genMode: 'first-last-frame',
+		refImages: ['https://example.com/first.png', 'https://example.com/last.png'],
+	})
+	assert.deepEqual(JSON.parse(requests[2].body).input.media, [
+		{ type: 'first_frame', url: 'https://example.com/first.png' },
+		{ type: 'last_frame', url: 'https://example.com/last.png' },
+	])
+
+	await assert.rejects(
+		() => provider.generateVideo('Missing ref', { modelId: 'wan3.0-video', genMode: 'image-ref' }),
+		/requires at least one upstream reference/,
+	)
+	await assert.rejects(
+		() => provider.generateVideo('Invalid mix', {
+			modelId: 'wan3.0-video',
+			genMode: 'first-frame',
+			refImages: ['https://example.com/first.png'],
+			refAudios: ['https://example.com/ref.mp3'],
+		}),
+		/cannot be combined with reference video, audio, or files/,
+	)
+
+	console.log('DashScope Wan 3.0 checks passed.')
+} finally {
+	delete process.__bragiWan3RequestHandler
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -709,8 +709,10 @@ export default class BragiCanvas extends Plugin {
 			? imageMimeType(vaultPath)
 			: modality === 'video'
 				? videoMimeType(vaultPath)
-				: audioMimeType(vaultPath)
-		const ext = getFileExtension(vaultPath, modality === 'image' ? 'png' : modality === 'video' ? 'mp4' : 'mp3')
+				: modality === 'audio'
+					? audioMimeType(vaultPath)
+					: 'application/pdf'
+		const ext = getFileExtension(vaultPath, modality === 'image' ? 'png' : modality === 'video' ? 'mp4' : modality === 'audio' ? 'mp3' : 'pdf')
 
 		// native_asset reaches here only when no provider-native asset flow ran
 		// (e.g. credentials missing) — fall back to relay so generation still works.
@@ -766,7 +768,8 @@ export default class BragiCanvas extends Plugin {
 			// Seedance can consume provider-specific asset:// IDs.
 			const isSeedanceModel = model.id.startsWith('seedance')
 			const isMuleRouterWan = activeProvider === 'mulerouter' && model.id === 'wan-2.7'
-			const isDashScopeWan = activeProvider === 'dashscope' && model.id === 'wan-2.7'
+			const isDashScopeWan3 = activeProvider === 'dashscope' && model.id === 'wan-3.0'
+			const isDashScopeWan = activeProvider === 'dashscope' && (model.id === 'wan-2.7' || isDashScopeWan3)
 			const supportsApimartVideoRef = activeProvider === 'apimart' && model.id === 'omni-flash-ext'
 			const supportsKlingOmniVideoRef = model.id === 'kling-3.0-omni' && (activeProvider === 'kling' || activeProvider === 'apimart')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
@@ -885,6 +888,11 @@ export default class BragiCanvas extends Plugin {
 					}
 				}
 			}
+
+			if (isDashScopeWan3 && uniquePdfs.length > 0) {
+				if (uniquePdfs.length > 1) throw new Error('Wan 3.0 supports at most 1 reference file.')
+				refPdfs.push(await this.prepareReferenceMedia(activeProvider, model, 'pdf', uniquePdfs[0]))
+			}
 			}
 
 			if (model.type === 'image') {
@@ -911,7 +919,7 @@ export default class BragiCanvas extends Plugin {
 					markNodeFailed(placeholder, `${activeProvider} doesn't support video generation`)
 					return
 				}
-				const videoResult = await provider.generateVideo(finalPrompt, { ...params, modelId: apiModelId, genMode: mode, refImages, refAudios, refVideos })
+				const videoResult = await provider.generateVideo(finalPrompt, { ...params, modelId: apiModelId, genMode: mode, refImages, refAudios, refVideos, refPdfs })
 
 				if (videoResult.done && videoResult.filePath) {
 					// Rare: synchronous completion

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -7,7 +7,7 @@ import { seedance2, seedance2Fast } from './seedance'
 import { kling3, klingOmni3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
-import { zImageSpicy, qwenImageEditSpicy, wan27 } from './wan'
+import { zImageSpicy, qwenImageEditSpicy, wan30, wan27 } from './wan'
 import { gpt55, gpt55Pro, gemini31Pro, gemini35Flash, gemini3Flash, claudeOpus47, claudeSonnet46, qwen36Plus, grok43, grok4Fast } from './text-gen'
 import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
@@ -51,6 +51,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	kling26,
 	happyHorseT2V,
 	happyHorseI2V,
+	wan30,
 	wan27,
 	veo31,
 	veo31Lite,

--- a/src/models/wan.ts
+++ b/src/models/wan.ts
@@ -50,6 +50,72 @@ export const qwenImageEditSpicy: ModelConfig = {
 	params: [],
 }
 
+export const wan30: ModelConfig = {
+	id: 'wan-3.0',
+	name: 'Wan 3.0',
+	type: 'video',
+	supportedProviders: {
+		dashscope: { apiModelId: 'wan3.0-video' },
+	},
+	modes: [
+		'text-to-video',
+		'first-frame',
+		'first-last-frame',
+		'image-ref',
+		'video-ref',
+	],
+	params: [
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '480P', value: '480P' },
+				{ label: '720P', value: '720P' },
+				{ label: '1080P', value: '1080P' },
+			],
+			default: '1080P',
+		},
+		{
+			id: 'ratio',
+			label: 'Ratio',
+			type: 'select',
+			options: [
+				{ label: 'Adaptive', value: 'adaptive' },
+				{ label: '16:9', value: '16:9' },
+				{ label: '4:3', value: '4:3' },
+				{ label: '1:1', value: '1:1' },
+				{ label: '3:4', value: '3:4' },
+				{ label: '9:16', value: '9:16' },
+			],
+			default: 'adaptive',
+		},
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'select',
+			options: [
+				{ label: 'Auto', value: '-1' },
+				...Array.from({ length: 29 }, (_, index) => {
+					const seconds = index + 2
+					return { label: `${seconds}s`, value: String(seconds) }
+				}),
+			],
+			default: '5',
+		},
+		{
+			id: 'audio',
+			label: 'Audio',
+			type: 'select',
+			options: [
+				{ label: 'On', value: 'true' },
+				{ label: 'Off', value: 'false' },
+			],
+			default: 'true',
+		},
+	],
+}
+
 export const wan27: ModelConfig = {
 	id: 'wan-2.7',
 	name: 'Wan 2.7',

--- a/src/providers/dashscope.ts
+++ b/src/providers/dashscope.ts
@@ -25,6 +25,7 @@ const WAN27_T2V = 'wan2.7-t2v-2026-04-25'
 const WAN27_I2V = 'wan2.7-i2v-2026-04-25'
 const WAN27_R2V = 'wan2.7-r2v'
 const WAN27_VIDEOEDIT = 'wan2.7-videoedit'
+const WAN30_VIDEO = 'wan3.0-video'
 const VIDEO_DONE_STATUSES = new Set(['SUCCEEDED', 'SUCCESS', 'COMPLETED'])
 const VIDEO_FAILED_STATUSES = new Set(['FAILED', 'FAILURE', 'ERROR', 'CANCELED', 'CANCELLED', 'UNKNOWN'])
 
@@ -212,16 +213,33 @@ function normalizeResolution(value: unknown): string {
 	return text === '1080P' ? '1080P' : '720P'
 }
 
+function normalizeWan30Resolution(value: unknown): string {
+	const text = stringParam(value, '1080P').trim().toUpperCase()
+	return ['480P', '720P', '1080P'].includes(text) ? text : '1080P'
+}
+
 function normalizeRatio(value: unknown): string | undefined {
 	const ratio = stringParam(value, '').trim()
 	return ['16:9', '9:16', '1:1', '4:3', '3:4'].includes(ratio) ? ratio : undefined
+}
+
+function normalizeWan30Ratio(value: unknown): string {
+	const ratio = stringParam(value, 'adaptive').trim()
+	return ['adaptive', '16:9', '9:16', '1:1', '4:3', '3:4'].includes(ratio) ? ratio : 'adaptive'
+}
+
+function normalizeWan30Duration(value: unknown): number {
+	const parsed = optionalNumberParam(value)
+	if (parsed !== undefined && Math.round(parsed) === -1) return -1
+	return boundedInt(value, 5, 2, 30)
 }
 
 function isHttpUrl(value: string): boolean {
 	return /^https?:\/\//i.test(value)
 }
 
-function extensionForMime(mimeType: string, kind: 'image' | 'audio' | 'video'): string {
+function extensionForMime(mimeType: string, kind: 'image' | 'audio' | 'video' | 'pdf'): string {
+	if (mimeType.includes('pdf')) return 'pdf'
 	if (mimeType.includes('webp')) return 'webp'
 	if (mimeType.includes('bmp')) return 'bmp'
 	if (mimeType.includes('jpeg') || mimeType.includes('jpg')) return 'jpg'
@@ -235,10 +253,10 @@ function extensionForMime(mimeType: string, kind: 'image' | 'audio' | 'video'): 
 	if (mimeType.includes('ogg')) return 'ogg'
 	if (mimeType.includes('opus')) return 'opus'
 	if (mimeType.includes('mpeg') || mimeType.includes('mp3')) return 'mp3'
-	return kind === 'video' ? 'mp4' : kind === 'audio' ? 'mp3' : 'png'
+	return kind === 'video' ? 'mp4' : kind === 'audio' ? 'mp3' : kind === 'pdf' ? 'pdf' : 'png'
 }
 
-function dataUriToBytes(dataUri: string, kind: 'image' | 'audio' | 'video'): { bytes: Uint8Array; ext: string; mimeType: string } | null {
+function dataUriToBytes(dataUri: string, kind: 'image' | 'audio' | 'video' | 'pdf'): { bytes: Uint8Array; ext: string; mimeType: string } | null {
 	const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
 	if (!match) return null
 	const mimeType = match[1]
@@ -433,9 +451,9 @@ function mergeVoices(voices: VoiceOption[]): VoiceOption[] {
 	return [...byId.values()]
 }
 
-type MediaKind = 'image' | 'audio' | 'video'
+type MediaKind = 'image' | 'audio' | 'video' | 'pdf'
 
-interface Wan27Route {
+interface WanVideoRoute {
 	model: string
 	input: UnknownRecord
 	parameters: UnknownRecord
@@ -452,7 +470,10 @@ export class DashScopeVideoProvider implements VideoProvider {
 	) {}
 
 	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
-		const route = await this.buildWan27Route(prompt, params || {})
+		const options = params || {}
+		const route = stringParam(options.modelId, 'wan-2.7') === WAN30_VIDEO
+			? await this.buildWan30Route(prompt, options)
+			: await this.buildWan27Route(prompt, options)
 		const resp = await requestUrl({
 			url: dashScopeUrl(this.baseUrl, VIDEO_SYNTHESIS_PATH),
 			method: 'POST',
@@ -501,7 +522,59 @@ export class DashScopeVideoProvider implements VideoProvider {
 		return { done: false, taskId }
 	}
 
-	private async buildWan27Route(prompt: string, params: Record<string, unknown>): Promise<Wan27Route> {
+	private async buildWan30Route(prompt: string, params: Record<string, unknown>): Promise<WanVideoRoute> {
+		const genMode = stringParam(params.genMode, 'text-to-video')
+		const refImages = stringList(params.refImages)
+		const refAudios = stringList(params.refAudios)
+		const refVideos = stringList(params.refVideos)
+		const refPdfs = stringList(params.refPdfs)
+		const supportedModes = new Set(['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref'])
+		if (!supportedModes.has(genMode)) throw new Error(`Wan 3.0 does not support ${genMode} mode.`)
+
+		const media: UnknownRecord[] = []
+		if (genMode === 'first-frame' || genMode === 'first-last-frame') {
+			const expectedImages = genMode === 'first-last-frame' ? 2 : 1
+			if (refImages.length !== expectedImages) {
+				throw new Error(`Wan 3.0 ${genMode} mode requires exactly ${expectedImages} upstream image${expectedImages === 1 ? '' : 's'}.`)
+			}
+			if (refVideos.length > 0 || refAudios.length > 0 || refPdfs.length > 0) {
+				throw new Error('Wan 3.0 first-frame modes cannot be combined with reference video, audio, or files.')
+			}
+			media.push({ type: 'first_frame', url: await this.ensureUrl(refImages[0], 'image') })
+			if (genMode === 'first-last-frame') {
+				media.push({ type: 'last_frame', url: await this.ensureUrl(refImages[1], 'image') })
+			}
+		} else {
+			if (refImages.length > 10) throw new Error('Wan 3.0 supports at most 10 reference images.')
+			if (refVideos.length > 5) throw new Error('Wan 3.0 supports at most 5 reference videos.')
+			if (refAudios.length > 5) throw new Error('Wan 3.0 supports at most 5 reference audio clips.')
+			if (refPdfs.length > 1) throw new Error('Wan 3.0 supports at most 1 reference file.')
+			const imageMedia = await Promise.all(refImages.map(async url => ({ type: 'reference_image', url: await this.ensureUrl(url, 'image') })))
+			const videoMedia = await Promise.all(refVideos.map(async url => ({ type: 'reference_video', url: await this.ensureUrl(url, 'video') })))
+			const audioMedia = await Promise.all(refAudios.map(async url => ({ type: 'reference_audio', url: await this.ensureUrl(url, 'audio') })))
+			const fileMedia = await Promise.all(refPdfs.map(async url => ({ type: 'file', url: await this.ensureUrl(url, 'pdf') })))
+			media.push(...imageMedia, ...videoMedia, ...audioMedia, ...fileMedia)
+			if ((genMode === 'image-ref' || genMode === 'video-ref') && media.length === 0) {
+				throw new Error(`Wan 3.0 ${genMode} mode requires at least one upstream reference.`)
+			}
+		}
+
+		const input: UnknownRecord = { prompt }
+		if (media.length > 0) input.media = media
+		const parameters: UnknownRecord = {
+			resolution: normalizeWan30Resolution(params.resolution),
+			ratio: normalizeWan30Ratio(params.ratio || params.aspectRatio || params.aspect_ratio),
+			duration: normalizeWan30Duration(params.duration),
+			audio: optionalBooleanParam(params.audio) ?? true,
+			watermark: optionalBooleanParam(params.watermark) ?? false,
+		}
+		const seed = optionalNumberParam(params.seed)
+		if (seed !== undefined) parameters.seed = Math.min(Math.max(Math.round(seed), 0), 2147483647)
+
+		return { model: WAN30_VIDEO, input, parameters }
+	}
+
+	private async buildWan27Route(prompt: string, params: Record<string, unknown>): Promise<WanVideoRoute> {
 		const genMode = stringParam(params.genMode, 'text-to-video')
 		const modelId = stringParam(params.modelId, 'wan-2.7')
 		const refImages = stringList(params.refImages)
@@ -520,7 +593,7 @@ export class DashScopeVideoProvider implements VideoProvider {
 		return this.buildWan27T2v(prompt, params, refAudios)
 	}
 
-	private async buildWan27T2v(prompt: string, params: Record<string, unknown>, refAudios: string[]): Promise<Wan27Route> {
+	private async buildWan27T2v(prompt: string, params: Record<string, unknown>, refAudios: string[]): Promise<WanVideoRoute> {
 		const input: UnknownRecord = { prompt }
 		if (refAudios[0]) input.audio_url = await this.ensureUrl(refAudios[0], 'audio')
 		return {
@@ -537,7 +610,7 @@ export class DashScopeVideoProvider implements VideoProvider {
 		refImages: string[],
 		refVideos: string[],
 		refAudios: string[],
-	): Promise<Wan27Route> {
+	): Promise<WanVideoRoute> {
 		const media: UnknownRecord[] = []
 		if (genMode === 'video-extend') {
 			if (!refVideos[0]) throw new Error('Wan 2.7 video extend requires one upstream video.')
@@ -565,7 +638,7 @@ export class DashScopeVideoProvider implements VideoProvider {
 		refImages: string[],
 		refVideos: string[],
 		refAudios: string[],
-	): Promise<Wan27Route> {
+	): Promise<WanVideoRoute> {
 		const media: UnknownRecord[] = []
 		const imageMedia = await Promise.all(refImages.map(async url => ({ type: 'reference_image', url: await this.ensureUrl(url, 'image') })))
 		const videoMedia = await Promise.all(refVideos.map(async url => ({ type: 'reference_video', url: await this.ensureUrl(url, 'video') })))
@@ -588,7 +661,7 @@ export class DashScopeVideoProvider implements VideoProvider {
 		params: Record<string, unknown>,
 		refImages: string[],
 		refVideos: string[],
-	): Promise<Wan27Route> {
+	): Promise<WanVideoRoute> {
 		if (!refVideos[0]) throw new Error('Wan 2.7 VideoEdit requires one upstream video.')
 		if (refImages.length > 3) throw new Error('Wan 2.7 VideoEdit supports at most 3 reference images.')
 		const media: UnknownRecord[] = [


### PR DESCRIPTION
Adds Wan 3.0 through DashScope with text-to-video, first-frame, first-last-frame, image/video/audio reference inputs, PDF reference support, 480P/720P/1080P output, smart or 2-30 second duration, and audio control. Includes provider request regression coverage and preserves opt-in model enablement.\n\nPaired skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/57\n\nChecks: npm run test:dashscope-wan3; npm run build; npm run lint:obsidian; npm run check:catalog; npm run audit:catalog; paired sync check.