### PR TITLE
feat: add Seedance 2.5 for BytePlus and Volcengine

### DIFF
--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -46,15 +46,15 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Supported duration values are 4, 6, 8, and 10 seconds.
 - Supported resolution values are `720p`, `1080p`, and `4k`.
 
-## BytePlus Seedance 2.5
+## Volcengine and BytePlus Seedance 2.5
 
-- Bragi model ID: `seedance-2.5`; BytePlus model ID: `dreamina-seedance-2-5-260628`.
-- Submit tasks to `POST https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks` and poll `GET /api/v3/contents/generations/tasks/{task_id}` through the existing `SeedanceProvider`.
+- Bragi model ID: `seedance-2.5`; Volcengine model ID: `doubao-seedance-2-5-260628`; BytePlus model ID: `dreamina-seedance-2-5-260628`.
+- Volcengine submits to `POST https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks`; BytePlus submits to `POST https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks`. Both poll `GET /api/v3/contents/generations/tasks/{task_id}` through the existing `SeedanceProvider`.
 - Supported Bragi modes are text-to-video, first-frame, first-last-frame, image reference, video reference, video extension, and video edit. First-frame inputs use `role: first_frame`; the second image in first-last-frame uses `role: last_frame`; multimodal references use `reference_image`, `reference_video`, and `reference_audio`.
 - Multimodal limits are 30 images, 10 videos, and 10 audio clips (50 references total). Audio-only reference input is supported through `video-ref` mode.
 - Duration defaults to Auto (`-1`) and accepts `-1` or 4–30 seconds. Video edit only accepts `-1`. Ratio defaults to `adaptive`; first-frame, first-last-frame, video-extend, and video-edit only accept `adaptive`. Text/reference generation also accepts `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, and `21:9`.
 - Output resolution is 480p or 720p. Output format is MP4 or MOV; preserve a `.mov` extension when the completed task returns a MOV URL.
-- With BytePlus native asset credentials, reference media uses the existing `asset://` flow. Without those credentials, Bragi falls back to temporary HTTPS relay URLs; face-containing media may still require an approved BytePlus asset.
+- Volcengine sends local reference media through temporary HTTPS relay URLs and passes manually bound `bytedance` `asset://` IDs through unchanged. With BytePlus native asset credentials, reference media uses the existing `asset://` flow; without those credentials, Bragi falls back to relay URLs. Face-containing media may still require a provider-approved asset.
 
 ## Kling 3.0 Omni
 

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -46,6 +46,16 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Supported duration values are 4, 6, 8, and 10 seconds.
 - Supported resolution values are `720p`, `1080p`, and `4k`.
 
+## BytePlus Seedance 2.5
+
+- Bragi model ID: `seedance-2.5`; BytePlus model ID: `dreamina-seedance-2-5-260628`.
+- Submit tasks to `POST https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks` and poll `GET /api/v3/contents/generations/tasks/{task_id}` through the existing `SeedanceProvider`.
+- Supported Bragi modes are text-to-video, first-frame, first-last-frame, image reference, video reference, video extension, and video edit. First-frame inputs use `role: first_frame`; the second image in first-last-frame uses `role: last_frame`; multimodal references use `reference_image`, `reference_video`, and `reference_audio`.
+- Multimodal limits are 30 images, 10 videos, and 10 audio clips (50 references total). Audio-only reference input is supported through `video-ref` mode.
+- Duration defaults to Auto (`-1`) and accepts `-1` or 4–30 seconds. Video edit only accepts `-1`. Ratio defaults to `adaptive`; first-frame, first-last-frame, video-extend, and video-edit only accept `adaptive`. Text/reference generation also accepts `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, and `21:9`.
+- Output resolution is 480p or 720p. Output format is MP4 or MOV; preserve a `.mov` extension when the completed task returns a MOV URL.
+- With BytePlus native asset credentials, reference media uses the existing `asset://` flow. Without those credentials, Bragi falls back to temporary HTTPS relay URLs; face-containing media may still require an approved BytePlus asset.
+
 ## Kling 3.0 Omni
 
 - Bragi model ID: `kling-3.0-omni`; upstream model ID on both providers: `kling-v3-omni`.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:text-multimodal": "node scripts/verify-text-multimodal.mjs",
     "test:pika-provider": "node scripts/verify-pika-provider.mjs",
     "test:mureka-music": "node scripts/verify-mureka-music.mjs",
-    "test:dashscope-wan3": "node scripts/verify-dashscope-wan3.mjs"
+    "test:dashscope-wan3": "node scripts/verify-dashscope-wan3.mjs",
+    "test:seedance-2-5": "node scripts/verify-seedance-2-5.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-seedance-2-5.mjs
+++ b/scripts/verify-seedance-2-5.mjs
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-seedance-2-5-'))
+const bundlePath = join(tempDir, 'seedance-provider.mjs')
+
+try {
+	await build({
+		entryPoints: ['src/providers/seedance.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: bundlePath,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export async function requestUrl(options) {
+							return process.__bragiSeedanceRequestHandler(options)
+						}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const { buildSeedanceRequestBody, SeedanceProvider } = await import(`${pathToFileURL(bundlePath).href}?t=${Date.now()}`)
+	const modelId = 'dreamina-seedance-2-5-260628'
+
+	const firstLast = buildSeedanceRequestBody('Move from dawn to dusk', {
+		modelId,
+		genMode: 'first-last-frame',
+		refImages: ['https://relay.example/first.png', 'https://relay.example/last.png'],
+	})
+	assert.equal(firstLast.duration, -1)
+	assert.equal(firstLast.ratio, 'adaptive')
+	assert.deepEqual(firstLast.content.slice(1).map(item => item.role), ['first_frame', 'last_frame'])
+
+	const multimodal = buildSeedanceRequestBody('Use every reference', {
+		modelId,
+		genMode: 'video-ref',
+		duration: '30',
+		ratio: '21:9',
+		resolution: '480p',
+		generate_audio: 'false',
+		output_format: 'mov',
+		refImages: Array.from({ length: 30 }, (_, index) => `https://relay.example/image-${index}.png`),
+		refVideos: Array.from({ length: 10 }, (_, index) => `https://relay.example/video-${index}.mp4`),
+		refAudios: Array.from({ length: 10 }, (_, index) => `https://relay.example/audio-${index}.mp3`),
+	})
+	assert.equal(multimodal.content.length, 51)
+	assert.equal(multimodal.generate_audio, false)
+	assert.equal(multimodal.output_format, 'mov')
+
+	assert.throws(
+		() => buildSeedanceRequestBody('Too many images', {
+			modelId,
+			genMode: 'image-ref',
+			refImages: Array.from({ length: 31 }, (_, index) => `https://relay.example/image-${index}.png`),
+		}),
+		/up to 30 reference images/,
+	)
+	assert.throws(
+		() => buildSeedanceRequestBody('Wrong ratio', {
+			modelId,
+			genMode: 'first-frame',
+			ratio: '16:9',
+			refImages: ['https://relay.example/first.png'],
+		}),
+		/requires adaptive ratio/,
+	)
+	assert.throws(
+		() => buildSeedanceRequestBody('Edit the video', {
+			modelId,
+			genMode: 'video-edit',
+			duration: '10',
+			refVideos: ['https://relay.example/source.mp4'],
+		}),
+		/requires Auto \(-1\) duration/,
+	)
+	assert.throws(
+		() => buildSeedanceRequestBody('No refs', { modelId, genMode: 'video-ref' }),
+		/requires reference media/,
+	)
+
+	const requests = []
+	const writes = []
+	const app = {
+		vault: {
+			adapter: {
+				exists: async () => true,
+				mkdir: async () => {},
+				writeBinary: async (path, data) => writes.push({ path, data }),
+			},
+		},
+	}
+	const provider = new SeedanceProvider(
+		'test-key',
+		app,
+		'assets',
+		'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks',
+	)
+
+	process.__bragiSeedanceRequestHandler = async (request) => {
+		requests.push(request)
+		return { status: 200, json: { id: 'task-25' }, text: '' }
+	}
+	assert.deepEqual(await provider.generateVideo('A paper boat sails', {
+		modelId,
+		genMode: 'text-to-video',
+		output_format: 'mov',
+	}), { done: false, taskId: 'task-25' })
+	assert.equal(requests[0].url, 'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks')
+	assert.equal(requests[0].headers.Authorization, 'Bearer test-key')
+	assert.equal(JSON.parse(requests[0].body).model, modelId)
+
+	process.__bragiSeedanceRequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/task-25')) {
+			return { status: 200, json: { status: 'succeeded', content: { video_url: 'https://cdn.example/result.mov?token=redacted' } } }
+		}
+		if (request.url.startsWith('https://cdn.example/result.mov')) {
+			return { status: 200, arrayBuffer: new Uint8Array([1, 2, 3]).buffer }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	const completed = await provider.checkStatus('task-25')
+	assert.match(completed.filePath, /^assets\/vid_\d+\.mov$/)
+	assert.equal(writes.length, 1)
+	assert.deepEqual([...new Uint8Array(writes[0].data)], [1, 2, 3])
+
+	const [modelSource, mainSource, providerRules] = await Promise.all([
+		readFile('src/models/seedance.ts', 'utf8'),
+		readFile('src/main.ts', 'utf8'),
+		readFile('docs/model-provider-rules.md', 'utf8'),
+	])
+	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*apiModelId: 'dreamina-seedance-2-5-260628'/)
+	assert.match(modelSource, /modes: \['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'\]/)
+	assert.match(mainSource, /getSeedanceReferenceLimits\(model\.id\)/)
+	assert.match(providerRules, /## BytePlus Seedance 2\.5[\s\S]*dreamina-seedance-2-5-260628/)
+
+	console.log('Seedance 2.5 provider checks passed.')
+} finally {
+	delete process.__bragiSeedanceRequestHandler
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/scripts/verify-seedance-2-5.mjs
+++ b/scripts/verify-seedance-2-5.mjs
@@ -122,6 +122,20 @@ try {
 	assert.equal(requests[0].headers.Authorization, 'Bearer test-key')
 	assert.equal(JSON.parse(requests[0].body).model, modelId)
 
+	const volcengineModelId = 'doubao-seedance-2-5-260628'
+	const volcengineProvider = new SeedanceProvider('volcengine-key', app, 'assets')
+	process.__bragiSeedanceRequestHandler = async (request) => {
+		requests.push(request)
+		return { status: 200, json: { id: 'volcengine-task-25' }, text: '' }
+	}
+	assert.deepEqual(await volcengineProvider.generateVideo('A kite crosses the sky', {
+		modelId: volcengineModelId,
+		genMode: 'text-to-video',
+	}), { done: false, taskId: 'volcengine-task-25' })
+	assert.equal(requests.at(-1).url, 'https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks')
+	assert.equal(requests.at(-1).headers.Authorization, 'Bearer volcengine-key')
+	assert.equal(JSON.parse(requests.at(-1).body).model, volcengineModelId)
+
 	process.__bragiSeedanceRequestHandler = async (request) => {
 		requests.push(request)
 		if (request.url.endsWith('/task-25')) {
@@ -142,10 +156,10 @@ try {
 		readFile('src/main.ts', 'utf8'),
 		readFile('docs/model-provider-rules.md', 'utf8'),
 	])
-	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*apiModelId: 'dreamina-seedance-2-5-260628'/)
+	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*bytedance: \{ apiModelId: 'doubao-seedance-2-5-260628' \}[\s\S]*apiModelId: 'dreamina-seedance-2-5-260628'/)
 	assert.match(modelSource, /modes: \['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'\]/)
 	assert.match(mainSource, /getSeedanceReferenceLimits\(model\.id\)/)
-	assert.match(providerRules, /## BytePlus Seedance 2\.5[\s\S]*dreamina-seedance-2-5-260628/)
+	assert.match(providerRules, /## Volcengine and BytePlus Seedance 2\.5[\s\S]*doubao-seedance-2-5-260628[\s\S]*dreamina-seedance-2-5-260628/)
 
 	console.log('Seedance 2.5 provider checks passed.')
 } finally {

--- a/scripts/verify-svnewapi-video-params.mjs
+++ b/scripts/verify-svnewapi-video-params.mjs
@@ -24,7 +24,7 @@ assert.match(
 
 assert.match(
 	directSeedanceSource,
-	/const duration = parseInt\(params\?\.duration \|\| '5'\)[\s\S]*?duration,/,
+	/const duration = Number\.parseInt\(stringParam\(params, 'duration', is25 \? '-1' : '5'\), 10\)[\s\S]*?duration,/,
 	'Direct BytePlus/Volcengine Seedance must continue forwarding Auto duration as numeric -1.',
 )
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ import { BFL_DENOISE_PROMPT } from './providers/bfl'
 import { getAssetIdsForFiles, getNodeAssetId, getNodeAssetIdMap, getSeedanceAssetMediaKind, SEEDANCE_ASSET_PROVIDER_LABELS, setNodeAssetId, type SeedanceAssetProviderId } from './asset-ids'
 import { requestNlm35Denoise } from './denoise'
 import { DenoiseChoiceModal, type DenoiseMethod } from './ui/denoise-choice-modal'
+import { getSeedanceReferenceLimits } from './seedance-capabilities'
 
 const ELEVENLABS_VOICE_CHANGER_MODEL_ID = 'eleven_multilingual_sts_v2'
 
@@ -774,6 +775,16 @@ export default class BragiCanvas extends Plugin {
 			const supportsKlingOmniVideoRef = model.id === 'kling-3.0-omni' && (activeProvider === 'kling' || activeProvider === 'apimart')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
+			const seedanceReferenceLimits = isSeedanceModel ? getSeedanceReferenceLimits(model.id) : null
+			if (seedanceReferenceLimits && uniqueImages.length > seedanceReferenceLimits.images) {
+				throw new Error(`${model.name} supports up to ${seedanceReferenceLimits.images} reference images.`)
+			}
+			if (seedanceReferenceLimits && uniqueAudios.length > seedanceReferenceLimits.audios) {
+				throw new Error(`${model.name} supports up to ${seedanceReferenceLimits.audios} reference audio files.`)
+			}
+			if (seedanceReferenceLimits && uniqueVideos.length > seedanceReferenceLimits.videos) {
+				throw new Error(`${model.name} supports up to ${seedanceReferenceLimits.videos} reference videos.`)
+			}
 			// BytePlus asset library: run when Seedance has reference media and AK/SK configured.
 			const bytePlusCreds = (activeProvider === 'byteplus' && isNativeSeedance && hasSeedanceMediaRefs)
 				? getBytePlusAssetCreds(this)
@@ -829,9 +840,6 @@ export default class BragiCanvas extends Plugin {
 
 			// Upload reference audios for providers/models that need public media URLs.
 			if ((supportsSeedanceUrlRefs || isMuleRouterWan || isDashScopeWan) && uniqueAudios.length > 0) {
-				if (supportsSeedanceUrlRefs && uniqueAudios.length > 3) {
-					throw new Error('Seedance supports up to 3 reference audio files.')
-				}
 				const audioRefs = isMuleRouterWan ? uniqueAudios.slice(0, 1) : uniqueAudios
 				for (const audioPath of audioRefs) {
 					if (bytePlusCreds) {
@@ -848,22 +856,17 @@ export default class BragiCanvas extends Plugin {
 			}
 
 			// Prepare reference videos for models/providers that can consume upstream video inputs.
-			// BytePlus Seedance videos must go through asset:// so face-containing clips are reviewed first.
+			// BytePlus uses asset:// when native asset credentials are configured; otherwise
+			// the declarative delivery path falls back to a temporary HTTPS relay URL.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
 				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !supportsKlingOmniVideoRef && !isDashScopeWan) {
 					throw new Error('Reference video is not available for the active model and provider.')
-				}
-				if (supportsSeedanceUrlRefs && uniqueVideos.length > 3) {
-					throw new Error('Seedance supports up to 3 reference videos.')
 				}
 				if (supportsApimartVideoRef && uniqueVideos.length > 1) {
 					throw new Error('APIMart Omni-Flash-Ext supports at most 1 reference video.')
 				}
 				if (supportsKlingOmniVideoRef && uniqueVideos.length > 1) {
 					throw new Error('Kling 3.0 Omni supports at most 1 reference video.')
-				}
-				if (isNativeSeedance && activeProvider === 'byteplus' && !bytePlusCreds) {
-					throw new Error('Add BytePlus access key and secret key in settings to use reference videos.')
 				}
 				const shouldUseVideos = supportsSeedanceUrlRefs || isDashScopeWan || mode === 'video-extend' || mode === 'video-edit' || mode === 'video-ref' || mode === 'motion-control'
 				if (shouldUseVideos) {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,7 @@ import { gptImage, gptImageOfficial } from './gpt-image'
 import { flux2Klein9b } from './flux'
 import { nanoBananaPro, nanoBanana2 } from './nano-banana'
 import { seedream5, seedream5Lite, seedream45 } from './seedream'
-import { seedance2, seedance2Fast } from './seedance'
+import { seedance25, seedance2, seedance2Fast } from './seedance'
 import { kling3, klingOmni3, kling26 } from './kling'
 import { happyHorseT2V, happyHorseI2V } from './happyhorse'
 import { veo31, veo31Lite } from './veo'
@@ -44,6 +44,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	zImageSpicy,
 	qwenImageEditSpicy,
 	// Video
+	seedance25,
 	seedance2,
 	seedance2Fast,
 	kling3,

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -1,5 +1,91 @@
 import type { ModelConfig } from './types'
 
+const seedance25DurationOptions = [
+	{ label: 'Auto', value: '-1' },
+	...Array.from({ length: 27 }, (_, index) => {
+		const seconds = index + 4
+		return { label: `${seconds}s`, value: String(seconds) }
+	}),
+]
+
+const seedance25AdaptiveOnly = [{ label: 'Adaptive', value: 'adaptive' }]
+
+export const seedance25: ModelConfig = {
+	id: 'seedance-2.5',
+	name: 'Seedance 2.5',
+	type: 'video',
+	supportedProviders: {
+		byteplus: {
+			apiModelId: 'dreamina-seedance-2-5-260628',
+			refDelivery: { image: 'native_asset', video: 'native_asset', audio: 'native_asset', nativeAssetProvider: 'byteplus' },
+		},
+	},
+	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'],
+	params: [
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'select',
+			options: seedance25DurationOptions,
+			optionsByMode: {
+				'video-edit': [{ label: 'Auto', value: '-1' }],
+			},
+			default: '-1',
+		},
+		{
+			id: 'ratio',
+			label: 'Ratio',
+			type: 'select',
+			options: [
+				...seedance25AdaptiveOnly,
+				{ label: '16:9', value: '16:9' },
+				{ label: '4:3', value: '4:3' },
+				{ label: '1:1', value: '1:1' },
+				{ label: '3:4', value: '3:4' },
+				{ label: '9:16', value: '9:16' },
+				{ label: '21:9', value: '21:9' },
+			],
+			optionsByMode: {
+				'first-frame': seedance25AdaptiveOnly,
+				'first-last-frame': seedance25AdaptiveOnly,
+				'video-extend': seedance25AdaptiveOnly,
+				'video-edit': seedance25AdaptiveOnly,
+			},
+			default: 'adaptive',
+		},
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '480p', value: '480p' },
+				{ label: '720p', value: '720p' },
+			],
+			default: '720p',
+		},
+		{
+			id: 'generate_audio',
+			label: 'Audio',
+			type: 'select',
+			options: [
+				{ label: 'On', value: 'true' },
+				{ label: 'Off', value: 'false' },
+			],
+			default: 'true',
+		},
+		{
+			id: 'output_format',
+			label: 'Format',
+			type: 'select',
+			options: [
+				{ label: 'MP4', value: 'mp4' },
+				{ label: 'MOV', value: 'mov' },
+			],
+			default: 'mp4',
+		},
+	],
+}
+
 export const seedance2: ModelConfig = {
 	id: 'seedance-2.0',
 	name: 'Seedance 2.0',

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -15,6 +15,7 @@ export const seedance25: ModelConfig = {
 	name: 'Seedance 2.5',
 	type: 'video',
 	supportedProviders: {
+		bytedance: { apiModelId: 'doubao-seedance-2-5-260628' },
 		byteplus: {
 			apiModelId: 'dreamina-seedance-2-5-260628',
 			refDelivery: { image: 'native_asset', video: 'native_asset', audio: 'native_asset', nativeAssetProvider: 'byteplus' },

--- a/src/providers/seedance.ts
+++ b/src/providers/seedance.ts
@@ -3,8 +3,145 @@ import type { VideoProvider, GenerateVideoResult } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
 import { uploadRef } from './upload'
+import { getSeedanceReferenceLimits, isSeedance25ModelId } from '../seedance-capabilities'
 
 const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks'
+
+type SeedanceContent =
+	| { type: 'text'; text: string }
+	| { type: 'image_url'; image_url: { url: string }; role: 'first_frame' | 'last_frame' | 'reference_image' }
+	| { type: 'audio_url'; audio_url: { url: string }; role: 'reference_audio' }
+	| { type: 'video_url'; video_url: { url: string }; role: 'reference_video' }
+
+export interface SeedanceRequestBody {
+	model: string
+	content: SeedanceContent[]
+	duration: number
+	ratio: string
+	resolution: string
+	generate_audio: boolean
+	watermark: false
+	output_format?: 'mp4' | 'mov'
+}
+
+function stringParam(params: Record<string, unknown>, key: string, fallback: string): string {
+	const value = params[key]
+	if (typeof value === 'string') return value
+	if (typeof value === 'number' || typeof value === 'boolean') return `${value}`
+	return fallback
+}
+
+function stringArrayParam(params: Record<string, unknown>, key: string): string[] {
+	const value = params[key]
+	return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function assertSeedanceInputs(
+	modelId: string,
+	genMode: string,
+	duration: number,
+	ratio: string,
+	resolution: string,
+	outputFormat: string,
+	refImages: string[],
+	refAudios: string[],
+	refVideos: string[],
+): void {
+	const is25 = isSeedance25ModelId(modelId)
+	const limits = getSeedanceReferenceLimits(modelId)
+	const modelName = is25 ? 'Seedance 2.5' : 'Seedance'
+	if (refImages.length > limits.images) throw new Error(`${modelName} supports up to ${limits.images} reference images.`)
+	if (refVideos.length > limits.videos) throw new Error(`${modelName} supports up to ${limits.videos} reference videos.`)
+	if (refAudios.length > limits.audios) throw new Error(`${modelName} supports up to ${limits.audios} reference audio files.`)
+
+	const supportedModes = is25
+		? ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit']
+		: ['text-to-video', 'first-frame', 'image-ref', 'video-ref']
+	if (!supportedModes.includes(genMode)) throw new Error(`${modelName} does not support ${genMode} mode.`)
+
+	const totalRefs = refImages.length + refAudios.length + refVideos.length
+	if (genMode === 'text-to-video' && totalRefs > 0) {
+		throw new Error(`${modelName} text-to-video mode does not accept reference media.`)
+	}
+	if (genMode === 'first-frame' && (refImages.length !== 1 || refAudios.length > 0 || refVideos.length > 0)) {
+		throw new Error(`${modelName} first-frame mode requires exactly one image and no other reference media.`)
+	}
+	if (genMode === 'first-last-frame' && (refImages.length !== 2 || refAudios.length > 0 || refVideos.length > 0)) {
+		throw new Error(`${modelName} first-last-frame mode requires exactly two images and no other reference media.`)
+	}
+	if (genMode === 'image-ref' && refImages.length === 0) {
+		throw new Error(`${modelName} image-ref mode requires at least one reference image.`)
+	}
+	if (genMode === 'video-ref' && (is25 ? totalRefs === 0 : refImages.length + refVideos.length === 0)) {
+		throw new Error(`${modelName} video-ref mode requires reference media.`)
+	}
+	if ((genMode === 'video-edit' || genMode === 'video-extend') && refVideos.length === 0) {
+		throw new Error(`${modelName} ${genMode} mode requires at least one reference video.`)
+	}
+
+	if (!Number.isInteger(duration) || (duration !== -1 && (duration < 4 || duration > (is25 ? 30 : 15)))) {
+		throw new Error(`${modelName} duration must be Auto (-1) or an integer from 4 to ${is25 ? 30 : 15} seconds.`)
+	}
+	if (is25) {
+		const supportedRatios = ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9']
+		if (!supportedRatios.includes(ratio)) throw new Error(`Seedance 2.5 does not support ratio ${ratio}.`)
+		if (['first-frame', 'first-last-frame', 'video-extend', 'video-edit'].includes(genMode) && ratio !== 'adaptive') {
+			throw new Error(`Seedance 2.5 ${genMode} mode requires adaptive ratio.`)
+		}
+		if (genMode === 'video-edit' && duration !== -1) {
+			throw new Error('Seedance 2.5 video-edit mode requires Auto (-1) duration.')
+		}
+		if (!['480p', '720p'].includes(resolution)) throw new Error(`Seedance 2.5 does not support ${resolution} output.`)
+		if (!['mp4', 'mov'].includes(outputFormat)) throw new Error(`Seedance 2.5 does not support ${outputFormat} output.`)
+	}
+}
+
+export function buildSeedanceRequestBody(prompt: string, params: Record<string, unknown> = {}): SeedanceRequestBody {
+	const modelId = stringParam(params, 'modelId', 'doubao-seedance-2-0-260128')
+	const is25 = isSeedance25ModelId(modelId)
+	const genMode = stringParam(params, 'genMode', 'text-to-video')
+	const duration = Number.parseInt(stringParam(params, 'duration', is25 ? '-1' : '5'), 10)
+	const ratio = stringParam(params, 'ratio', is25 ? 'adaptive' : '16:9')
+	const resolution = stringParam(params, 'resolution', '720p')
+	const outputFormat = stringParam(params, 'output_format', 'mp4')
+	const refImages = stringArrayParam(params, 'refImages')
+	const refAudios = stringArrayParam(params, 'refAudios')
+	const refVideos = stringArrayParam(params, 'refVideos')
+	const generateAudio = params.generate_audio !== 'false' && params.generate_audio !== false
+
+	assertSeedanceInputs(modelId, genMode, duration, ratio, resolution, outputFormat, refImages, refAudios, refVideos)
+	if (genMode === 'text-to-video' && !prompt.trim()) throw new Error(`${is25 ? 'Seedance 2.5' : 'Seedance'} text-to-video mode requires a prompt.`)
+
+	const content: SeedanceContent[] = []
+	if (prompt.trim()) content.push({ type: 'text', text: prompt })
+
+	for (const [index, imageUrl] of refImages.entries()) {
+		const role = genMode === 'first-frame'
+			? 'first_frame'
+			: genMode === 'first-last-frame'
+				? index === 0 ? 'first_frame' : 'last_frame'
+				: 'reference_image'
+		content.push({ type: 'image_url', image_url: { url: imageUrl }, role })
+	}
+	for (const audioUrl of refAudios) {
+		content.push({ type: 'audio_url', audio_url: { url: audioUrl }, role: 'reference_audio' })
+	}
+	for (const videoUrl of refVideos) {
+		content.push({ type: 'video_url', video_url: { url: videoUrl }, role: 'reference_video' })
+	}
+
+	const body: SeedanceRequestBody = {
+		model: modelId,
+		content,
+		duration,
+		ratio,
+		resolution,
+		generate_audio: generateAudio,
+		watermark: false,
+	}
+	if (is25) body.output_format = outputFormat as 'mp4' | 'mov'
+	return body
+}
 
 export class SeedanceProvider implements VideoProvider {
 	name = 'Seedance'
@@ -21,21 +158,11 @@ export class SeedanceProvider implements VideoProvider {
 	}
 
 	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
-		const modelId = params?.modelId || 'doubao-seedance-2-0-260128'
-		const duration = parseInt(params?.duration || '5')
-		const ratio = params?.ratio || '16:9'
-		const resolution = params?.resolution || '720p'
-		const refImages: string[] = params?.refImages || []
-		const refAudios: string[] = params?.refAudios || []
-		const refVideos: string[] = params?.refVideos || []
-		const generateAudio = params?.generate_audio !== 'false'
-
-		if (refImages.length > 9) throw new Error('Seedance supports up to 9 reference images.')
-		if (refVideos.length > 3) throw new Error('Seedance supports up to 3 reference videos.')
-		if (refAudios.length > 3) throw new Error('Seedance supports up to 3 reference audio files.')
-
-		// Build content array
-		const content: unknown[] = []
+		const requestParams = params || {}
+		// Validate before any reference upload so an invalid task cannot create orphaned assets.
+		buildSeedanceRequestBody(prompt, requestParams)
+		const refImages = stringArrayParam(requestParams, 'refImages')
+		const preparedImages: string[] = []
 
 		// Add reference images
 		for (const dataUri of refImages) {
@@ -47,51 +174,17 @@ export class SeedanceProvider implements VideoProvider {
 			} else {
 				const match = dataUri.match(/^data:([^;]+);base64,(.+)$/)
 				if (match) {
-					// Upload to R2 to get a real URL (data URI too large for API)
+					// Upload through the temporary relay to get a public URL.
 					const binary = Uint8Array.from(atob(match[2]), c => c.charCodeAt(0))
 					const ext = match[1].includes('png') ? 'png' : 'jpg'
 					imageUrl = await uploadRef(undefined, binary.buffer, `ref.${ext}`, match[1])
 				}
 			}
 
-			content.push({
-				type: 'image_url',
-				image_url: { url: imageUrl },
-				role: 'reference_image',
-			})
+			preparedImages.push(imageUrl)
 		}
 
-		// Add reference audios
-		for (const audioUrl of refAudios) {
-			content.push({
-				type: 'audio_url',
-				audio_url: { url: audioUrl },
-				role: 'reference_audio',
-			})
-		}
-
-		// Add reference videos
-		for (const videoUrl of refVideos) {
-			content.push({
-				type: 'video_url',
-				video_url: { url: videoUrl },
-				role: 'reference_video',
-			})
-		}
-
-		// Add prompt text
-		content.push({ type: 'text', text: prompt })
-
-		// Create task
-		const requestBody = {
-			model: modelId,
-			content,
-			duration,
-			ratio,
-			resolution,
-			generate_audio: generateAudio,
-			watermark: false,
-		}
+		const requestBody = buildSeedanceRequestBody(prompt, { ...requestParams, refImages: preparedImages })
 		const response = await requestUrl({
 			url: this.baseUrl,
 			method: 'POST',
@@ -154,7 +247,13 @@ export class SeedanceProvider implements VideoProvider {
 	private async downloadVideo(url: string): Promise<string> {
 		const response = await requestUrl({ url })
 		const timestamp = Date.now()
-		const fileName = `vid_${timestamp}.mp4`
+		let extension = 'mp4'
+		try {
+			if (new URL(url).pathname.toLowerCase().endsWith('.mov')) extension = 'mov'
+		} catch {
+			// Provider result URLs are normally absolute; default to MP4 if parsing fails.
+		}
+		const fileName = `vid_${timestamp}.${extension}`
 		const filePath = `${this.outputDir}/${fileName}`
 
 		const adapter = this.app.vault.adapter

--- a/src/seedance-capabilities.ts
+++ b/src/seedance-capabilities.ts
@@ -1,0 +1,15 @@
+export interface SeedanceReferenceLimits {
+	images: number
+	videos: number
+	audios: number
+}
+
+export function isSeedance25ModelId(modelId: string): boolean {
+	return /seedance-2[.-]5(?:-|$)/.test(modelId)
+}
+
+export function getSeedanceReferenceLimits(modelId: string): SeedanceReferenceLimits {
+	return isSeedance25ModelId(modelId)
+		? { images: 30, videos: 10, audios: 10 }
+		: { images: 9, videos: 3, audios: 3 }
+}


### PR DESCRIPTION
## Summary
- add Seedance 2.5 to the shared video model catalog
- map BytePlus and Volcengine upstream model IDs and endpoints
- support text, first-frame, first-last-frame, multimodal reference, extension, and edit modes
- validate 4–30 second duration, adaptive-only modes, 480p/720p, MP4/MOV, and reference limits
- document provider-specific relay and native asset behavior

## Validation
- npm run test:seedance-2-5
- npm run test:svnewapi-video-params
- npm run check:catalog
- npm run audit:catalog
- npm run build
- npm run lint:obsidian
- real BytePlus 2.5 text-to-video smoke test succeeded
- real BytePlus 2.5 HTTPS first-frame smoke test succeeded