### PR TITLE
Add SVRouter support for Seedance 2.5

### DIFF
--- a/scripts/verify-mureka-music.mjs
+++ b/scripts/verify-mureka-music.mjs
@@ -216,7 +216,7 @@ try {
 	assert.match(mainSource, /outputType: 'audio'/, 'Async audio snapshots must persist outputType.')
 	assert.match(panelSource, /model\?\.id === 'mureka-music' && params\.generation_mode === 'lyrics'/, 'Mureka lyrics mode must share the upstream lyrics guard.')
 	assert.match(settingsSource, /mureka: string/, 'Settings must include the Mureka credential.')
-	assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = 11/, 'Adding Mureka must advance the settings schema version.')
+	assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = (1[2-9]|[2-9]\d+)/, 'Adding Mureka must advance the settings schema version.')
 
 	console.log('Mureka music and async audio queue checks passed.')
 } finally {

--- a/scripts/verify-pika-provider.mjs
+++ b/scripts/verify-pika-provider.mjs
@@ -219,7 +219,7 @@ try {
 	assert.match(settingsSource, /pika: ''/, 'Default settings must include an empty Pika key.')
 	assert.match(
 		migrationsSource,
-		/CURRENT_SETTINGS_SCHEMA_VERSION = 11/,
+		/CURRENT_SETTINGS_SCHEMA_VERSION = (1[2-9]|[2-9]\d+)/,
 		'Adding a provider credential must advance the settings schema version.',
 	)
 	assert.match(

--- a/scripts/verify-seedance-2-5.mjs
+++ b/scripts/verify-seedance-2-5.mjs
@@ -151,15 +151,27 @@ try {
 	assert.equal(writes.length, 1)
 	assert.deepEqual([...new Uint8Array(writes[0].data)], [1, 2, 3])
 
-	const [modelSource, mainSource, providerRules] = await Promise.all([
+	const [modelSource, mainSource, providerRules, migrationsSource] = await Promise.all([
 		readFile('src/models/seedance.ts', 'utf8'),
 		readFile('src/main.ts', 'utf8'),
 		readFile('docs/model-provider-rules.md', 'utf8'),
+		readFile('src/settings-migrations.ts', 'utf8'),
 	])
 	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*bytedance: \{ apiModelId: 'doubao-seedance-2-5-260628' \}[\s\S]*apiModelId: 'dreamina-seedance-2-5-260628'/)
+	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*svnewapi: \{ apiModelId: 'sv-seedance-2\.5' \}/)
 	assert.match(modelSource, /modes: \['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'\]/)
 	assert.match(mainSource, /getSeedanceReferenceLimits\(model\.id\)/)
 	assert.match(providerRules, /## Volcengine and BytePlus Seedance 2\.5[\s\S]*doubao-seedance-2-5-260628[\s\S]*dreamina-seedance-2-5-260628/)
+	assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = 12/)
+	assert.match(
+		migrationsSource,
+		/function migrateSeedance25SvRouter[\s\S]*const modelId = 'seedance-2\.5'[\s\S]*connectProviderToModel\(settings, 'svnewapi', modelId\)/,
+	)
+	assert.doesNotMatch(
+		migrationsSource.match(/function migrateSeedance25SvRouter[\s\S]*?\n}/)?.[0] || '',
+		/selectedProvider/,
+		'Seedance 2.5 SVRouter migration must not change the active provider.',
+	)
 
 	console.log('Seedance 2.5 provider checks passed.')
 } finally {

--- a/scripts/verify-svnewapi-video-params.mjs
+++ b/scripts/verify-svnewapi-video-params.mjs
@@ -12,8 +12,26 @@ assert.match(
 
 assert.match(
 	source,
-	/if \(modelId === SV_VIDEO_SEEDANCE\) \{[\s\S]*?if \(duration\) metadata\.duration = duration === '-1' \? -1 : parseInt\(duration, 10\)/,
+	/if \(SV_VIDEO_SEEDANCE_RE\.test\(modelId\)\) \{[\s\S]*?if \(duration\) metadata\.duration = duration === '-1' \? -1 : parseInt\(duration, 10\)/,
 	'SV NewAPI Seedance must forward Auto duration as metadata.duration = -1 to match direct Ark Seedance.',
+)
+
+assert.match(
+	source,
+	/const SV_VIDEO_SEEDANCE_RE = \/\^sv-seedance-2\\\.\(\?:0\|5\)\(\?:-\|\$\)\//,
+	'SV NewAPI Seedance special handling must include Seedance 2.0 and 2.5 virtual models.',
+)
+
+assert.match(
+	source,
+	/if \(genMode\) \{[\s\S]*?body\.mode = genMode[\s\S]*?metadata\.genMode = genMode[\s\S]*?\}[\s\S]*?if \(outputFormat\) metadata\.output_format = outputFormat/,
+	'SV NewAPI Seedance must forward mode and output_format through the gateway metadata contract.',
+)
+
+assert.match(
+	source,
+	/metadata\.generate_audio = params\.generate_audio !== false && params\.generate_audio !== 'false'/,
+	'SV NewAPI Seedance must preserve boolean false generate_audio values.',
 )
 
 assert.match(

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -20,6 +20,7 @@ export const seedance25: ModelConfig = {
 			apiModelId: 'dreamina-seedance-2-5-260628',
 			refDelivery: { image: 'native_asset', video: 'native_asset', audio: 'native_asset', nativeAssetProvider: 'byteplus' },
 		},
+		svnewapi: { apiModelId: 'sv-seedance-2.5' },
 	},
 	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'],
 	params: [

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -30,7 +30,8 @@ const SV_IMAGE_BANANA_PRO = 'sv-nano-banana-pro'    // APIMart gemini-3-pro-imag
 // aspect-ratio `size` + 1k/2k/4k `resolution` tier — same shape as the direct APIMart provider.
 const SV_IMAGE_GPT_RE = /^sv-gpt-image-2(-official)?$/
 const SV_IMAGE_GPT_OFFICIAL = 'sv-gpt-image-2-official' // only this one honors `quality`
-const SV_VIDEO_SEEDANCE = 'sv-seedance-2.0'         // byteplus seedance: params go in `metadata`, not top-level
+// byteplus seedance: params go in `metadata`, not top-level.
+const SV_VIDEO_SEEDANCE_RE = /^sv-seedance-2\.(?:0|5)(?:-|$)/
 // Seedream's Ark upstream enforces a per-tier minimum pixel count, so its `size` must come
 // from the Seedream-specific map, not the smaller generic OpenAI table (kept as a fallback for
 // other OpenAI-compatible image models).
@@ -375,13 +376,20 @@ function buildVideoBody(
 	const ratio = optionalString(params.ratio || params.aspect_ratio || params.aspectRatio)
 	const duration = optionalString(params.duration || params.durationSeconds)
 	const resolution = optionalString(params.resolution)
+	const genMode = optionalString(params.genMode || params.gen_mode || params.mode)
+	const outputFormat = optionalString(params.output_format || params.outputFormat)
 
-	if (modelId === SV_VIDEO_SEEDANCE) {
+	if (SV_VIDEO_SEEDANCE_RE.test(modelId)) {
 		const metadata: JsonRecord = { watermark: false }
+		if (genMode) {
+			body.mode = genMode
+			metadata.genMode = genMode
+		}
 		if (ratio) metadata.ratio = ratio
 		if (duration) metadata.duration = duration === '-1' ? -1 : parseInt(duration, 10)
 		if (resolution) metadata.resolution = resolution
-		if (params.generate_audio !== undefined) metadata.generate_audio = params.generate_audio !== 'false'
+		if (params.generate_audio !== undefined) metadata.generate_audio = params.generate_audio !== false && params.generate_audio !== 'false'
+		if (outputFormat) metadata.output_format = outputFormat
 		body.metadata = metadata
 		// The gateway converts each entry to an Ark content[] reference part
 		// (image_url/reference_image, audio_url/reference_audio, video_url/reference_video).

--- a/src/settings-migrations.ts
+++ b/src/settings-migrations.ts
@@ -10,7 +10,7 @@ import { DEFAULT_SETTINGS, type BragiSettings, type GeneratedAssetRecord, type L
 
 type UnknownRecord = Record<string, unknown>
 
-export const CURRENT_SETTINGS_SCHEMA_VERSION = 11
+export const CURRENT_SETTINGS_SCHEMA_VERSION = 12
 const PROVIDER_MODEL_PREFS_SCHEMA_VERSION = 2
 
 export interface SettingsMigrationResult {
@@ -517,6 +517,15 @@ function migrateDashScopeWan27(settings: BragiSettings, previousVersion: number)
 	}
 }
 
+function migrateSeedance25SvRouter(settings: BragiSettings, previousVersion: number): void {
+	if (previousVersion >= 12) return
+	if (!settings.providers.svnewapi?.trim()) return
+	const modelId = 'seedance-2.5'
+	const pref = settings.modelPrefs[modelId]
+	if (pref?.enabled !== true) return
+	connectProviderToModel(settings, 'svnewapi', modelId)
+}
+
 const RECOGNIZABLE_KEYS = [
 	'settingsSchemaVersion',
 	'outputDir',
@@ -568,6 +577,7 @@ export function migrateSettings(
 	migrateProviderPrefs19(settings)
 	migrateProviderModelPrefs(settings, previousVersion)
 	migrateDashScopeWan27(settings, previousVersion)
+	migrateSeedance25SvRouter(settings, previousVersion)
 	settings.settingsSchemaVersion = CURRENT_SETTINGS_SCHEMA_VERSION
 
 	const valid = options.strict ? errors.length === 0 : true


### PR DESCRIPTION
## Summary
- add SVRouter as a supported provider for Seedance 2.5 using `sv-seedance-2.5`
- route SVRouter Seedance 2.5 video params through metadata, including mode and output_format
- add a v12 settings migration that backfills the Seedance 2.5 SVRouter provider connection without changing the active provider

## Tests
- `npm run test:seedance-2-5`
- `npm run test:svnewapi-video-params`
- `npm run test:pika-provider`
- `npm run test:mureka-music`
- `npm run check:catalog`
- `npm run build`