### PR TITLE
feat: add APIMart MiniMax-H3 video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added MiniMax-H3 video generation through APIMart with text-to-video, first-frame, first-last-frame, image-reference, and video-reference modes.
+- Added MiniMax-H3 image/video/audio Relay handling, strict frame-versus-reference validation, 4–15 second duration, 2K/768P output, adaptive/fixed ratios, and optional watermarking.
+- Added APIMart MiniMax-H3 request, relay, async polling, error, catalog, and documentation regression coverage.
+
 ## 1.34.2
 
 - Added SVRouter support for Seedance 2.5 through `sv-seedance-2.5`.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -46,6 +46,18 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Supported duration values are 4, 6, 8, and 10 seconds.
 - Supported resolution values are `720p`, `1080p`, and `4k`.
 
+## APIMart MiniMax-H3
+
+- Bragi model ID: `minimax-h3`; APIMart model ID: `MiniMax-H3`.
+- Submit with `POST https://api.apimart.ai/v1/videos/generations`; poll with `GET https://api.apimart.ai/v1/tasks/{task_id}` and read the completed URL from `result.videos[0].url`.
+- Supported Bragi modes are `text-to-video`, `first-frame`, `first-last-frame`, `image-ref`, and `video-ref`. APIMart infers its upstream mode from the submitted reference fields; do not send a `mode` field.
+- `first-frame` and `first-last-frame` use `first_frame_image` / `last_frame_image`. They require exactly one or two ordered images, ignore aspect ratio, and cannot include reference image/video/audio fields.
+- `image-ref` sends up to 9 images in `image_urls` and may add up to 3 `audio_urls`. `video-ref` sends up to 3 `video_urls` and may combine them with up to 9 images and 3 audios. Audio cannot be the only reference modality.
+- Every image, video, and audio reference must be re-uploaded through Bragi Relay. The APIMart request receives only temporary HTTPS URLs; never send data URIs or arbitrary external URLs directly.
+- Prompt is required in every mode and must not exceed 7000 characters. Duration is a whole number from 4 through 15. Resolution is `2K` or `768P`.
+- Ratios are `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, and `9:16`. `adaptive` is accepted for reference generation; text-to-video normalizes it to `16:9`, while frame-controlled modes omit the field.
+- `watermark` is a boolean and defaults to `false`. Webhooks are intentionally not exposed in the canvas model because Bragi's persistent task queue already owns completion tracking.
+
 ## Volcengine and BytePlus Seedance 2.5
 
 - Bragi model ID: `seedance-2.5`; Volcengine model ID: `doubao-seedance-2-5-260628`; BytePlus model ID: `dreamina-seedance-2-5-260628`.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
     "test:kling-omni": "node scripts/verify-kling-omni.mjs",
+    "test:apimart-minimax-h3": "node scripts/verify-apimart-minimax-h3.mjs",
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",
     "test:svnewapi-audio-params": "node scripts/verify-svnewapi-audio-params.mjs",
     "test:elevenlabs-voice-changer": "node scripts/verify-elevenlabs-voice-changer.mjs",

--- a/scripts/verify-apimart-minimax-h3.mjs
+++ b/scripts/verify-apimart-minimax-h3.mjs
@@ -1,0 +1,322 @@
+import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-apimart-minimax-h3-'))
+
+try {
+	const payloadBundle = join(tempDir, 'payload.mjs')
+	const providerBundle = join(tempDir, 'provider.mjs')
+	await build({
+		entryPoints: ['src/providers/apimart-minimax-h3-payload.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: payloadBundle,
+		logLevel: 'silent',
+	})
+	await build({
+		entryPoints: ['src/providers/apimart.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: providerBundle,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export async function requestUrl(options) {
+							return process.__bragiApimartH3RequestHandler(options)
+						}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const { buildApimartMinimaxH3Request, MINIMAX_H3_MODEL_ID } = await import(`${pathToFileURL(payloadBundle).href}?t=${Date.now()}`)
+	const { APIMartProvider } = await import(`${pathToFileURL(providerBundle).href}?t=${Date.now()}`)
+
+	assert.equal(MINIMAX_H3_MODEL_ID, 'MiniMax-H3')
+	assert.deepEqual(buildApimartMinimaxH3Request('A paper boat crosses a moonlit lake'), {
+		model: 'MiniMax-H3',
+		prompt: 'A paper boat crosses a moonlit lake',
+		duration: 5,
+		resolution: '2K',
+		watermark: false,
+		aspect_ratio: '16:9',
+	})
+
+	for (let duration = 4; duration <= 15; duration++) {
+		assert.equal(buildApimartMinimaxH3Request('Duration boundary', { duration }).duration, duration)
+	}
+	for (const aspectRatio of ['21:9', '16:9', '4:3', '1:1', '3:4', '9:16']) {
+		assert.equal(
+			buildApimartMinimaxH3Request('Ratio boundary', { aspect_ratio: aspectRatio }).aspect_ratio,
+			aspectRatio,
+		)
+	}
+
+	const firstFrame = buildApimartMinimaxH3Request('Wake into motion', {
+		genMode: 'first-frame',
+		refImages: ['https://temp.bragi.now/first.png'],
+		aspect_ratio: '9:16',
+		resolution: '768p',
+		watermark: 'true',
+	})
+	assert.equal(firstFrame.first_frame_image, 'https://temp.bragi.now/first.png')
+	assert.equal(firstFrame.last_frame_image, undefined)
+	assert.equal(firstFrame.aspect_ratio, undefined)
+	assert.equal(firstFrame.resolution, '768P')
+	assert.equal(firstFrame.watermark, true)
+
+	const firstLast = buildApimartMinimaxH3Request('Move from dawn into dusk', {
+		genMode: 'first-last-frame',
+		refImages: ['https://temp.bragi.now/first.png', 'https://temp.bragi.now/last.png'],
+		duration: '15',
+	})
+	assert.equal(firstLast.first_frame_image, 'https://temp.bragi.now/first.png')
+	assert.equal(firstLast.last_frame_image, 'https://temp.bragi.now/last.png')
+	assert.equal(firstLast.image_urls, undefined)
+	assert.equal(firstLast.aspect_ratio, undefined)
+
+	const imageAudioRefs = buildApimartMinimaxH3Request('Keep the character and voice consistent', {
+		genMode: 'image-ref',
+		refImages: Array.from({ length: 9 }, (_, index) => `https://temp.bragi.now/image-${index}.png`),
+		refAudios: Array.from({ length: 3 }, (_, index) => `https://temp.bragi.now/audio-${index}.mp3`),
+		aspect_ratio: 'adaptive',
+	})
+	assert.equal(imageAudioRefs.image_urls.length, 9)
+	assert.equal(imageAudioRefs.audio_urls.length, 3)
+	assert.equal(imageAudioRefs.aspect_ratio, 'adaptive')
+
+	const multimodalRefs = buildApimartMinimaxH3Request('Use every reference deliberately', {
+		genMode: 'video-ref',
+		refImages: ['https://temp.bragi.now/character.png'],
+		refVideos: Array.from({ length: 3 }, (_, index) => `https://temp.bragi.now/motion-${index}.mp4`),
+		refAudios: ['https://temp.bragi.now/voice.wav'],
+		aspectRatio: '9:16',
+	})
+	assert.deepEqual(multimodalRefs.image_urls, ['https://temp.bragi.now/character.png'])
+	assert.equal(multimodalRefs.video_urls.length, 3)
+	assert.deepEqual(multimodalRefs.audio_urls, ['https://temp.bragi.now/voice.wav'])
+	assert.equal(multimodalRefs.aspect_ratio, '9:16')
+
+	assert.throws(() => buildApimartMinimaxH3Request('   '), /prompt is required/)
+	assert.throws(() => buildApimartMinimaxH3Request('x'.repeat(7001)), /at most 7000 characters/)
+	for (const duration of [3, 16, 4.5, 'not-a-number']) {
+		assert.throws(() => buildApimartMinimaxH3Request('Bad duration', { duration }), /whole number from 4 to 15/)
+	}
+	assert.throws(() => buildApimartMinimaxH3Request('Bad resolution', { resolution: '1080P' }), /resolution must be 2K or 768P/)
+	assert.throws(() => buildApimartMinimaxH3Request('Bad ratio', { aspect_ratio: '2:1' }), /does not support aspect ratio/)
+	assert.throws(() => buildApimartMinimaxH3Request('Bad watermark', { watermark: 'yes' }), /watermark must be true or false/)
+	assert.throws(() => buildApimartMinimaxH3Request('Bad mode', { genMode: 'video-edit' }), /does not support video-edit/)
+	assert.throws(() => buildApimartMinimaxH3Request('T2V with ref', {
+		refImages: ['https://temp.bragi.now/ref.png'],
+	}), /does not accept reference media/)
+	assert.throws(() => buildApimartMinimaxH3Request('Missing first frame', { genMode: 'first-frame' }), /requires exactly one reference image/)
+	assert.throws(() => buildApimartMinimaxH3Request('Frame mixed with audio', {
+		genMode: 'first-frame',
+		refImages: ['https://temp.bragi.now/first.png'],
+		refAudios: ['https://temp.bragi.now/voice.mp3'],
+	}), /cannot be combined with reference video or audio/)
+	assert.throws(() => buildApimartMinimaxH3Request('Missing last frame', {
+		genMode: 'first-last-frame',
+		refImages: ['https://temp.bragi.now/first.png'],
+	}), /requires exactly two reference images/)
+	assert.throws(() => buildApimartMinimaxH3Request('Audio alone', {
+		refAudios: ['https://temp.bragi.now/voice.mp3'],
+	}), /must be paired with a reference image or video/)
+	assert.throws(() => buildApimartMinimaxH3Request('Image mode without image', {
+		genMode: 'image-ref',
+	}), /requires at least one reference image/)
+	assert.throws(() => buildApimartMinimaxH3Request('Image mode with video', {
+		genMode: 'image-ref',
+		refImages: ['https://temp.bragi.now/character.png'],
+		refVideos: ['https://temp.bragi.now/motion.mp4'],
+	}), /use video-ref mode/)
+	assert.throws(() => buildApimartMinimaxH3Request('Video mode without video', {
+		genMode: 'video-ref',
+		refImages: ['https://temp.bragi.now/character.png'],
+	}), /requires at least one reference video/)
+	assert.throws(() => buildApimartMinimaxH3Request('Too many images', {
+		genMode: 'image-ref',
+		refImages: Array.from({ length: 10 }, (_, index) => `https://temp.bragi.now/${index}.png`),
+	}), /at most 9 reference images/)
+	assert.throws(() => buildApimartMinimaxH3Request('Too many videos', {
+		genMode: 'video-ref',
+		refVideos: Array.from({ length: 4 }, (_, index) => `https://temp.bragi.now/${index}.mp4`),
+	}), /at most 3 reference videos/)
+	assert.throws(() => buildApimartMinimaxH3Request('Too many audios', {
+		genMode: 'image-ref',
+		refImages: ['https://temp.bragi.now/character.png'],
+		refAudios: Array.from({ length: 4 }, (_, index) => `https://temp.bragi.now/${index}.mp3`),
+	}), /at most 3 reference audio clips/)
+
+	const requests = []
+	const writes = []
+	const app = {
+		vault: {
+			adapter: {
+				exists: async () => true,
+				mkdir: async () => {},
+				writeBinary: async (path, data) => writes.push({ path, data }),
+			},
+		},
+	}
+	const provider = new APIMartProvider('test-key', app, 'assets')
+	let taskCounter = 0
+	process.__bragiApimartH3RequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url === 'https://example.com/voice.mp3') {
+			return {
+				status: 200,
+				headers: { 'Content-Type': 'audio/mpeg' },
+				arrayBuffer: new Uint8Array([73, 68, 51]).buffer,
+			}
+		}
+		if (request.url === 'https://temp.bragi.now/upload?ext=mp3') {
+			return { status: 200, json: { url: 'https://temp.bragi.now/relayed-voice.mp3' } }
+		}
+		if (request.url === 'https://api.apimart.ai/v1/videos/generations') {
+			taskCounter++
+			return { status: 200, json: { code: 200, data: [{ status: 'submitted', task_id: `h3-task-${taskCounter}` }] } }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+
+	assert.deepEqual(await provider.generateVideo('A silver train crosses the desert', {
+		modelId: 'MiniMax-H3',
+		genMode: 'text-to-video',
+		duration: 6,
+		resolution: '2K',
+		aspect_ratio: '21:9',
+	}), { done: false, taskId: 'h3-task-1' })
+	const requestsAfterTextSubmit = requests.length
+	await assert.rejects(
+		() => provider.generateVideo('Do not misroute this mode', {
+			modelId: 'MiniMax-H3',
+			genMode: 'motion-control',
+		}),
+		/does not support motion-control mode/,
+	)
+	assert.equal(requests.length, requestsAfterTextSubmit, 'Invalid H3 modes must fail before any provider request.')
+	assert.equal(requests[0].url, 'https://api.apimart.ai/v1/videos/generations')
+	assert.equal(requests[0].headers.Authorization, 'Bearer test-key')
+	assert.deepEqual(JSON.parse(requests[0].body), {
+		model: 'MiniMax-H3',
+		prompt: 'A silver train crosses the desert',
+		duration: 6,
+		resolution: '2K',
+		watermark: false,
+		aspect_ratio: '21:9',
+	})
+
+	assert.deepEqual(await provider.generateVideo('Match the person and voice', {
+		modelId: 'MiniMax-H3',
+		genMode: 'image-ref',
+		refImages: ['https://temp.bragi.now/character.png'],
+		refAudios: ['https://example.com/voice.mp3'],
+	}), { done: false, taskId: 'h3-task-2' })
+	const relayUpload = requests.find(request => request.url === 'https://temp.bragi.now/upload?ext=mp3')
+	assert.equal(relayUpload.headers['Content-Type'], 'audio/mpeg')
+	assert.match(relayUpload.headers.Authorization, /^Bearer /)
+	const refSubmit = requests.filter(request => request.url === 'https://api.apimart.ai/v1/videos/generations').at(-1)
+	assert.deepEqual(JSON.parse(refSubmit.body).audio_urls, ['https://temp.bragi.now/relayed-voice.mp3'])
+
+	process.__bragiApimartH3RequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/tasks/pending-task')) {
+			return { status: 200, json: { data: { status: 'processing' } } }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	assert.deepEqual(await provider.checkStatus('pending-task'), { done: false, taskId: 'pending-task' })
+
+	process.__bragiApimartH3RequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/tasks/failed-task')) {
+			return { status: 200, json: { data: { status: 'failed', error: { code: 'content_rejected', message: 'unsafe input' } } } }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	await assert.rejects(() => provider.checkStatus('failed-task'), /content_rejected.*unsafe input/)
+
+	process.__bragiApimartH3RequestHandler = async (request) => {
+		requests.push(request)
+		if (request.url.endsWith('/tasks/completed-task')) {
+			return { status: 200, json: { data: { status: 'completed', result: { videos: [{ url: 'https://cdn.example/h3-result.mp4' }] } } } }
+		}
+		if (request.url === 'https://cdn.example/h3-result.mp4') {
+			return { status: 200, arrayBuffer: new Uint8Array([1, 2, 3, 4]).buffer }
+		}
+		throw new Error(`Unexpected request: ${request.url}`)
+	}
+	const completed = await provider.checkStatus('completed-task')
+	assert.match(completed.filePath, /^assets\/apimart_video_\d+\.mp4$/)
+	assert.equal(writes.length, 1)
+	assert.deepEqual([...new Uint8Array(writes[0].data)], [1, 2, 3, 4])
+
+	process.__bragiApimartH3RequestHandler = async () => ({
+		status: 400,
+		json: { error: { code: 'invalid_request_error', message: 'Invalid request parameters' } },
+		text: '',
+	})
+	await assert.rejects(
+		() => provider.generateVideo('Rejected request', { modelId: 'MiniMax-H3', genMode: 'text-to-video' }),
+		/APIMart MiniMax-H3: invalid_request_error — Invalid request parameters/,
+	)
+
+	const siblingSkillDir = join('..', basename(process.cwd()).replace(/-plugin$/, '-skill'), 'bragi-canvas')
+	const skillDir = [join('..', 'skill', 'bragi-canvas'), siblingSkillDir].find(candidate => existsSync(candidate))
+	assert.ok(skillDir, 'Paired Bragi skill checkout must be available for sync verification.')
+	const [modelSource, modelIndexSource, providerSource, registrySource, mainSource, panelSource, rulesSource, changelogSource, packageSource, settingsSource, migrationsSource, skillModelsSource, skillWorkflowsSource, skillGotchasSource] = await Promise.all([
+		readFile('src/models/minimax-h3.ts', 'utf8'),
+		readFile('src/models/index.ts', 'utf8'),
+		readFile('src/providers/apimart.ts', 'utf8'),
+		readFile('src/providers/registry.ts', 'utf8'),
+		readFile('src/main.ts', 'utf8'),
+		readFile('src/panel.ts', 'utf8'),
+		readFile('docs/model-provider-rules.md', 'utf8'),
+		readFile('CHANGELOG.md', 'utf8'),
+		readFile('package.json', 'utf8'),
+		readFile('src/settings.ts', 'utf8'),
+		readFile('src/settings-migrations.ts', 'utf8'),
+		readFile(join(skillDir, 'references/models.md'), 'utf8'),
+		readFile(join(skillDir, 'references/workflows.md'), 'utf8'),
+		readFile(join(skillDir, 'references/gotchas.md'), 'utf8'),
+	])
+	assert.match(modelSource, /id: 'minimax-h3'[\s\S]*apimart: \{ apiModelId: 'MiniMax-H3' \}/)
+	assert.match(modelSource, /modes: \['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref'\]/)
+	assert.match(modelIndexSource, /import \{ minimaxH3 \} from '\.\/minimax-h3'/)
+	assert.match(providerSource, /modelId === MINIMAX_H3_MODEL_ID[\s\S]*generateMinimaxH3/)
+	assert.match(providerSource, /ensureRelayUrl\(ref, 'audio'\)/)
+	assert.match(registrySource, /id: 'apimart'[\s\S]*defaultRefDelivery: \{ image: 'relay', video: 'relay', audio: 'relay' \}/)
+	assert.match(mainSource, /supportsApimartMinimaxH3Refs/)
+	assert.match(panelSource, /audioCount > 0 && imageCount > 0 && modes\.includes\('image-ref'\)/)
+	assert.match(rulesSource, /## APIMart MiniMax-H3[\s\S]*MiniMax-H3/)
+	assert.match(changelogSource, /## Unreleased[\s\S]*MiniMax-H3/)
+	assert.match(packageSource, /"test:apimart-minimax-h3": "node scripts\/verify-apimart-minimax-h3\.mjs"/)
+	assert.match(settingsSource, /modelPrefs: \{\}[\s\S]*providerModelPrefs: \{\}/)
+	assert.doesNotMatch(
+		migrationsSource,
+		/connectProviderToModel\(settings, 'apimart', 'minimax-h3'\)/,
+		'New MiniMax-H3 support must not auto-connect or enable the model for existing users.',
+	)
+	assert.match(skillModelsSource, /MiniMax-H3[\s\S]*`minimax-h3`[\s\S]*APIMart/)
+	assert.match(skillWorkflowsSource, /MiniMax-H3 multimodal reference/)
+	assert.match(skillGotchasSource, /MiniMax-H3 frame and reference inputs are mutually exclusive/)
+
+	console.log('APIMart MiniMax-H3 payload, provider, relay, polling, catalog, and documentation checks passed.')
+} finally {
+	delete process.__bragiApimartH3RequestHandler
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/scripts/verify-bfl-denoise.mjs
+++ b/scripts/verify-bfl-denoise.mjs
@@ -47,7 +47,7 @@ assert.match(
 )
 assert.match(
 	panelSource,
-	/modes\.length <= 1 \|\| selectedModel\.inferModeFromInputs[\s\S]*inferMode\(modes, upstreamImageCount, upstreamVideoCount\)/,
+	/modes\.length <= 1 \|\| selectedModel\.inferModeFromInputs[\s\S]*inferMode\(modes, upstreamImageCount, upstreamVideoCount, upstreamAudioCount\)/,
 	'The generation bar must hide inferred mode selectors while preserving upstream mode inference.',
 )
 assert.match(

--- a/scripts/verify-byteplus-asset-error-reason.mjs
+++ b/scripts/verify-byteplus-asset-error-reason.mjs
@@ -37,9 +37,11 @@ const providerStub = {
 }
 
 try {
+	const bytePlusAssetsPath = path.resolve('src/providers/byteplus-assets.ts')
+	const svNewApiAssetFlowPath = path.resolve('src/svnewapi-asset-flow.ts')
 	await writeFile(entry, `
-		import { waitForActive as waitForBytePlusActive } from '${path.resolve('src/providers/byteplus-assets.ts').replaceAll('\\', '\\\\')}'
-		import { ensureSvNewApiAsset } from '${path.resolve('src/svnewapi-asset-flow.ts').replaceAll('\\', '\\\\')}'
+		import { waitForActive as waitForBytePlusActive } from ${JSON.stringify(bytePlusAssetsPath)}
+		import { ensureSvNewApiAsset } from ${JSON.stringify(svNewApiAssetFlowPath)}
 
 		export async function runBytePlusWait() {
 			globalThis.__bragiRequestUrl = async () => ({

--- a/scripts/verify-tokenrouter-modelark-assets.mjs
+++ b/scripts/verify-tokenrouter-modelark-assets.mjs
@@ -156,7 +156,7 @@ assert.match(
 
 assert.match(
 	mainSource,
-	/provider\.generateVideo\(finalPrompt, \{ \.\.\.params, modelId: apiModelId, genMode: mode, refImages, refAudios, refVideos \}\)/,
+	/provider\.generateVideo\(finalPrompt, \{ \.\.\.params, modelId: apiModelId, genMode: mode, refImages, refAudios, refVideos, refPdfs \}\)/,
 	'video generation must pass only the current explicit reference arrays',
 )
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -772,6 +772,7 @@ export default class BragiCanvas extends Plugin {
 			const isDashScopeWan3 = activeProvider === 'dashscope' && model.id === 'wan-3.0'
 			const isDashScopeWan = activeProvider === 'dashscope' && (model.id === 'wan-2.7' || isDashScopeWan3)
 			const supportsApimartVideoRef = activeProvider === 'apimart' && model.id === 'omni-flash-ext'
+			const supportsApimartMinimaxH3Refs = activeProvider === 'apimart' && model.id === 'minimax-h3'
 			const supportsKlingOmniVideoRef = model.id === 'kling-3.0-omni' && (activeProvider === 'kling' || activeProvider === 'apimart')
 			const isNativeSeedance = (activeProvider === 'bytedance' || activeProvider === 'byteplus') && isSeedanceModel
 			const hasSeedanceMediaRefs = uniqueImages.length > 0 || uniqueAudios.length > 0 || uniqueVideos.length > 0
@@ -839,7 +840,7 @@ export default class BragiCanvas extends Plugin {
 			}
 
 			// Upload reference audios for providers/models that need public media URLs.
-			if ((supportsSeedanceUrlRefs || isMuleRouterWan || isDashScopeWan) && uniqueAudios.length > 0) {
+			if ((supportsSeedanceUrlRefs || isMuleRouterWan || isDashScopeWan || supportsApimartMinimaxH3Refs) && uniqueAudios.length > 0) {
 				const audioRefs = isMuleRouterWan ? uniqueAudios.slice(0, 1) : uniqueAudios
 				for (const audioPath of audioRefs) {
 					if (bytePlusCreds) {
@@ -859,7 +860,7 @@ export default class BragiCanvas extends Plugin {
 			// BytePlus uses asset:// when native asset credentials are configured; otherwise
 			// the declarative delivery path falls back to a temporary HTTPS relay URL.
 			if (model.type === 'video' && uniqueVideos.length > 0) {
-				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !supportsKlingOmniVideoRef && !isDashScopeWan) {
+				if (mode === 'video-ref' && !supportsSeedanceUrlRefs && !supportsApimartVideoRef && !supportsApimartMinimaxH3Refs && !supportsKlingOmniVideoRef && !isDashScopeWan) {
 					throw new Error('Reference video is not available for the active model and provider.')
 				}
 				if (supportsApimartVideoRef && uniqueVideos.length > 1) {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -13,6 +13,7 @@ import { grokImagine, grokVideo } from './grok'
 import { midjourneyV8, midjourneyNiji7 } from './midjourney'
 import { lumaUni1 } from './luma'
 import { omniFlashExt } from './omni-flash'
+import { minimaxH3 } from './minimax-h3'
 import {
 	elevenLabsTTS,
 	minimaxTTS,
@@ -57,6 +58,7 @@ export const ALL_MODELS: ModelConfig[] = [
 	veo31,
 	veo31Lite,
 	grokVideo,
+	minimaxH3,
 	omniFlashExt,
 	// Text
 	claudeOpus47,

--- a/src/models/minimax-h3.ts
+++ b/src/models/minimax-h3.ts
@@ -1,0 +1,59 @@
+import type { ModelConfig } from './types'
+
+export const minimaxH3: ModelConfig = {
+	id: 'minimax-h3',
+	name: 'MiniMax-H3',
+	type: 'video',
+	supportedProviders: {
+		apimart: { apiModelId: 'MiniMax-H3' },
+	},
+	modes: ['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref'],
+	params: [
+		{
+			id: 'duration',
+			label: 'Duration',
+			type: 'range',
+			default: 5,
+			min: 4,
+			max: 15,
+			step: 1,
+			unit: 's',
+		},
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '2K', value: '2K' },
+				{ label: '768P', value: '768P' },
+			],
+			default: '2K',
+		},
+		{
+			id: 'aspect_ratio',
+			label: 'Ratio',
+			type: 'select',
+			modes: ['text-to-video', 'image-ref', 'video-ref'],
+			options: [
+				{ label: 'Adaptive', value: 'adaptive' },
+				{ label: '21:9', value: '21:9' },
+				{ label: '16:9', value: '16:9' },
+				{ label: '4:3', value: '4:3' },
+				{ label: '1:1', value: '1:1' },
+				{ label: '3:4', value: '3:4' },
+				{ label: '9:16', value: '9:16' },
+			],
+			default: 'adaptive',
+		},
+		{
+			id: 'watermark',
+			label: 'Watermark',
+			type: 'select',
+			options: [
+				{ label: 'Off', value: 'false' },
+				{ label: 'On', value: 'true' },
+			],
+			default: 'false',
+		},
+	],
+}

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -238,7 +238,11 @@ function supportsVoiceSource(model: ModelConfig, source: VoiceMode): boolean {
  * Infer the best default mode based on upstream inputs and model's supported modes.
  * Falls through priorities — if the model doesn't support a mode, skip it.
  */
-function inferMode(modes: Mode[], imageCount: number, videoCount: number): Mode {
+function inferMode(modes: Mode[], imageCount: number, videoCount: number, audioCount = 0): Mode {
+	// Audio refs are multimodal references, never first/last-frame controls.
+	if (audioCount > 0 && videoCount > 0 && modes.includes('video-ref')) return 'video-ref'
+	if (audioCount > 0 && imageCount > 0 && modes.includes('image-ref')) return 'image-ref'
+
 	// Image + video upstream → Kling Motion Control (character image + motion clip)
 	if (imageCount > 0 && videoCount > 0 && modes.includes('motion-control')) return 'motion-control'
 
@@ -547,13 +551,13 @@ export function showGenerateBar(
 		if (!selectedModel || modes.length <= 1 || selectedModel.inferModeFromInputs) {
 			modeSelect.classList.add('bragi-hidden')
 			selectedMode = selectedModel?.inferModeFromInputs
-				? inferMode(modes, upstreamImageCount, upstreamVideoCount)
+				? inferMode(modes, upstreamImageCount, upstreamVideoCount, upstreamAudioCount)
 				: modes[0] || null
 			return
 		}
 
 		modeSelect.classList.remove('bragi-hidden')
-		const inferred = inferMode(modes, upstreamImageCount, upstreamVideoCount)
+		const inferred = inferMode(modes, upstreamImageCount, upstreamVideoCount, upstreamAudioCount)
 
 		for (const mode of modes) {
 			const opt = createEl('option')

--- a/src/providers/apimart-minimax-h3-payload.ts
+++ b/src/providers/apimart-minimax-h3-payload.ts
@@ -1,0 +1,140 @@
+export const MINIMAX_H3_MODEL_ID = 'MiniMax-H3'
+
+const MINIMAX_H3_MODES = new Set([
+	'text-to-video',
+	'first-frame',
+	'first-last-frame',
+	'image-ref',
+	'video-ref',
+])
+const MINIMAX_H3_RESOLUTIONS = new Set(['2K', '768P'])
+const MINIMAX_H3_RATIOS = new Set(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16'])
+
+export interface ApimartMinimaxH3Request {
+	model: typeof MINIMAX_H3_MODEL_ID
+	prompt: string
+	duration: number
+	resolution: '2K' | '768P'
+	watermark: boolean
+	aspect_ratio?: string
+	first_frame_image?: string
+	last_frame_image?: string
+	image_urls?: string[]
+	video_urls?: string[]
+	audio_urls?: string[]
+}
+
+function stringParam(value: unknown, fallback: string): string {
+	if (typeof value === 'string' && value.trim()) return value.trim()
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+	return fallback
+}
+
+function stringList(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+		: []
+}
+
+function booleanParam(value: unknown, fallback: boolean): boolean {
+	if (value === undefined || value === null || value === '') return fallback
+	if (value === true || value === 'true') return true
+	if (value === false || value === 'false') return false
+	throw new Error('APIMart MiniMax-H3 watermark must be true or false.')
+}
+
+function assertNoReferences(genMode: string, refImages: string[], refVideos: string[], refAudios: string[]): void {
+	if (refImages.length + refVideos.length + refAudios.length > 0) {
+		throw new Error(`APIMart MiniMax-H3 ${genMode} mode does not accept reference media.`)
+	}
+}
+
+export function buildApimartMinimaxH3Request(
+	prompt: string,
+	params: Record<string, unknown> = {},
+): ApimartMinimaxH3Request {
+	if (!prompt.trim()) throw new Error('APIMart MiniMax-H3 prompt is required.')
+	if (prompt.length > 7000) throw new Error('APIMart MiniMax-H3 prompt must be at most 7000 characters.')
+
+	const genMode = stringParam(params.genMode, 'text-to-video')
+	if (!MINIMAX_H3_MODES.has(genMode)) {
+		throw new Error(`APIMart MiniMax-H3 does not support ${genMode} mode.`)
+	}
+
+	const duration = Number(params.duration ?? params.durationSeconds ?? 5)
+	if (!Number.isInteger(duration) || duration < 4 || duration > 15) {
+		throw new Error('APIMart MiniMax-H3 duration must be a whole number from 4 to 15 seconds.')
+	}
+
+	const resolution = stringParam(params.resolution, '2K').toUpperCase()
+	if (!MINIMAX_H3_RESOLUTIONS.has(resolution)) {
+		throw new Error('APIMart MiniMax-H3 resolution must be 2K or 768P.')
+	}
+
+	const ratio = stringParam(params.aspect_ratio ?? params.aspectRatio ?? params.ratio, 'adaptive').toLowerCase()
+	if (!MINIMAX_H3_RATIOS.has(ratio)) {
+		throw new Error(`APIMart MiniMax-H3 does not support aspect ratio ${ratio}.`)
+	}
+
+	const refImages = stringList(params.refImages)
+	const refVideos = stringList(params.refVideos)
+	const refAudios = stringList(params.refAudios)
+	if (refImages.length > 9) throw new Error('APIMart MiniMax-H3 supports at most 9 reference images.')
+	if (refVideos.length > 3) throw new Error('APIMart MiniMax-H3 supports at most 3 reference videos.')
+	if (refAudios.length > 3) throw new Error('APIMart MiniMax-H3 supports at most 3 reference audio clips.')
+	if (refAudios.length > 0 && refImages.length + refVideos.length === 0) {
+		throw new Error('APIMart MiniMax-H3 reference audio must be paired with a reference image or video.')
+	}
+
+	const body: ApimartMinimaxH3Request = {
+		model: MINIMAX_H3_MODEL_ID,
+		prompt,
+		duration,
+		resolution: resolution as '2K' | '768P',
+		watermark: booleanParam(params.watermark ?? params.aigc_watermark, false),
+	}
+
+	if (genMode === 'text-to-video') {
+		assertNoReferences(genMode, refImages, refVideos, refAudios)
+		body.aspect_ratio = ratio === 'adaptive' ? '16:9' : ratio
+		return body
+	}
+
+	if (genMode === 'first-frame') {
+		if (refImages.length !== 1) {
+			throw new Error('APIMart MiniMax-H3 first-frame mode requires exactly one reference image.')
+		}
+		if (refVideos.length > 0 || refAudios.length > 0) {
+			throw new Error('APIMart MiniMax-H3 first-frame mode cannot be combined with reference video or audio.')
+		}
+		body.first_frame_image = refImages[0]
+		return body
+	}
+
+	if (genMode === 'first-last-frame') {
+		if (refImages.length !== 2) {
+			throw new Error('APIMart MiniMax-H3 first-last-frame mode requires exactly two reference images.')
+		}
+		if (refVideos.length > 0 || refAudios.length > 0) {
+			throw new Error('APIMart MiniMax-H3 first-last-frame mode cannot be combined with reference video or audio.')
+		}
+		body.first_frame_image = refImages[0]
+		body.last_frame_image = refImages[1]
+		return body
+	}
+
+	if (genMode === 'image-ref' && refImages.length === 0) {
+		throw new Error('APIMart MiniMax-H3 image-ref mode requires at least one reference image.')
+	}
+	if (genMode === 'image-ref' && refVideos.length > 0) {
+		throw new Error('APIMart MiniMax-H3 image-ref mode does not accept reference videos; use video-ref mode.')
+	}
+	if (genMode === 'video-ref' && refVideos.length === 0) {
+		throw new Error('APIMart MiniMax-H3 video-ref mode requires at least one reference video.')
+	}
+	body.aspect_ratio = ratio
+	if (refImages.length > 0) body.image_urls = refImages
+	if (refVideos.length > 0) body.video_urls = refVideos
+	if (refAudios.length > 0) body.audio_urls = refAudios
+	return body
+}

--- a/src/providers/apimart.ts
+++ b/src/providers/apimart.ts
@@ -6,6 +6,7 @@ import { stringParam } from './params'
 import { BUILTIN_BRAGI_RELAY } from './bragi-relay'
 import { uploadRef } from './upload'
 import { buildApimartKlingOmniRequest, KLING_OMNI_MODEL_ID } from './kling-omni-payload'
+import { buildApimartMinimaxH3Request, MINIMAX_H3_MODEL_ID } from './apimart-minimax-h3-payload'
 
 /**
  * APIMart provider.
@@ -15,8 +16,8 @@ import { buildApimartKlingOmniRequest, KLING_OMNI_MODEL_ID } from './kling-omni-
  *   2. GET  /v1/tasks/{task_id}    → polls; on "completed" returns result.images[0].url[0]
  *   3. Download that URL and write to the vault.
  *
- * Omni-Flash-Ext video generation uses the same task endpoint, with
- * videos returned at result.videos[0].url[0].
+ * Video models use the same task endpoint. Omni-Flash-Ext and MiniMax-H3
+ * results are returned at result.videos[0].url (string or string array).
  */
 const DEFAULT_MODEL = 'gpt-image-2'
 const DEFAULT_VIDEO_MODEL = 'Omni-Flash-Ext'
@@ -27,7 +28,7 @@ const FIRST_POLL_DELAY_MS = 10000
 const MAX_WAIT_MS = 300000
 const VIDEO_DURATIONS = new Set([4, 6, 8, 10])
 const BRAGI_RELAY_BASE = BUILTIN_BRAGI_RELAY.endpoint.replace(/\/+$/, '')
-type RelayAssetKind = 'image' | 'video'
+type RelayAssetKind = 'image' | 'video' | 'audio'
 
 async function sleep(ms: number): Promise<void> {
 	return new Promise(r => window.setTimeout(r, ms))
@@ -83,14 +84,16 @@ function extensionFromMime(mimeType: string, kind: RelayAssetKind): string {
 	if (mime.includes('quicktime')) return 'mov'
 	if (mime.includes('webm')) return 'webm'
 	if (mime.includes('mp4')) return 'mp4'
-	return kind === 'image' ? 'jpg' : 'mp4'
+	if (mime.includes('wav')) return 'wav'
+	if (mime.includes('mpeg') || mime.includes('mp3')) return 'mp3'
+	return kind === 'image' ? 'jpg' : kind === 'video' ? 'mp4' : 'mp3'
 }
 
 function extensionFromUrl(url: string, kind: RelayAssetKind): string {
 	const clean = url.split(/[?#]/)[0].toLowerCase()
 	const match = clean.match(/\.([a-z0-9]+)$/)
 	if (match?.[1]) return match[1]
-	return kind === 'image' ? 'jpg' : 'mp4'
+	return kind === 'image' ? 'jpg' : kind === 'video' ? 'mp4' : 'mp3'
 }
 
 function headerValue(headers: Record<string, string>, name: string): string {
@@ -106,8 +109,8 @@ function isGenericContentType(contentType: string): boolean {
 
 function fallbackMime(kind: RelayAssetKind, ext: string): string {
 	if (kind === 'image') return ext === 'jpg' ? 'image/jpeg' : `image/${ext}`
-	if (ext === 'mov') return 'video/quicktime'
-	return `video/${ext}`
+	if (kind === 'video') return ext === 'mov' ? 'video/quicktime' : `video/${ext}`
+	return ext === 'mp3' ? 'audio/mpeg' : `audio/${ext}`
 }
 
 export class APIMartProvider implements ImageProvider, VideoProvider {
@@ -181,6 +184,9 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 		const modelId = stringParam(params?.modelId, DEFAULT_VIDEO_MODEL)
 
 		const genMode = stringParam(params?.genMode, '')
+		if (modelId === MINIMAX_H3_MODEL_ID) {
+			return this.generateMinimaxH3(prompt, params)
+		}
 		if (genMode === 'motion-control' || modelId.includes('motion-control')) {
 			return this.generateMotionControl(prompt, modelId, params)
 		}
@@ -240,6 +246,35 @@ export class APIMartProvider implements ImageProvider, VideoProvider {
 		const taskId = first?.task_id || first?.id
 		if (!taskId) {
 			throw new Error(`APIMart: no task_id in video submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
+		}
+		return { done: false, taskId }
+	}
+
+	private async generateMinimaxH3(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
+		const refImages = await Promise.all(arrayParam(params?.refImages).map(ref => this.ensureRelayUrl(ref, 'image')))
+		const refVideos = await Promise.all(arrayParam(params?.refVideos).map(ref => this.ensureRelayUrl(ref, 'video')))
+		const refAudios = await Promise.all(arrayParam(params?.refAudios).map(ref => this.ensureRelayUrl(ref, 'audio')))
+		const body = buildApimartMinimaxH3Request(prompt, { ...(params || {}), refImages, refVideos, refAudios })
+
+		const resp = await requestUrl({
+			url: `${API_BASE}/videos/generations`,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${this.apiKey}`,
+			},
+			body: JSON.stringify(body),
+			throw: false,
+		})
+
+		if (resp.status === 401 || resp.status === 403) throw new Error('APIMart: invalid API key')
+		if (resp.status >= 400) throw new Error(`APIMart MiniMax-H3: ${parseApimartError(resp)}`)
+
+		const submitData = resp.json
+		const first = submitData?.data?.[0]
+		const taskId = first?.task_id || first?.id
+		if (!taskId) {
+			throw new Error(`APIMart MiniMax-H3: no task_id in submit response — ${JSON.stringify(submitData).substring(0, 200)}`)
 		}
 		return { done: false, taskId }
 	}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -546,7 +546,7 @@ export const PROVIDERS: ProviderSpec[] = [
 		name: 'APIMart',
 		docUrl: 'https://docs.apimart.ai/en/api-reference/videos/kling-v3-omni/generation',
 		fields: [{ key: 'apimart', label: 'API Key', placeholder: 'sk-...', type: 'password' }],
-		defaultRefDelivery: { image: 'relay', video: 'relay' },
+		defaultRefDelivery: { image: 'relay', video: 'relay', audio: 'relay' },
 		isConfigured: (s) => !!s.providers.apimart,
 		makeImage: ({ settings, app, outputDir }) =>
 			new APIMartProvider(settings.providers.apimart, app, outputDir),


### PR DESCRIPTION
## Summary

- add MiniMax-H3 video generation through the existing APIMart provider
- support text-to-video, first-frame, first/last-frame, image/video/audio references, and Relay uploads
- validate 4–15 second duration, 2K/768P resolution, supported aspect ratios, and watermark options
- update the model catalog, provider wiring, and paired skill documentation

## Validation

- all 23 regression scripts passed
- 49-model catalog check passed
- 229 model/provider/mode audit combinations passed
- production build passed
- Obsidian lint passed
- paired sync check passed: 27 MCP tools
- real APIMart smoke test passed: 4s 768P generation completed in 117s and returned valid video/mp4

## Paired skill PR

- https://github.com/nextbound/bragi-canvas-skill/pull/63