### PR TITLE
feat: upgrade xAI Grok Imagine models

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -83,7 +83,7 @@ All "this provider differs from the base model" facts live in the model's `suppo
 - `editableApiModelId?: boolean` — opt-in pencil editor, only for providers that accept arbitrary upstream ids (e.g. BytePlus C-Dance). Ignored when `aggregated`.
 - `aggregated?: boolean` — the provider routes the model's modes to multiple upstream ids internally (DashScope Wan 2.7; DashScope voice). Routing stays hard-coded in the provider; the catalog only marks it. Locks the id editor. Must not also set `editableApiModelId`.
 - `modes?: Mode[]` — restrict a provider to a subset of the model's modes. The mode dropdown and MCP schema show only the active provider's effective modes; unsupported modes are hidden, never shown as disabled/"not supported". Provider resolution is strict-to-active (no mode-based fallback).
-- Param `providerOverrides[providerId]` — narrow a param's `options`/`default`/`min`/`max`/`step`/`unit` for one provider, or set `hidden: true` to drop it entirely for that provider.
+- Param `providerOverrides[providerId]` — narrow a param's `options`/`optionsByMode`/`default`/`min`/`max`/`step`/`unit` for one provider, or set `hidden: true` to drop it entirely for that provider.
 - Extension cost: new instances of existing param types and existing modalities are pure catalog data. A brand-new param `type`, a brand-new `Mode` value, or a 5th `GenerationType` is a one-time, bounded code change (panel render + MCP schema, or the `Mode`/`GenerationType` union + `make*` + panel wiring); after that, instances of that kind are declarative again.
 
 ### Catalog checks

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -17,7 +17,7 @@ Everything that makes a provider differ from the base model lives in its `suppor
 - `editableApiModelId?: boolean` — opt-in. Set `true` to expose the pencil editor for providers that accept arbitrary upstream model ids (e.g. BytePlus C-Dance). Ignored when `aggregated` is set.
 - `aggregated?: boolean` — the provider routes the model's modes to multiple upstream ids internally (e.g. DashScope Wan 2.7 -> t2v/i2v/r2v/videoedit; DashScope voice -> tts/enrollment models). Routing stays hard-coded in the provider; the catalog only marks it. Aggregated locks the id editor and shows a static label. Must not also set `editableApiModelId`.
 - `modes?: Mode[]` — restrict this provider to a subset of the model's `modes`. The mode dropdown and MCP schema only show the active provider's effective modes; unsupported modes are hidden (never shown as disabled / "not supported"). Provider resolution is strict-to-active — there is no mode-based provider fallback.
-- Param `providerOverrides[providerId]` — narrow a param's `options`/`default`/`min`/`max`/`step`/`unit` for one provider, or set `hidden: true` to drop the param entirely for that provider (e.g. MuleRouter Wan 2.7 omits `ratio` and uses lowercase resolutions).
+- Param `providerOverrides[providerId]` — narrow a param's `options`/`optionsByMode`/`default`/`min`/`max`/`step`/`unit` for one provider, or set `hidden: true` to drop it entirely for that provider (e.g. MuleRouter Wan 2.7 omits `ratio`; xAI Grok Video 1.5 extends reference-to-video duration to 15 seconds while the legacy fal route remains capped at 10).
 
 Example: Wan 2.7 (`src/models/wan.ts`) is one model with DashScope (aggregated, all modes) and MuleRouter (`modes: ['first-frame']`, lowercase resolution override, hidden `ratio`).
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:mureka-music": "node scripts/verify-mureka-music.mjs",
     "test:dashscope-wan3": "node scripts/verify-dashscope-wan3.mjs",
     "test:seedance-2-5": "node scripts/verify-seedance-2-5.mjs",
-    "test:byteplus-seedance-endpoint": "node scripts/verify-byteplus-seedance-endpoint.mjs"
+    "test:byteplus-seedance-endpoint": "node scripts/verify-byteplus-seedance-endpoint.mjs",
+    "test:xai-grok": "node scripts/verify-xai-grok.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/verify-xai-grok.mjs
+++ b/scripts/verify-xai-grok.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-xai-grok-'))
+
+try {
+	const providerBundle = join(tempDir, 'provider.mjs')
+	const catalogBundle = join(tempDir, 'catalog.mjs')
+	await build({
+		entryPoints: ['src/providers/xai.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: providerBundle,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export async function requestUrl(options) {
+							return process.__bragiXaiRequestHandler(options)
+						}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+	await build({
+		entryPoints: ['src/models/grok.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: catalogBundle,
+		logLevel: 'silent',
+	})
+
+	const { XAIImageProvider, XAIVideoProvider } = await import(`${pathToFileURL(providerBundle).href}?t=${Date.now()}`)
+	const { grokImagine, grokVideo } = await import(`${pathToFileURL(catalogBundle).href}?t=${Date.now()}`)
+	const requests = []
+	const writes = []
+	const app = {
+		vault: {
+			adapter: {
+				exists: async () => true,
+				mkdir: async () => {},
+				writeBinary: async (path, data) => writes.push({ path, data }),
+			},
+		},
+	}
+
+	assert.equal(grokImagine.id, 'grok-imagine')
+	assert.equal(grokImagine.name, 'Grok Imagine')
+	assert.equal(grokImagine.supportedProviders.xai.apiModelId, 'grok-imagine-image-2.0')
+	assert.equal(grokImagine.supportedProviders.fal.apiModelId, 'xai/grok-imagine-image')
+	const imageAspect = grokImagine.params.find(param => param.id === 'aspectRatio')
+	const imageResolution = grokImagine.params.find(param => param.id === 'resolution')
+	const imageQuality = grokImagine.params.find(param => param.id === 'quality')
+	assert.equal(imageAspect.options.length, 14)
+	assert.equal(imageAspect.default, 'auto')
+	assert.equal(imageAspect.providerOverrides.fal.options.length, 9)
+	assert.equal(imageResolution.providerOverrides.fal.hidden, true)
+	assert.equal(imageQuality.providerOverrides.fal.hidden, true)
+
+	assert.equal(grokVideo.id, 'grok-video')
+	assert.equal(grokVideo.name, 'Grok Video')
+	assert.equal(grokVideo.supportedProviders.xai.apiModelId, 'grok-imagine-video-1.5')
+	assert.equal(grokVideo.supportedProviders.xai.aggregated, true)
+	assert.deepEqual(grokVideo.modes, ['text-to-video', 'first-frame', 'image-ref', 'video-edit', 'video-extend'])
+	assert.deepEqual(grokVideo.supportedProviders.fal.modes, ['text-to-video', 'first-frame', 'image-ref', 'video-extend'])
+	assert.deepEqual(grokVideo.supportedProviders.svnewapi.modes, ['text-to-video', 'first-frame', 'image-ref', 'video-extend'])
+	const durationParam = grokVideo.params.find(param => param.id === 'duration')
+	assert.equal(durationParam.optionsByMode['image-ref'].length, 10)
+	assert.equal(durationParam.providerOverrides.xai.optionsByMode['image-ref'].length, 15)
+	assert.equal(durationParam.optionsByMode['video-extend'].length, 9)
+	const resolutionParam = grokVideo.params.find(param => param.id === 'resolution')
+	assert.equal(resolutionParam.optionsByMode['image-ref'].length, 2)
+
+	let imageCounter = 0
+	process.__bragiXaiRequestHandler = async request => {
+		requests.push(request)
+		if (request.url.startsWith('https://api.x.ai/v1/images/')) {
+			imageCounter++
+			return { status: 200, json: { data: [{ url: `https://cdn.example/image-${imageCounter}.jpg` }] } }
+		}
+		if (request.url.startsWith('https://cdn.example/image-')) {
+			return { status: 200, arrayBuffer: new Uint8Array([255, 216, 255, 217]).buffer }
+		}
+		throw new Error(`Unexpected image request: ${request.url}`)
+	}
+
+	const imageProvider = new XAIImageProvider('test-key', app, 'assets')
+	await imageProvider.generateImage('A glass observatory above the clouds', {
+		modelId: 'grok-imagine-image-2.0',
+		aspectRatio: 'auto',
+		resolution: '2k',
+		quality: 'low',
+	})
+	let request = requests.find(item => item.url.endsWith('/images/generations'))
+	assert.equal(request.headers.Authorization, 'Bearer test-key')
+	assert.deepEqual(JSON.parse(request.body), {
+		model: 'grok-imagine-image-2.0',
+		prompt: 'A glass observatory above the clouds',
+		n: 1,
+		resolution: '2k',
+		quality: 'low',
+		response_format: 'url',
+	})
+
+	await imageProvider.generateImage('Add a copper frame', {
+		modelId: 'grok-imagine-image-2.0',
+		aspectRatio: '16:9',
+		resolution: '1k',
+		quality: 'medium',
+		refImages: ['https://refs.example/source.jpg'],
+	})
+	request = requests.filter(item => item.url.endsWith('/images/edits')).at(-1)
+	assert.deepEqual(JSON.parse(request.body).image, { url: 'https://refs.example/source.jpg' })
+	assert.equal(JSON.parse(request.body).images, undefined)
+
+	await imageProvider.generateImage('Combine the subjects', {
+		refImages: ['https://refs.example/1.jpg', 'https://refs.example/2.jpg', 'https://refs.example/3.jpg'],
+	})
+	request = requests.filter(item => item.url.endsWith('/images/edits')).at(-1)
+	assert.deepEqual(JSON.parse(request.body).images, [
+		{ url: 'https://refs.example/1.jpg' },
+		{ url: 'https://refs.example/2.jpg' },
+		{ url: 'https://refs.example/3.jpg' },
+	])
+	assert.equal(JSON.parse(request.body).image, undefined)
+	await assert.rejects(
+		() => imageProvider.generateImage('Too many', { refImages: ['1', '2', '3', '4'] }),
+		/at most 3 reference images/,
+	)
+	await assert.rejects(() => imageProvider.generateImage('Bad quality', { quality: 'high' }), /low or medium/)
+
+	let taskCounter = 0
+	process.__bragiXaiRequestHandler = async requestOptions => {
+		requests.push(requestOptions)
+		if (/\/videos\/(generations|edits|extensions)$/.test(requestOptions.url)) {
+			taskCounter++
+			return { status: 200, json: { request_id: `task-${taskCounter}` } }
+		}
+		throw new Error(`Unexpected video request: ${requestOptions.url}`)
+	}
+	const videoProvider = new XAIVideoProvider('test-key', app, 'assets')
+
+	assert.deepEqual(await videoProvider.generateVideo('Launch through the clouds', {
+		modelId: 'grok-imagine-video-1.5', genMode: 'text-to-video', duration: 15,
+		aspect_ratio: '9:16', resolution: '1080p',
+	}), { done: false, taskId: 'task-1' })
+	request = requests.filter(item => item.url.endsWith('/videos/generations')).at(-1)
+	assert.deepEqual(JSON.parse(request.body), {
+		model: 'grok-imagine-video-1.5', prompt: 'Launch through the clouds',
+		duration: 15, aspect_ratio: '9:16', resolution: '1080p',
+	})
+
+	await videoProvider.generateVideo('Animate the portrait', {
+		genMode: 'first-frame', duration: 1, aspect_ratio: '1:1', resolution: '1080p',
+		refImages: ['https://refs.example/frame.jpg'],
+	})
+	request = requests.filter(item => item.url.endsWith('/videos/generations')).at(-1)
+	assert.deepEqual(JSON.parse(request.body).image, { url: 'https://refs.example/frame.jpg' })
+
+	const sevenRefs = Array.from({ length: 7 }, (_, index) => `https://refs.example/ref-${index}.jpg`)
+	await videoProvider.generateVideo('Keep every subject consistent', {
+		genMode: 'image-ref', duration: 15, aspect_ratio: '16:9', resolution: '720p', refImages: sevenRefs,
+	})
+	request = requests.filter(item => item.url.endsWith('/videos/generations')).at(-1)
+	assert.equal(JSON.parse(request.body).reference_images.length, 7)
+
+	await videoProvider.generateVideo('Change the coat to red', {
+		genMode: 'video-edit', duration: 99, aspect_ratio: 'bad', resolution: 'bad',
+		refVideos: ['https://refs.example/base.mp4'],
+	})
+	request = requests.filter(item => item.url.endsWith('/videos/edits')).at(-1)
+	assert.deepEqual(JSON.parse(request.body), {
+		model: 'grok-imagine-video', prompt: 'Change the coat to red',
+		video: { url: 'https://refs.example/base.mp4' },
+	})
+
+	await videoProvider.generateVideo('Continue into a wide shot', {
+		genMode: 'video-extend', duration: 2, refVideos: ['https://refs.example/base.mp4'],
+	})
+	request = requests.filter(item => item.url.endsWith('/videos/extensions')).at(-1)
+	assert.deepEqual(JSON.parse(request.body), {
+		model: 'grok-imagine-video', prompt: 'Continue into a wide shot',
+		video: { url: 'https://refs.example/base.mp4' }, duration: 2,
+	})
+
+	await assert.rejects(() => videoProvider.generateVideo('Bad mode', { genMode: 'video-ref' }), /unsupported Grok Video mode/)
+	await assert.rejects(() => videoProvider.generateVideo('Missing frame', { genMode: 'first-frame' }), /exactly one reference image/)
+	await assert.rejects(() => videoProvider.generateVideo('Too many frames', { genMode: 'first-frame', refImages: ['1', '2'] }), /exactly one reference image/)
+	await assert.rejects(() => videoProvider.generateVideo('Too many refs', { genMode: 'image-ref', refImages: [...sevenRefs, '8'] }), /at most 7/)
+	await assert.rejects(() => videoProvider.generateVideo('Too large', { genMode: 'image-ref', refImages: ['1'], resolution: '1080p' }), /up to 720p/)
+	await assert.rejects(() => videoProvider.generateVideo('Missing video', { genMode: 'video-edit' }), /exactly one upstream video/)
+	await assert.rejects(() => videoProvider.generateVideo('Short extension', { genMode: 'video-extend', duration: 1, refVideos: ['v'] }), /2 to 10/)
+	await assert.rejects(() => videoProvider.generateVideo('Text with ref', { genMode: 'text-to-video', refImages: ['1'] }), /does not accept reference images/)
+
+	process.__bragiXaiRequestHandler = async requestOptions => {
+		requests.push(requestOptions)
+		if (requestOptions.url.endsWith('/videos/pending-http')) return { status: 202, json: {} }
+		if (requestOptions.url.endsWith('/videos/pending-body')) return { status: 200, json: { status: 'pending' } }
+		if (requestOptions.url.endsWith('/videos/failed')) {
+			return { status: 200, json: { status: 'failed', error: { code: 'invalid_argument', message: 'unsafe input' } } }
+		}
+		if (requestOptions.url.endsWith('/videos/expired')) return { status: 200, json: { status: 'expired' } }
+		if (requestOptions.url.endsWith('/videos/done')) {
+			return { status: 200, json: { status: 'done', video: { url: 'https://cdn.example/result.mp4' } } }
+		}
+		if (requestOptions.url === 'https://cdn.example/result.mp4') {
+			return { status: 200, arrayBuffer: new Uint8Array([0, 0, 0, 24]).buffer }
+		}
+		throw new Error(`Unexpected polling request: ${requestOptions.url}`)
+	}
+	assert.deepEqual(await videoProvider.checkStatus('pending-http'), { done: false, taskId: 'pending-http' })
+	assert.deepEqual(await videoProvider.checkStatus('pending-body'), { done: false, taskId: 'pending-body' })
+	await assert.rejects(() => videoProvider.checkStatus('failed'), /invalid_argument.*unsafe input/)
+	await assert.rejects(() => videoProvider.checkStatus('expired'), /video expired.*no reason provided/)
+	const done = await videoProvider.checkStatus('done')
+	assert.equal(done.done, true)
+	assert.match(done.filePath, /^assets\/grok_video_\d+\.mp4$/)
+	assert.ok(writes.length >= 4)
+
+	console.log('xAI Grok Imagine Image 2.0 and Video 1.5 checks passed.')
+} finally {
+	delete process.__bragiXaiRequestHandler
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/models/grok.ts
+++ b/src/models/grok.ts
@@ -1,6 +1,6 @@
 import type { ModelConfig } from './types'
 
-const GROK_IMAGE_RATIOS = [
+const LEGACY_GROK_IMAGE_RATIOS = [
 	{ label: '1:1', value: '1:1' },
 	{ label: '16:9', value: '16:9' },
 	{ label: '9:16', value: '9:16' },
@@ -12,13 +12,28 @@ const GROK_IMAGE_RATIOS = [
 	{ label: '1:2', value: '1:2' },
 ]
 
+const XAI_GROK_IMAGE_2_RATIOS = [
+	{ label: 'Auto', value: 'auto' },
+	...LEGACY_GROK_IMAGE_RATIOS,
+	{ label: '19.5:9', value: '19.5:9' },
+	{ label: '9:19.5', value: '9:19.5' },
+	{ label: '20:9', value: '20:9' },
+	{ label: '9:20', value: '9:20' },
+]
+
+function secondOptions(min: number, max: number) {
+	return Array.from({ length: max - min + 1 }, (_, index) => {
+		const seconds = min + index
+		return { label: `${seconds}s`, value: String(seconds) }
+	})
+}
+
 export const grokImagine: ModelConfig = {
 	id: 'grok-imagine',
 	name: 'Grok Imagine',
 	type: 'image',
 	supportedProviders: {
-		// Default apiModelId is the quality tier; XAIImageProvider overrides based on the `quality` param.
-		xai: { apiModelId: 'grok-imagine-image-quality' },
+		xai: { apiModelId: 'grok-imagine-image-2.0' },
 		fal: { apiModelId: 'xai/grok-imagine-image' },
 	},
 	modes: ['text-to-image', 'image-ref-to-image'],
@@ -27,18 +42,37 @@ export const grokImagine: ModelConfig = {
 			id: 'aspectRatio',
 			label: 'Aspect Ratio',
 			type: 'select',
-			options: GROK_IMAGE_RATIOS,
-			default: '1:1',
+			options: XAI_GROK_IMAGE_2_RATIOS,
+			default: 'auto',
+			providerOverrides: {
+				fal: { options: LEGACY_GROK_IMAGE_RATIOS, default: '1:1' },
+			},
+		},
+		{
+			id: 'resolution',
+			label: 'Resolution',
+			type: 'select',
+			options: [
+				{ label: '1K', value: '1k' },
+				{ label: '2K', value: '2k' },
+			],
+			default: '1k',
+			providerOverrides: {
+				fal: { hidden: true },
+			},
 		},
 		{
 			id: 'quality',
 			label: 'Quality',
 			type: 'select',
 			options: [
-				{ label: 'Quality', value: 'quality' },
-				{ label: 'Normal', value: 'normal' },
+				{ label: 'Low', value: 'low' },
+				{ label: 'Medium', value: 'medium' },
 			],
-			default: 'quality',
+			default: 'medium',
+			providerOverrides: {
+				fal: { hidden: true },
+			},
 		},
 	],
 }
@@ -48,36 +82,39 @@ export const grokVideo: ModelConfig = {
 	name: 'Grok Video',
 	type: 'video',
 	supportedProviders: {
-		xai: { apiModelId: 'grok-imagine-video' },
-		fal: { apiModelId: 'xai/grok-imagine-video' },
+		xai: { apiModelId: 'grok-imagine-video-1.5', aggregated: true },
+		fal: { apiModelId: 'xai/grok-imagine-video', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'] },
 		// Gateway maps sv-grok-video to the fal grok base id and picks the sub-endpoint
 		// by input shape: 1 image -> image-to-video, 2+ -> reference-to-video, video -> extend.
 		svnewapi: { apiModelId: 'sv-grok-video', modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'] },
 	},
-	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'],
+	modes: ['text-to-video', 'first-frame', 'image-ref', 'video-edit', 'video-extend'],
 	params: [
 		{
 			id: 'duration',
 			label: 'Duration',
 			type: 'select',
-			options: [
-				{ label: '5s', value: '5' },
-				{ label: '10s', value: '10' },
-				{ label: '15s', value: '15' },
-			],
-			// xAI caps image-ref at 10s; other modes allow 15s.
+			modes: ['text-to-video', 'first-frame', 'image-ref', 'video-extend'],
+			options: secondOptions(1, 15),
 			optionsByMode: {
-				'image-ref': [
-					{ label: '5s', value: '5' },
-					{ label: '10s', value: '10' },
-				],
+				'image-ref': secondOptions(1, 10),
+				'video-extend': secondOptions(2, 10),
 			},
 			default: '5',
+			providerOverrides: {
+				xai: {
+					optionsByMode: {
+						'image-ref': secondOptions(1, 15),
+						'video-extend': secondOptions(2, 10),
+					},
+				},
+			},
 		},
 		{
 			id: 'aspect_ratio',
 			label: 'Ratio',
 			type: 'select',
+			modes: ['text-to-video', 'first-frame', 'image-ref'],
 			options: [
 				{ label: '16:9', value: '16:9' },
 				{ label: '9:16', value: '9:16' },
@@ -93,11 +130,18 @@ export const grokVideo: ModelConfig = {
 			id: 'resolution',
 			label: 'Resolution',
 			type: 'select',
+			modes: ['text-to-video', 'first-frame', 'image-ref'],
 			options: [
 				{ label: '480p', value: '480p' },
 				{ label: '720p', value: '720p' },
 				{ label: '1080p', value: '1080p' },
 			],
+			optionsByMode: {
+				'image-ref': [
+					{ label: '480p', value: '480p' },
+					{ label: '720p', value: '720p' },
+				],
+			},
 			default: '720p',
 		},
 	],

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -36,6 +36,11 @@ export interface ParamOption {
 
 export interface ModelParamProviderOverride {
 	options?: ParamOption[]
+	/**
+	 * Provider-specific mode option sets. Replaces the base `optionsByMode` map
+	 * for this provider after the provider override is applied.
+	 */
+	optionsByMode?: Record<string, ParamOption[]>
 	default?: string | number
 	min?: number
 	max?: number

--- a/src/providers/xai.ts
+++ b/src/providers/xai.ts
@@ -30,6 +30,28 @@ function stringValue(value: unknown): string {
 	return ''
 }
 
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string' && item.length > 0)
+		: []
+}
+
+function integerValue(value: unknown, fallback: number): number {
+	if (value === undefined || value === null || value === '') return fallback
+	const parsed = typeof value === 'number' ? value : Number.parseInt(stringValue(value), 10)
+	return parsed
+}
+
+const XAI_IMAGE_MODEL = 'grok-imagine-image-2.0'
+const XAI_VIDEO_MODEL = 'grok-imagine-video-1.5'
+const XAI_LEGACY_VIDEO_MODEL = 'grok-imagine-video'
+const XAI_IMAGE_RATIOS = new Set([
+	'auto', '1:1', '16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '2:1', '1:2',
+	'19.5:9', '9:19.5', '20:9', '9:20',
+])
+const XAI_VIDEO_RATIOS = new Set(['16:9', '9:16', '1:1', '4:3', '3:4', '3:2', '2:3'])
+const XAI_VIDEO_RESOLUTIONS = new Set(['480p', '720p', '1080p'])
+
 function normalizeXaiVoice(record: Record<string, unknown>, source: VoiceOption['source']): VoiceOption | null {
 	const id = stringValue(record.voice_id || record.id)
 	if (!id) return null
@@ -50,10 +72,9 @@ function normalizeXaiVoice(record: Record<string, unknown>, source: VoiceOption[
  *
  * Endpoints:
  *   POST /v1/images/generations   — text-to-image, sync, returns hosted jpeg URL
- *   POST /v1/images/edits          — image-ref editing (up to 5 refs)
+ *   POST /v1/images/edits          — image-ref editing (up to 3 refs)
  *
- * Models: grok-imagine-image ($0.02), grok-imagine-image-quality ($0.04, recommended),
- * grok-imagine-image-pro ($0.07, deprecated but still live).
+ * Model: grok-imagine-image-2.0.
  */
 export class XAIImageProvider implements ImageProvider {
 	name = 'xAI'
@@ -68,30 +89,38 @@ export class XAIImageProvider implements ImageProvider {
 	}
 
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
-		// `quality` param (quality|normal) overrides the default apiModelId so we can expose one
-		// "Grok Imagine" card in the UI but still hit the right tier on xAI.
-		const tier = params?.quality === 'normal' ? 'grok-imagine-image' : 'grok-imagine-image-quality'
-		const modelId = tier
-		const aspectRatio = params?.aspectRatio || '1:1'
-		const refImages: string[] = params?.refImages || []
+		const modelId = stringValue(params?.modelId) || XAI_IMAGE_MODEL
+		const aspectRatio = stringValue(params?.aspectRatio) || 'auto'
+		const resolution = stringValue(params?.resolution) || '1k'
+		const quality = stringValue(params?.quality) || 'medium'
+		const refImages = stringArray(params?.refImages)
+
+		if (!XAI_IMAGE_RATIOS.has(aspectRatio)) throw new Error(`xAI: unsupported image aspect ratio ${aspectRatio}`)
+		if (resolution !== '1k' && resolution !== '2k') throw new Error('xAI: image resolution must be 1k or 2k')
+		if (quality !== 'low' && quality !== 'medium') throw new Error('xAI: image quality must be low or medium')
+		if (refImages.length > 3) throw new Error('xAI: Grok Imagine 2.0 supports at most 3 reference images')
 
 		const isEdit = refImages.length > 0
 		const url = isEdit ? `${XAI_BASE}/images/edits` : `${XAI_BASE}/images/generations`
 
-		const body: unknown = {
+		const body: Record<string, unknown> = {
 			model: modelId,
 			prompt,
 			n: 1,
-			aspect_ratio: aspectRatio,
+			resolution,
+			quality,
 			response_format: 'url',
 		}
+		// Omitting auto preserves the first input image's ratio for editing and lets
+		// the model choose a ratio for text-to-image.
+		if (aspectRatio !== 'auto') body.aspect_ratio = aspectRatio
 
 		if (isEdit) {
 			// xAI accepts EITHER `image` (single) OR `images` (array) — sending both → 400.
 			if (refImages.length === 1) {
 				body.image = toImageUrlStruct(refImages[0])
 			} else {
-				body.images = refImages.slice(0, 5).map(toImageUrlStruct)
+				body.images = refImages.map(toImageUrlStruct)
 			}
 		}
 
@@ -125,10 +154,11 @@ export class XAIImageProvider implements ImageProvider {
 }
 
 /**
- * xAI Grok Imagine video — one model, three modes routed via field selection:
+ * xAI Grok Imagine Video 1.5 — one model, five modes routed via field selection:
  *   text-to-video:       /v1/videos/generations  { prompt }
  *   first-frame (image): /v1/videos/generations  { prompt, image:{url} }
  *   image-ref:           /v1/videos/generations  { prompt, reference_images:[{url},…] }
+ *   video-edit:          /v1/videos/edits        { prompt, video:{url} }
  *   video-extend:        /v1/videos/extensions   { prompt, video:{url}, duration:2–10 }
  *
  * All async: POST returns {request_id}; poll GET /v1/videos/{id} (202 pending / 200 done).
@@ -146,46 +176,62 @@ export class XAIVideoProvider implements VideoProvider {
 	}
 
 	async generateVideo(prompt: string, params?: Record<string, unknown>): Promise<GenerateVideoResult> {
-		const modelId = params?.modelId || 'grok-imagine-video'
-		const aspectRatio = params?.aspect_ratio || params?.aspectRatio || '16:9'
-		let duration = parseInt(params?.duration || params?.durationSeconds || '5')
-		const resolution = params?.resolution || '720p'
-		const refImages: string[] = params?.refImages || []
-		const refVideos: string[] = params?.refVideos || []
-		const genMode = params?.genMode || 'text-to-video'
+		const modelId = stringValue(params?.modelId) || XAI_VIDEO_MODEL
+		const aspectRatio = stringValue(params?.aspect_ratio || params?.aspectRatio) || '16:9'
+		const duration = integerValue(params?.duration ?? params?.durationSeconds, 5)
+		const resolution = stringValue(params?.resolution) || '720p'
+		const refImages = stringArray(params?.refImages)
+		const refVideos = stringArray(params?.refVideos)
+		const genMode = stringValue(params?.genMode) || 'text-to-video'
+		const allowedModes = new Set(['text-to-video', 'first-frame', 'image-ref', 'video-edit', 'video-extend'])
 
-		// Per-mode duration caps (verified against live API, 2026-05-07):
-		//   text-to-video / first-frame / video-extend: 1–15s
-		//   reference-to-video:                         1–10s
-		if (genMode === 'image-ref' && duration > 10) duration = 10
+		if (!allowedModes.has(genMode)) throw new Error(`xAI: unsupported Grok Video mode ${genMode}`)
 
-		const body: unknown = {
-			model: modelId,
-			prompt,
-			aspect_ratio: aspectRatio,
-			duration,
-			resolution,
-		}
-
+		// Video 1.5 supports generation, first-frame, and reference-to-video. The
+		// official edit/extension endpoints still reject 1.5 and require the legacy
+		// Grok video model, so the xAI catalogue entry is intentionally aggregated.
+		const requestModelId = genMode === 'video-edit' || genMode === 'video-extend'
+			? XAI_LEGACY_VIDEO_MODEL
+			: modelId
+		const body: Record<string, unknown> = { model: requestModelId, prompt }
 		let endpoint = `${XAI_BASE}/videos/generations`
 
-		if (genMode === 'video-extend') {
-			if (refVideos.length === 0) {
-				throw new Error('xAI video-extend requires an upstream video URL.')
+		if (genMode === 'video-edit' || genMode === 'video-extend') {
+			if (refVideos.length !== 1) throw new Error(`xAI ${genMode} requires exactly one upstream video.`)
+			if (refImages.length > 0) throw new Error(`xAI ${genMode} does not accept reference images.`)
+			if (genMode === 'video-edit') {
+				endpoint = `${XAI_BASE}/videos/edits`
+			} else {
+				if (!Number.isInteger(duration) || duration < 2 || duration > 10) {
+					throw new Error('xAI video-extend duration must be a whole number from 2 to 10 seconds')
+				}
+				endpoint = `${XAI_BASE}/videos/extensions`
+				body.duration = duration
 			}
-			endpoint = `${XAI_BASE}/videos/extensions`
-			body.video = { url: refVideos[0] }
-			// aspect_ratio/resolution are ignored on extend; the server follows the source video.
-		} else if (genMode === 'first-frame') {
-			if (refImages.length === 0) throw new Error('xAI first-frame requires one reference image.')
-			// Data: URIs must be uploaded first — xAI rejects data:-uri for image field in practice
-			// (server sometimes accepts it inline, sometimes rejects as too large). Upload to Bragi
-			// Relay to be safe + keep request bodies small.
-			body.image = { url: await this.ensureUrl(refImages[0]) }
-		} else if (genMode === 'image-ref') {
-			if (refImages.length === 0) throw new Error('xAI image-ref requires at least one reference image.')
-			const urls = await Promise.all(refImages.slice(0, 3).map(r => this.ensureUrl(r)))
-			body.reference_images = urls.map(u => ({ url: u }))
+			body.video = { url: await this.ensureUrl(refVideos[0]) }
+		} else {
+			if (!Number.isInteger(duration) || duration < 1 || duration > 15) {
+				throw new Error('xAI: video duration must be a whole number from 1 to 15 seconds')
+			}
+			if (!XAI_VIDEO_RATIOS.has(aspectRatio)) throw new Error(`xAI: unsupported video aspect ratio ${aspectRatio}`)
+			if (!XAI_VIDEO_RESOLUTIONS.has(resolution)) throw new Error(`xAI: unsupported video resolution ${resolution}`)
+			if (refVideos.length > 0) throw new Error(`xAI ${genMode} does not accept reference videos.`)
+			body.duration = duration
+			body.aspect_ratio = aspectRatio
+			body.resolution = resolution
+
+			if (genMode === 'text-to-video') {
+				if (refImages.length > 0) throw new Error('xAI text-to-video does not accept reference images.')
+			} else if (genMode === 'first-frame') {
+				if (refImages.length !== 1) throw new Error('xAI first-frame requires exactly one reference image.')
+				body.image = { url: await this.ensureUrl(refImages[0]) }
+			} else {
+				if (refImages.length === 0) throw new Error('xAI image-ref requires at least one reference image.')
+				if (refImages.length > 7) throw new Error('xAI image-ref supports at most 7 reference images.')
+				if (resolution === '1080p') throw new Error('xAI image-ref supports up to 720p resolution.')
+				const urls = await Promise.all(refImages.map(ref => this.ensureUrl(ref)))
+				body.reference_images = urls.map(url => ({ url }))
+			}
 		}
 
 		const resp = await requestUrl({
@@ -223,7 +269,9 @@ export class XAIVideoProvider implements VideoProvider {
 		const status = body?.status
 		if (status === 'pending') return { done: false, taskId }
 		if (status === 'failed' || status === 'expired') {
-			throw new Error(`xAI: video ${status} — ${body?.error?.message || 'no reason provided'}`)
+			const code = stringValue(body?.error?.code)
+			const message = stringValue(body?.error?.message) || 'no reason provided'
+			throw new Error(`xAI: video ${status}${code ? ` [${code}]` : ''} — ${message}`)
 		}
 		if (status === 'done') {
 			const videoUrl = body?.video?.url
@@ -239,14 +287,17 @@ export class XAIVideoProvider implements VideoProvider {
 		return { done: false, taskId }
 	}
 
-	/** Accept data: URI or http(s) URL; upload data URIs to Bragi temporary storage for a short public URL. */
+	/** Accept a data URI or http(s) URL; upload data URIs to Bragi temporary storage. */
 	private async ensureUrl(ref: string): Promise<string> {
 		if (/^https?:/.test(ref)) return ref
 		const match = ref.match(/^data:([^;]+);base64,(.+)$/)
-		if (!match) throw new Error('xAI: unsupported reference image format')
+		if (!match) throw new Error('xAI: unsupported reference media format')
 		const mime = match[1]
 		const bytes = Uint8Array.from(atob(match[2]), c => c.charCodeAt(0))
-		const ext = mime.includes('png') ? 'png' : mime.includes('webp') ? 'webp' : 'jpg'
+		const ext = mime.includes('png') ? 'png'
+			: mime.includes('webp') ? 'webp'
+				: mime.includes('video') ? 'mp4'
+					: 'jpg'
 		return uploadRef(undefined, bytes.buffer, `ref.${ext}`, mime)
 	}
 }


### PR DESCRIPTION
## Summary

- upgrade the native xAI image route to grok-imagine-image-2.0
- expose xAI Image 2.0 aspect ratio, 1K/2K resolution, and Low/Medium quality controls
- upgrade Grok video generation to grok-imagine-video-1.5 while preserving stable Bragi model IDs
- keep fal.ai and SVRouter on their existing Grok routes and provider-scoped capabilities
- add deterministic provider and catalogue verification

## xAI video routing

Live API verification showed that grok-imagine-video-1.5 supports text-to-video, first-frame, and reference-to-video, but xAI rejects edit and extension for that model. The xAI catalogue entry is therefore aggregated: generation uses 1.5, while video-edit and video-extend use the official legacy grok-imagine-video route.

## Validation

- npm run test:xai-grok
- npm run check:catalog
- npm run audit:catalog
- npm run build
- npm run lint:obsidian
- API worker typecheck
- paired worktree sync check
- live xAI smoke tests for Image 2.0 generation/edit and all five exposed video modes

Paired skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/65