### PR TITLE
fix: preserve SVRouter gateway error details

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:elevenlabs-voice-changer": "node scripts/verify-elevenlabs-voice-changer.mjs",
     "test:audio-asset-id": "node scripts/verify-audio-asset-id.mjs",
     "test:byteplus-asset-error-reason": "node scripts/verify-byteplus-asset-error-reason.mjs",
+    "test:svnewapi-error-response": "node scripts/verify-svnewapi-error-response.mjs",
     "test:svnewapi-image-refs": "node scripts/verify-svnewapi-image-refs.mjs",
     "test:svnewapi-video-params": "node scripts/verify-svnewapi-video-params.mjs",
     "test:tokenrouter-modelark-assets": "node scripts/verify-tokenrouter-modelark-assets.mjs",

--- a/scripts/verify-byteplus-asset-error-reason.mjs
+++ b/scripts/verify-byteplus-asset-error-reason.mjs
@@ -94,6 +94,27 @@ try {
 			await ensureSvNewApiAsset(plugin, canvas, 'refs/face.png', 'seedance', { baseUrl: 'https://gateway.test', apiKey: 'key' })
 			if (call !== 2) throw new Error('expected create + status calls')
 		}
+
+		export async function runSvNewApiPlainTextAssetError() {
+			globalThis.__bragiRequestUrl = async () => {
+				const response = { status: 502, text: 'error code: 502\\n' }
+				Object.defineProperty(response, 'json', {
+					get() { throw new SyntaxError("Unexpected token 'e'") },
+				})
+				return response
+			}
+			const plugin = {
+				app: {
+					vault: {
+						adapter: {
+							readBinary: async () => new ArrayBuffer(1),
+						},
+					},
+				},
+			}
+			const canvas = { nodes: new Map() }
+			await ensureSvNewApiAsset(plugin, canvas, 'refs/face.png', 'seedance', { baseUrl: 'https://gateway.test', apiKey: 'key' })
+		}
 	`)
 
 	await esbuild.build({
@@ -118,6 +139,12 @@ try {
 		mod.runSvNewApiAssetFlow(),
 		/gateway saw BytePlus moderation failure/,
 		'SV NewAPI asset status failures should include nested Result.Error.Message when present',
+	)
+
+	await assert.rejects(
+		mod.runSvNewApiPlainTextAssetError(),
+		/SV NewAPI asset register failed: error code: 502/,
+		'SV NewAPI asset registration should preserve plain-text gateway errors',
 	)
 
 	console.log('BytePlus asset error reason checks passed.')

--- a/scripts/verify-svnewapi-error-response.mjs
+++ b/scripts/verify-svnewapi-error-response.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import esbuild from 'esbuild'
+
+const tempDir = await mkdtemp(path.join(tmpdir(), 'bragi-svnewapi-error-'))
+const entry = path.join(tempDir, 'entry.ts')
+const outfile = path.join(tempDir, 'svnewapi-error.mjs')
+
+const obsidianStub = {
+	name: 'obsidian-stub',
+	setup(build) {
+		build.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'obsidian-stub' }))
+		build.onLoad({ filter: /.*/, namespace: 'obsidian-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const requestUrl = (...args) => globalThis.__bragiRequestUrl(...args);',
+		}))
+	},
+}
+
+const providerStub = {
+	name: 'provider-stub',
+	setup(build) {
+		build.onResolve({ filter: /^\.\/upload$/ }, () => ({ path: 'upload', namespace: 'provider-stub' }))
+		build.onResolve({ filter: /^\.\/openai-image-size$/ }, () => ({ path: 'openai-image-size', namespace: 'provider-stub' }))
+		build.onResolve({ filter: /^\.\/seedream$/ }, () => ({ path: 'seedream', namespace: 'provider-stub' }))
+		build.onLoad({ filter: /^upload$/, namespace: 'provider-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const uploadRef = async () => "https://refs.test/ref.png";',
+		}))
+		build.onLoad({ filter: /^openai-image-size$/, namespace: 'provider-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const resolveOpenAIImageSize = () => "1024x1024";',
+		}))
+		build.onLoad({ filter: /^seedream$/, namespace: 'provider-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const resolveSeedreamImageSize = () => "2048x2048";',
+		}))
+	},
+}
+
+const jsonError = 'BytePlus CreateAsset: InvalidParameter.FpsTooLow - Frame rate is too low'
+
+try {
+	const providerPath = path.resolve('src/providers/svnewapi.ts')
+	await writeFile(entry, `
+		import { SvNewApiVideoProvider } from ${JSON.stringify(providerPath)}
+
+		const provider = () => new SvNewApiVideoProvider('key', {}, 'out', 'https://gateway.test')
+
+		export async function runJsonError() {
+			globalThis.__bragiRequestUrl = async () => ({
+				status: 502,
+				json: { error: ${JSON.stringify(jsonError)} },
+				text: JSON.stringify({ error: ${JSON.stringify(jsonError)} }),
+			})
+			await provider().generateVideo('prompt', { modelId: 'sv-seedance-2.0' })
+		}
+
+		export async function runPlainTextError() {
+			globalThis.__bragiRequestUrl = async () => {
+				const response = { status: 502, text: 'error code: 502\\n' }
+				Object.defineProperty(response, 'json', {
+					get() { throw new SyntaxError("Unexpected token 'e'") },
+				})
+				return response
+			}
+			await provider().generateVideo('prompt', { modelId: 'sv-seedance-2.0' })
+		}
+	`)
+
+	await esbuild.build({
+		entryPoints: [entry],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile,
+		logLevel: 'silent',
+		plugins: [obsidianStub, providerStub],
+	})
+
+	const mod = await import(pathToFileURL(outfile).href)
+	const expectedJsonMessage = `SV NewAPI video: ${jsonError}`
+	await assert.rejects(
+		mod.runJsonError(),
+		error => error instanceof Error && error.message === expectedJsonMessage,
+		'JSON error strings from SVRouter should be shown without the JSON envelope',
+	)
+	await assert.rejects(
+		mod.runPlainTextError(),
+		error => error instanceof Error && error.message === 'SV NewAPI video: error code: 502',
+		'plain-text SVRouter errors should preserve the HTTP body',
+	)
+
+	console.log('SV NewAPI error response checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/providers/svnewapi.ts
+++ b/src/providers/svnewapi.ts
@@ -79,12 +79,25 @@ function isHttpUrl(value: string): boolean {
 	return /^https?:\/\//i.test(value)
 }
 
+function responseJson(resp: { text?: string; json?: unknown }): unknown {
+	try {
+		const json = resp.json
+		if (json !== undefined && json !== null) return json
+	} catch {
+		// Obsidian may throw here when a gateway returns a non-JSON error body.
+	}
+	try {
+		return resp.text ? JSON.parse(resp.text) : null
+	} catch {
+		return null
+	}
+}
+
 function parseProviderError(label: string, resp: { status: number; text?: string; json?: unknown }): string {
-	const body = asRecord(resp.json) || (() => {
-		try { return asRecord(JSON.parse(resp.text || '')) } catch { return null }
-	})()
+	const body = asRecord(responseJson(resp))
 	const error = asRecord(body?.error)
-	const msg = stringParam(error?.message || body?.message || resp.text, `HTTP ${resp.status}`)
+	const detail = error?.message || body?.error || body?.message || body?.detail || resp.text
+	const msg = stringParam(detail, `HTTP ${resp.status}`).trim() || `HTTP ${resp.status}`
 	const code = stringParam(error?.code || error?.type || body?.code, '')
 	return `${label}: ${code ? code + ' — ' : ''}${msg}`
 }

--- a/src/svnewapi-asset-flow.ts
+++ b/src/svnewapi-asset-flow.ts
@@ -118,6 +118,20 @@ interface GatewayResp {
 	text: string
 }
 
+function responseJson(resp: { text?: string; json?: unknown }): unknown {
+	try {
+		const json = resp.json
+		if (json !== undefined && json !== null) return json
+	} catch {
+		// Obsidian may throw here when the gateway returns a non-JSON error body.
+	}
+	try {
+		return resp.text ? JSON.parse(resp.text) : null
+	} catch {
+		return null
+	}
+}
+
 async function postJson(creds: SvNewApiAssetCreds, path: string, body: unknown): Promise<GatewayResp> {
 	const resp = await requestUrl({
 		url: `${creds.baseUrl}${path}`,
@@ -129,7 +143,7 @@ async function postJson(creds: SvNewApiAssetCreds, path: string, body: unknown):
 		body: JSON.stringify(body),
 		throw: false,
 	})
-	return { status: resp.status, json: resp.json, text: resp.text }
+	return { status: resp.status, json: responseJson(resp), text: resp.text }
 }
 
 async function createGatewayAsset(creds: SvNewApiAssetCreds, model: string, url: string, assetType: AssetType): Promise<{ id: string; status: string }> {


### PR DESCRIPTION
## Summary
- preserve SVRouter JSON error strings such as `BytePlus CreateAsset: InvalidParameter...`
- safely fall back to plain-text gateway responses instead of surfacing JSON parse errors
- apply the safe parsing to SVRouter asset registration/status responses
- add regression coverage for JSON and plain-text 502 responses

## Validation
- `npm run test:svnewapi-error-response`
- `npm run test:byteplus-asset-error-reason`
- `npm run test:svnewapi-image-refs`
- `npm run test:svnewapi-video-params`
- `npm run test:seedance-2-5`
- `npm run lint:obsidian`
- `npm run build`