### PR TITLE
Fix portrait video fullscreen cropping

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -510,6 +510,17 @@
 	object-fit: cover;
 }
 
+/* Native fullscreen should show the whole frame, especially for portrait video. */
+.canvas-node-content.media-embed.video-embed video:fullscreen,
+.canvas-node-content.media-embed.video-embed video:-webkit-full-screen {
+	width: 100vw;
+	height: 100vh;
+	max-width: 100vw;
+	max-height: 100vh;
+	object-fit: contain;
+	background-color: #000;
+}
+
 /* Audio embed nodes: Obsidian draws a border on WebKit's native player chrome */
 .canvas-node-content.media-embed audio {
 	border: none;

--- a/styles.css
+++ b/styles.css
@@ -510,6 +510,17 @@
 	object-fit: cover;
 }
 
+/* Native fullscreen should show the whole frame, especially for portrait video. */
+.canvas-node-content.media-embed.video-embed video:fullscreen,
+.canvas-node-content.media-embed.video-embed video:-webkit-full-screen {
+	width: 100vw;
+	height: 100vh;
+	max-width: 100vw;
+	max-height: 100vh;
+	object-fit: contain;
+	background-color: #000;
+}
+
 /* Audio embed nodes: Obsidian draws a border on WebKit's native player chrome */
 .canvas-node-content.media-embed audio {
 	border: none;


### PR DESCRIPTION
## Summary
- keep canvas video thumbnails using `object-fit: cover`
- switch native fullscreen playback to `object-fit: contain`
- constrain fullscreen video to the viewport and use a black background

## Verification
- `npm run build`
- `git diff --check`
- confirmed source and release CSS stay identical