### PR TITLE
fix: stabilize MCP image refs and add Seedance 2.5 1080p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed MCP reference-image generation races by waiting for newly imported Canvas edges before reading upstream inputs, including GPT Image 2 edit flows.
+- Added 1080p output for Seedance 2.5 in both the canvas generation bar and MCP model parameters.
+
 ## 1.36.1
 
 - Fixed portrait videos in native fullscreen playback so they are contained within the viewport instead of being cropped.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -65,7 +65,7 @@ When you add a model/provider, run the check; if it fails, fix the catalog rathe
 - Supported Bragi modes are text-to-video, first-frame, first-last-frame, image reference, video reference, video extension, and video edit. First-frame inputs use `role: first_frame`; the second image in first-last-frame uses `role: last_frame`; multimodal references use `reference_image`, `reference_video`, and `reference_audio`.
 - Multimodal limits are 30 images, 10 videos, and 10 audio clips (50 references total). Audio-only reference input is supported through `video-ref` mode.
 - Duration defaults to Auto (`-1`) and accepts `-1` or 4–30 seconds. Video edit only accepts `-1`. Ratio defaults to `adaptive`; first-frame, first-last-frame, video-extend, and video-edit only accept `adaptive`. Text/reference generation also accepts `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, and `21:9`.
-- Output resolution is 480p or 720p. Output format is MP4 or MOV; preserve a `.mov` extension when the completed task returns a MOV URL.
+- Output resolution is 480p, 720p, or 1080p. Output format is MP4 or MOV; preserve a `.mov` extension when the completed task returns a MOV URL.
 - Volcengine sends local reference media through temporary HTTPS relay URLs and passes manually bound `bytedance` `asset://` IDs through unchanged. With BytePlus native asset credentials, reference media uses the existing `asset://` flow; without those credentials, Bragi falls back to relay URLs. Face-containing media may still require a provider-approved asset.
 
 ## Kling 3.0 Omni

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:legnext-image-result": "node scripts/verify-legnext-image-result.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",
+    "test:mcp-reference-generation": "node scripts/verify-mcp-reference-generation.mjs",
     "test:kling-omni": "node scripts/verify-kling-omni.mjs",
     "test:apimart-minimax-h3": "node scripts/verify-apimart-minimax-h3.mjs",
     "test:suchuang-gemini-omni": "node scripts/verify-suchuang-gemini-omni.mjs",

--- a/scripts/verify-mcp-reference-generation.mjs
+++ b/scripts/verify-mcp-reference-generation.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { build } from 'esbuild'
+
+const tempDir = await mkdtemp(join(tmpdir(), 'bragi-mcp-reference-'))
+const bundlePath = join(tempDir, 'mcp-tool-registry.mjs')
+
+function makeNode(data) {
+	return {
+		id: data.id,
+		text: data.type === 'text' ? data.text : undefined,
+		getData: () => data,
+	}
+}
+
+function makeCanvas(nodeData, initialEdges = []) {
+	const nodes = new Map(nodeData.map(data => [data.id, makeNode(data)]))
+	let serialized = { nodes: nodeData, edges: initialEdges }
+	let runtimeEdges = []
+	let frameCount = 0
+
+	const materializeEdges = () => serialized.edges.map(data => ({
+		id: data.id,
+		from: { node: nodes.get(data.fromNode), side: data.fromSide },
+		to: { node: nodes.get(data.toNode), side: data.toSide },
+		getData: () => data,
+	}))
+
+	return {
+		nodes,
+		edges: new Map(),
+		selection: new Set(),
+		getData: () => serialized,
+		getEdgesForNode: node => runtimeEdges.filter(edge => edge.from.node.id === node.id || edge.to.node.id === node.id),
+		importData: data => { serialized = data },
+		requestFrame: async () => {
+			frameCount++
+			runtimeEdges = materializeEdges()
+		},
+		requestSave: async () => {},
+		get frameCount() { return frameCount },
+	}
+}
+
+try {
+	await build({
+		entryPoints: ['src/mcp-tool-registry.ts'],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile: bundlePath,
+		logLevel: 'silent',
+		plugins: [{
+			name: 'mock-obsidian',
+			setup(buildApi) {
+				buildApi.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'mock-obsidian' }))
+				buildApi.onLoad({ filter: /.*/, namespace: 'mock-obsidian' }, () => ({
+					contents: `
+						export class Modal {}
+						export class Notice {}
+						export class Plugin {}
+						export class PluginSettingTab {}
+						export class Setting {}
+						export class TFile {}
+						export class TFolder {}
+						export function addIcon() {}
+						export function getLanguage() { return 'en' }
+						export function normalizePath(path) { return path }
+						export async function requestUrl() { throw new Error('Unexpected requestUrl call') }
+						export function setIcon() {}
+						export function setTooltip() {}
+					`,
+					loader: 'js',
+				}))
+			},
+		}],
+	})
+
+	const { createMcpToolRegistry } = await import(`${pathToFileURL(bundlePath).href}?t=${Date.now()}`)
+	const image = { id: 'image-ref', type: 'file', file: 'refs/style.png', x: 0, y: 0, width: 400, height: 400 }
+	const prompt = { id: 'prompt', type: 'text', text: 'Keep the subject and change the lighting', x: 500, y: 0, width: 300, height: 200 }
+	const app = { vault: { getAbstractFileByPath: () => null } }
+
+	// connect_nodes must not return until getEdgesForNode() can see the new edge.
+	const connectedCanvas = makeCanvas([image, prompt])
+	const connectedTools = createMcpToolRegistry({ getCanvas: () => connectedCanvas, app })
+	const connect = connectedTools.find(tool => tool.name === 'connect_nodes')
+	const getUpstream = connectedTools.find(tool => tool.name === 'get_upstream')
+	assert.ok(connect && getUpstream)
+	await connect.handler({
+		fromId: image.id,
+		toId: prompt.id,
+		fromSide: 'right',
+		toSide: 'left',
+		toEnd: 'arrow',
+	})
+	assert.equal(connectedCanvas.frameCount, 1)
+	const upstreamResult = await getUpstream.handler({ id: prompt.id })
+	assert.deepEqual(JSON.parse(upstreamResult.content[0].text).images, ['refs/style.png'])
+
+	// generate must also provide its own frame barrier for callers that imported an
+	// edge immediately before invoking GPT Image 2 through MCP.
+	const pendingEdge = {
+		id: 'pending-ref-edge',
+		fromNode: image.id,
+		fromSide: 'right',
+		toNode: prompt.id,
+		toSide: 'left',
+		toEnd: 'arrow',
+	}
+	const generationCanvas = makeCanvas([image, prompt], [pendingEdge])
+	let capturedImages = []
+	const settings = {
+		providers: { openai: 'test-key' },
+		providerModelPrefs: { openai: { 'gpt-image-2': true } },
+		modelPrefs: { 'gpt-image-2': { enabled: true, selectedProvider: 'openai' } },
+		modelOrder: { image: [], video: [], text: [], audio: [] },
+		apiModelIdOverrides: {},
+	}
+	const generationTools = createMcpToolRegistry({
+		getCanvas: () => generationCanvas,
+		app,
+		getSettings: () => settings,
+		runGeneration: async node => {
+			const upstream = generationCanvas.getEdgesForNode(node)
+			capturedImages = upstream
+				.filter(edge => edge.to.node.id === node.id && edge.getData().toEnd === 'arrow')
+				.map(edge => edge.from.node.getData().file)
+			return { placeholderIds: ['placeholder'], expectedOutputType: 'image' }
+		},
+	})
+	const generate = generationTools.find(tool => tool.name === 'generate')
+	assert.ok(generate)
+	await generate.handler({ nodeId: prompt.id, modelId: 'gpt-image-2', batchCount: 1 })
+	assert.equal(generationCanvas.frameCount, 1)
+	assert.deepEqual(capturedImages, ['refs/style.png'])
+
+	console.log('MCP GPT Image 2 reference-generation checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/scripts/verify-seedance-2-5.mjs
+++ b/scripts/verify-seedance-2-5.mjs
@@ -60,6 +60,13 @@ try {
 	assert.equal(multimodal.generate_audio, false)
 	assert.equal(multimodal.output_format, 'mov')
 
+	const fullHd = buildSeedanceRequestBody('Render in full HD', {
+		modelId,
+		genMode: 'text-to-video',
+		resolution: '1080p',
+	})
+	assert.equal(fullHd.resolution, '1080p')
+
 	assert.throws(
 		() => buildSeedanceRequestBody('Too many images', {
 			modelId,
@@ -160,6 +167,7 @@ try {
 	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*bytedance: \{ apiModelId: 'doubao-seedance-2-5-260628' \}[\s\S]*apiModelId: 'dreamina-seedance-2-5-260628'/)
 	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*svnewapi: \{ apiModelId: 'sv-seedance-2\.5' \}/)
 	assert.match(modelSource, /modes: \['text-to-video', 'first-frame', 'first-last-frame', 'image-ref', 'video-ref', 'video-extend', 'video-edit'\]/)
+	assert.match(modelSource, /id: 'seedance-2\.5'[\s\S]*\{ label: '1080p', value: '1080p' \}/)
 	assert.match(mainSource, /getSeedanceReferenceLimits\(model\.id\)/)
 	assert.match(providerRules, /## Volcengine and BytePlus Seedance 2\.5[\s\S]*doubao-seedance-2-5-260628[\s\S]*dreamina-seedance-2-5-260628/)
 	assert.match(migrationsSource, /CURRENT_SETTINGS_SCHEMA_VERSION = 12/)

--- a/src/mcp-tool-registry.ts
+++ b/src/mcp-tool-registry.ts
@@ -336,7 +336,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 				toEnd: z.enum(['none', 'arrow']).optional().default('arrow').describe('Arrow at target end'),
 				label: z.string().optional().describe('Edge label'),
 			},
-			handler: ({ fromId, toId, fromSide, toSide, toEnd, label }) => {
+			handler: async ({ fromId, toId, fromSide, toSide, toEnd, label }) => {
 				const canvas = requireCanvas(getCanvas)
 				findNode(canvas, fromId)
 				findNode(canvas, toId)
@@ -351,8 +351,15 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 					toEnd,
 				}
 				if (label) edge.label = label
-				canvas.importData({ nodes: [], edges: [edge] })
-				void canvas.requestSave()
+				const full = canvas.getData()
+				canvas.importData({
+					...full,
+					edges: [...(full.edges || []), edge],
+				})
+				// MCP clients commonly connect a reference and call generate immediately.
+				// Wait for Canvas to materialize the runtime edge so getEdgesForNode() sees it.
+				await canvas.requestFrame()
+				await canvas.requestSave()
 				return ok({ edgeId })
 			},
 		},
@@ -540,6 +547,10 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 				if (!settings) throw new Error('Settings not available')
 
 				const canvas = requireCanvas(getCanvas)
+				// Flush any MCP-created nodes/edges before generation reads upstream refs.
+				// Without this barrier, a connect_nodes -> generate sequence can race the
+				// Canvas runtime and silently fall back to text-only image generation.
+				await canvas.requestFrame()
 				const node = findNode(canvas, nodeId)
 
 				const model = getModelById(modelId)
@@ -688,7 +699,7 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 					label: z.string().optional(),
 				})),
 			},
-			handler: ({ edges }) => {
+			handler: async ({ edges }) => {
 				const canvas = requireCanvas(getCanvas)
 				const full = canvas.getData()
 				const created: string[] = []
@@ -713,7 +724,8 @@ export function createMcpToolRegistry(ctx: McpToolContext): McpToolDef[] {
 					...full,
 					edges: [...(full.edges || []), ...newEdges],
 				})
-				void canvas.requestSave()
+				await canvas.requestFrame()
+				await canvas.requestSave()
 				return ok({ edgeIds: created })
 			},
 		},

--- a/src/models/seedance.ts
+++ b/src/models/seedance.ts
@@ -62,6 +62,7 @@ export const seedance25: ModelConfig = {
 			options: [
 				{ label: '480p', value: '480p' },
 				{ label: '720p', value: '720p' },
+				{ label: '1080p', value: '1080p' },
 			],
 			default: '720p',
 		},

--- a/src/providers/seedance.ts
+++ b/src/providers/seedance.ts
@@ -90,7 +90,7 @@ function assertSeedanceInputs(
 		if (genMode === 'video-edit' && duration !== -1) {
 			throw new Error('Seedance 2.5 video-edit mode requires Auto (-1) duration.')
 		}
-		if (!['480p', '720p'].includes(resolution)) throw new Error(`Seedance 2.5 does not support ${resolution} output.`)
+		if (!['480p', '720p', '1080p'].includes(resolution)) throw new Error(`Seedance 2.5 does not support ${resolution} output.`)
 		if (!['mp4', 'mov'].includes(outputFormat)) throw new Error(`Seedance 2.5 does not support ${outputFormat} output.`)
 	}
 }


### PR DESCRIPTION
## Summary

- wait for Obsidian Canvas runtime edges before MCP generation reads upstream references
- fix connect_nodes and connect_nodes_batch so immediate GPT Image 2 reference generation is reliable
- add Seedance 2.5 1080p to the UI, MCP model schema, provider validation, and docs
- add runtime MCP and Seedance 2.5 regression coverage

## Validation

- npm run build
- npm run lint:obsidian
- npm run check:catalog
- npm run audit:catalog
- npm run test:mcp-reference-generation
- npm run test:reference-image-upload
- npm run test:seedance-2-5
- npm run test:svnewapi-video-params
- git diff --check

Paired skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/68