### PR TITLE
Upgrade Legnext Midjourney to V8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Upgraded the stable `midjourney-v8` model to Midjourney V8.2 through Legnext, replacing the unsupported quality control with Standard/2K resolution and adding V8.2-compatible stylize, chaos, raw style, stop, and weird controls.
+- Added token-aware Midjourney prompt flag handling and V8.2 catalog/request regression coverage while preserving explicit prompt flags and the existing individual-image result selection.
+
 ## 1.36.2
 
 - Fixed MCP reference-image generation races by waiting for newly imported Canvas edges before reading upstream inputs, including GPT Image 2 edit flows.

--- a/docs/model-provider-rules.md
+++ b/docs/model-provider-rules.md
@@ -34,6 +34,13 @@ Example: Wan 2.7 (`src/models/wan.ts`) is one model with DashScope (aggregated, 
 
 When you add a model/provider, run the check; if it fails, fix the catalog rather than the script.
 
+## Legnext Midjourney V8.2
+
+- Bragi keeps the stable model ID `midjourney-v8` while displaying Midjourney V8.2 and injecting `--v 8.2` when the prompt does not already contain `--v` or `--version`.
+- Legnext accepts model and render controls inside the `/v1/diffusion` `text` field. V8.2 exposes aspect ratio, Standard/2K resolution (`--hd`), stylize, chaos, raw style, stop, and weird controls. It does not expose the rejected `--q` / `--quality` flag.
+- Explicit user-authored Midjourney flags win. Detect long and short aliases as complete tokens so `--s` does not collide with `--seed` and `--c` does not collide with `--cref`.
+- Completed image tasks prefer the first non-empty URL in `output.image_urls`; use `output.image_url` only as a backward-compatible grid fallback.
+
 ## APIMart Omni-Flash-Ext
 
 - Endpoint: `POST https://api.apimart.ai/v1/videos/generations`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:bfl-denoise": "node scripts/verify-bfl-denoise.mjs",
     "test:local-denoise": "node scripts/verify-local-denoise.mjs",
     "test:fal-flux-klein": "node scripts/verify-fal-flux-klein.mjs",
+    "test:legnext-v8-2": "node scripts/verify-legnext-v8-2.mjs",
     "test:legnext-image-result": "node scripts/verify-legnext-image-result.mjs",
     "test:mulerouter-carrothub": "node scripts/verify-mulerouter-carrothub-images.mjs",
     "test:reference-image-upload": "node scripts/verify-reference-image-upload.mjs",

--- a/scripts/verify-legnext-v8-2.mjs
+++ b/scripts/verify-legnext-v8-2.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import esbuild from 'esbuild'
+
+const tempDir = await mkdtemp(path.join(tmpdir(), 'bragi-legnext-v8-2-'))
+const entry = path.join(tempDir, 'entry.ts')
+const outfile = path.join(tempDir, 'legnext-v8-2.mjs')
+
+const obsidianStub = {
+	name: 'obsidian-stub',
+	setup(build) {
+		build.onResolve({ filter: /^obsidian$/ }, () => ({ path: 'obsidian', namespace: 'obsidian-stub' }))
+		build.onLoad({ filter: /.*/, namespace: 'obsidian-stub' }, () => ({
+			loader: 'js',
+			contents: 'export const requestUrl = () => { throw new Error("requestUrl should not be called"); };',
+		}))
+	},
+}
+
+try {
+	await writeFile(entry, `
+		export { buildLegnextPrompt } from ${JSON.stringify(path.resolve('src/providers/legnext.ts'))}
+		export { midjourneyV8, midjourneyNiji7 } from ${JSON.stringify(path.resolve('src/models/midjourney.ts'))}
+	`)
+
+	await esbuild.build({
+		entryPoints: [entry],
+		bundle: true,
+		platform: 'node',
+		format: 'esm',
+		outfile,
+		logLevel: 'silent',
+		plugins: [obsidianStub],
+	})
+
+	const { buildLegnextPrompt, midjourneyV8, midjourneyNiji7 } = await import(pathToFileURL(outfile).href)
+
+	assert.equal(midjourneyV8.id, 'midjourney-v8')
+	assert.equal(midjourneyV8.name, 'Midjourney V8.2')
+	assert.deepEqual(midjourneyV8.modes, ['text-to-image'])
+	assert.deepEqual(
+		midjourneyV8.params.map(param => param.id),
+		['ar', 'resolution', 'stylize', 'chaos', 'style', 'stop', 'weird'],
+	)
+	assert.equal(midjourneyV8.params.some(param => param.id === 'quality'), false)
+
+	assert.equal(
+		buildLegnextPrompt('Cinematic lighthouse', {
+			modelId: 'midjourney-v8',
+			ar: '1:1',
+			resolution: 'standard',
+			stylize: 100,
+			chaos: 0,
+			style: 'default',
+			stop: 100,
+			weird: 0,
+		}),
+		'Cinematic lighthouse --v 8.2 --ar 1:1',
+	)
+
+	assert.equal(
+		buildLegnextPrompt('Cinematic lighthouse', {
+			modelId: 'midjourney-v8',
+			ar: '16:9',
+			resolution: 'hd',
+			stylize: 250,
+			chaos: 20,
+			style: 'raw',
+			stop: 80,
+			weird: 500,
+		}),
+		'Cinematic lighthouse --v 8.2 --ar 16:9 --stylize 250 --hd --chaos 20 --style raw --stop 80 --weird 500',
+	)
+
+	const explicitFlags = 'Portrait --version 8.1 --aspect 16:9 --s 300 --hd --c 25 --raw --stop 70 --w 900'
+	assert.equal(
+		buildLegnextPrompt(explicitFlags, {
+			modelId: 'midjourney-v8',
+			ar: '1:1',
+			resolution: 'hd',
+			stylize: 200,
+			chaos: 10,
+			style: 'raw',
+			stop: 60,
+			weird: 400,
+		}),
+		explicitFlags,
+		'Explicit long and short aliases must win without duplicate flags.',
+	)
+
+	assert.equal(
+		buildLegnextPrompt('Portrait --seed 42 --cref https://example.test/ref.png', {
+			modelId: 'midjourney-v8',
+			stylize: 200,
+			chaos: 10,
+		}),
+		'Portrait --seed 42 --cref https://example.test/ref.png --v 8.2 --ar 1:1 --stylize 200 --chaos 10',
+		'Short aliases must not collide with longer flag names.',
+	)
+
+	const legacyQuality = buildLegnextPrompt('Legacy settings', {
+		modelId: 'midjourney-v8',
+		quality: '4',
+	})
+	assert.equal(legacyQuality, 'Legacy settings --v 8.2 --ar 1:1')
+	assert.doesNotMatch(legacyQuality, /(?:^|\s)--q(?:uality)?(?=\s|=|$)/i)
+
+	assert.equal(midjourneyNiji7.id, 'midjourney-niji-7')
+	assert.equal(
+		buildLegnextPrompt('Anime skyline', {
+			modelId: 'midjourney-niji-7',
+			ar: '9:16',
+			stylize: 200,
+			resolution: 'hd',
+			chaos: 20,
+		}),
+		'Anime skyline --niji 7 --ar 9:16 --stylize 200',
+		'Niji 7 behavior must remain unchanged by V8.2-only params.',
+	)
+
+	assert.throws(
+		() => buildLegnextPrompt('Bad resolution', { resolution: '4k' }),
+		/Resolution must be standard or hd/,
+	)
+	assert.throws(
+		() => buildLegnextPrompt('Bad style', { style: 'expressive' }),
+		/Style must be default or raw/,
+	)
+
+	console.log('Legnext Midjourney V8.2 checks passed.')
+} finally {
+	await rm(tempDir, { recursive: true, force: true })
+}

--- a/src/models/midjourney.ts
+++ b/src/models/midjourney.ts
@@ -2,7 +2,7 @@ import type { ModelConfig } from './types'
 
 export const midjourneyV8: ModelConfig = {
 	id: 'midjourney-v8',
-	name: 'Midjourney v8',
+	name: 'Midjourney V8.2',
 	type: 'image',
 	supportedProviders: {
 		legnext: { apiModelId: 'midjourney' },
@@ -28,14 +28,14 @@ export const midjourneyV8: ModelConfig = {
 			default: '1:1',
 		},
 		{
-			id: 'quality',
-			label: 'Quality',
+			id: 'resolution',
+			label: 'Resolution',
 			type: 'select',
 			options: [
-				{ label: 'Standard', value: '1' },
-				{ label: 'High (4x cost)', value: '4' },
+				{ label: 'Standard (1K)', value: 'standard' },
+				{ label: 'HD (2K, 1.5x cost)', value: 'hd' },
 			],
-			default: '1',
+			default: 'standard',
 		},
 		{
 			id: 'stylize',
@@ -45,6 +45,43 @@ export const midjourneyV8: ModelConfig = {
 			max: 1000,
 			step: 50,
 			default: 100,
+		},
+		{
+			id: 'chaos',
+			label: 'Chaos',
+			type: 'range',
+			min: 0,
+			max: 100,
+			step: 1,
+			default: 0,
+		},
+		{
+			id: 'style',
+			label: 'Style',
+			type: 'select',
+			options: [
+				{ label: 'Default', value: 'default' },
+				{ label: 'Raw', value: 'raw' },
+			],
+			default: 'default',
+		},
+		{
+			id: 'stop',
+			label: 'Stop',
+			type: 'range',
+			min: 10,
+			max: 100,
+			step: 10,
+			default: 100,
+		},
+		{
+			id: 'weird',
+			label: 'Weird',
+			type: 'range',
+			min: 0,
+			max: 3000,
+			step: 50,
+			default: 0,
 		},
 	],
 }

--- a/src/providers/legnext.ts
+++ b/src/providers/legnext.ts
@@ -2,13 +2,82 @@
 import type { ImageProvider, GenerateImageResult } from './types'
 import type { App } from 'obsidian'
 import { requestUrl } from 'obsidian'
-import { optionalStringParam, stringParam } from './params'
+import { stringParam } from './params'
 
 const BASE_URL = 'https://api.legnext.ai/api'
 
 interface LegnextImageOutput {
 	image_url?: unknown
 	image_urls?: unknown
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function hasMidjourneyFlag(prompt: string, aliases: string[]): boolean {
+	const names = aliases.map(escapeRegExp).join('|')
+	return new RegExp(`(?:^|\\s)--(?:${names})(?=\\s|=|$)`, 'i').test(prompt)
+}
+
+function appendFlag(prompt: string, aliases: string[], value: string): string {
+	return hasMidjourneyFlag(prompt, aliases) ? prompt : `${prompt} ${value}`
+}
+
+/** Build the provider prompt while preserving explicit user-authored Midjourney flags. */
+export function buildLegnextPrompt(prompt: string, params: Record<string, unknown> = {}): string {
+	const modelId = stringParam(params.modelId, 'midjourney-v8')
+	const isNiji = modelId === 'midjourney-niji-7'
+	let mjPrompt = prompt
+
+	if (isNiji) {
+		mjPrompt = appendFlag(mjPrompt, ['niji'], '--niji 7')
+	} else {
+		mjPrompt = appendFlag(mjPrompt, ['v', 'version'], '--v 8.2')
+	}
+
+	const ar = stringParam(params.ar, '1:1')
+	mjPrompt = appendFlag(mjPrompt, ['ar', 'aspect'], `--ar ${ar}`)
+
+	const stylize = stringParam(params.stylize, '100')
+	if (stylize !== '100') {
+		mjPrompt = appendFlag(mjPrompt, ['stylize', 's'], `--stylize ${stylize}`)
+	}
+
+	if (isNiji) return mjPrompt
+
+	const resolution = stringParam(params.resolution, 'standard').toLowerCase()
+	if (resolution !== 'standard' && resolution !== 'hd') {
+		throw new Error('Legnext: Resolution must be standard or hd')
+	}
+	if (resolution === 'hd') {
+		mjPrompt = appendFlag(mjPrompt, ['hd'], '--hd')
+	}
+
+	const chaos = stringParam(params.chaos, '0')
+	if (chaos !== '0') {
+		mjPrompt = appendFlag(mjPrompt, ['chaos', 'c'], `--chaos ${chaos}`)
+	}
+
+	const style = stringParam(params.style, 'default').toLowerCase()
+	if (style !== 'default' && style !== 'raw') {
+		throw new Error('Legnext: Style must be default or raw')
+	}
+	if (style === 'raw' && !hasMidjourneyFlag(mjPrompt, ['style', 'raw'])) {
+		mjPrompt += ' --style raw'
+	}
+
+	const stop = stringParam(params.stop, '100')
+	if (stop !== '100') {
+		mjPrompt = appendFlag(mjPrompt, ['stop'], `--stop ${stop}`)
+	}
+
+	const weird = stringParam(params.weird, '0')
+	if (weird !== '0') {
+		mjPrompt = appendFlag(mjPrompt, ['weird', 'w'], `--weird ${weird}`)
+	}
+
+	return mjPrompt
 }
 
 export function selectLegnextImageUrl(output: LegnextImageOutput | null | undefined): string | undefined {
@@ -26,7 +95,7 @@ export function selectLegnextImageUrl(output: LegnextImageOutput | null | undefi
 /**
  * Legnext AI provider for Midjourney image generation.
  * Async: POST /v1/diffusion → poll GET /v1/job/{id} → download image.
- * Model version and params are embedded in the prompt text (--v 8, --ar 16:9, etc.)
+ * Model version and params are embedded in the prompt text (--v 8.2, --ar 16:9, etc.)
  */
 export class LegnextProvider implements ImageProvider {
 	name = 'Legnext'
@@ -41,35 +110,7 @@ export class LegnextProvider implements ImageProvider {
 	}
 
 	async generateImage(prompt: string, params?: Record<string, unknown>): Promise<GenerateImageResult> {
-		const modelId = params?.modelId || 'midjourney-v8'
-
-		// Build MJ prompt with params appended
-		let mjPrompt = prompt
-
-		// Append version flag
-		if (modelId === 'midjourney-niji-7') {
-			if (!mjPrompt.includes('--niji')) mjPrompt += ' --niji 7'
-		} else {
-			if (!mjPrompt.includes('--v ')) mjPrompt += ' --v 8'
-		}
-
-		// Append aspect ratio
-		const ar = optionalStringParam(params?.ar)
-		if (ar && !mjPrompt.includes('--ar')) {
-			mjPrompt += ` --ar ${ar}`
-		}
-
-		// Append quality
-		const quality = optionalStringParam(params?.quality)
-		if (quality && quality !== '1' && !mjPrompt.includes('--q ')) {
-			mjPrompt += ` --q ${quality}`
-		}
-
-		// Append stylize
-		const stylize = params?.stylize === undefined ? undefined : stringParam(params.stylize, '100')
-		if (stylize !== undefined && stylize !== '100' && !mjPrompt.includes('--stylize')) {
-			mjPrompt += ` --stylize ${stylize}`
-		}
+		const mjPrompt = buildLegnextPrompt(prompt, params)
 
 		// Submit task
 		const submitResponse = await requestUrl({


### PR DESCRIPTION
## Summary

- keep the stable `midjourney-v8` Bragi model ID while upgrading its display and injected version flag to Midjourney V8.2
- replace the V8.2-incompatible quality control with Standard/2K HD resolution and add stylize, chaos, raw style, stop, and weird controls
- preserve explicit prompt flags with token-aware alias detection and retain individual-image-first Legnext result selection
- add focused request/catalog regression coverage and update provider documentation

## Validation

- `npm run test:legnext-v8-2`
- `npm run test:legnext-image-result`
- `npm run build`
- `npm run check:catalog`
- `npm run audit:catalog` (230 combinations, no anomalies)
- `npm run lint:obsidian`
- `git diff --check`
- API `npm run typecheck`
- paired temporary-root sync check (1.36.2, 27 MCP tools)

## Live Legnext validation

- Standard V8.2: 4 individual images, first image 1024x1024 PNG, 80 points
- 2K HD V8.2: 4 individual images, first image 2048x2048 PNG, 120 points
- no paid task retries

Paired Skill PR: https://github.com/nextbound/bragi-canvas-skill/pull/70
